### PR TITLE
feat(docs): slim CLAUDE.md, add .cursorrules and copilot-instructions

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,7 @@
+# .cursorrules
+
+This file provides guidance for Cursor AI when working with this repository.
+
+See [AGENTS.md](AGENTS.md) for project overview, development commands, environment setup, architecture, and implementation details.
+
+See [ARCHITECTURE.md](ARCHITECTURE.md) for codebase architecture reference including layer structure, data flow, and key patterns.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,7 @@
+# Copilot Instructions
+
+This file provides guidance for GitHub Copilot when working with this repository.
+
+See [AGENTS.md](../AGENTS.md) for project overview, development commands, environment setup, architecture, and implementation details.
+
+See [ARCHITECTURE.md](../ARCHITECTURE.md) for codebase architecture reference including layer structure, data flow, and key patterns.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,7 @@
+# CLAUDE.md
+
 This file provides guidance specific to Claude Code (claude.ai/code) when working with this repository.
 
 See [`AGENTS.md`](AGENTS.md) for project overview, development commands, environment setup, architecture, and implementation details.
+
+See [`ARCHITECTURE.md`](ARCHITECTURE.md) for codebase architecture reference including layer structure, data flow, and key patterns.


### PR DESCRIPTION
## Summary
- Updated `CLAUDE.md` to reference both `AGENTS.md` and `ARCHITECTURE.md` (7 lines, well under the 20-line target)
- Created `.cursorrules` for Cursor AI, pointing to the same source of truth
- Created `.github/copilot-instructions.md` for GitHub Copilot, pointing to the same source of truth

Closes #70

## Test plan
- [x] `CLAUDE.md` is under 20 lines
- [x] `.cursorrules` exists and references `AGENTS.md` and `ARCHITECTURE.md`
- [x] `.github/copilot-instructions.md` exists and references `AGENTS.md` and `ARCHITECTURE.md`
- [x] All three files point to the same source of truth