### PR TITLE
Add Redis configuration and caching service tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,8 @@ SMTP_PORT=1025
 SMTP_USER=
 SMTP_PASSWORD=
 SMTP_FROM_EMAIL=noreply@cinelog.app
+
+# Redis Configuration
+REDIS_ENABLED=false
+REDIS_URL=redis://localhost:6379/0
+# REDIS_DEFAULT_TTL=300

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,9 @@ Required environment variables (see `.env`):
 - `MONGODB_HOST`: MongoDB host (default: localhost) — only used if `MONGODB_URI` not set
 - `MONGODB_PORT`: MongoDB port (default: 27017) — only used if `MONGODB_URI` not set
 - `MONGODB_DB`: MongoDB database name (default: cinelog_db) — only used if `MONGODB_URI` not set
+- `REDIS_ENABLED`: Enable Redis caching (default: `false`)
+- `REDIS_URL`: Redis connection URL (default: `redis://localhost:6379/0`)
+- `REDIS_DEFAULT_TTL`: Default cache TTL in seconds (default: `300`)
 
 ### Git Hooks
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -37,10 +37,12 @@ All routes are registered under the `/v1/` prefix:
 1. Parse MongoDB connection from `MONGODB_URI` or `MONGODB_HOST`/`MONGODB_PORT`/`MONGODB_DB`
 2. Initialize `AsyncMongoClient` with `uuidRepresentation="standard"`
 3. Initialize Beanie with `[User, Log, Movie, MovieRating]` models
+4. Initialize `CacheService` from Redis config
 
 **Shutdown:**
-1. Close TMDB service connections (`TMDBService.aclose_all()`)
-2. Close MongoDB client
+1. Close cache service connections (`CacheService.aclose_all()`)
+2. Close TMDB service connections (`TMDBService.aclose_all()`)
+3. Close MongoDB client
 
 **Middleware stack** (in order): CSRFMiddleware → CORSMiddleware
 
@@ -63,6 +65,7 @@ All routes are registered under the `/v1/` prefix:
 **Singleton Pattern:**
 
 - `TMDBService` uses a thread-safe singleton with `Lock()` — lazy initialization on first `get_instance()` call, single global `httpx.AsyncClient`
+- `CacheService` uses a thread-safe singleton with `Lock()` — explicit initialization via `initialize(config)` during app startup
 
 **Soft Delete:**
 
@@ -171,6 +174,7 @@ The `__Host-` prefix enforces: `Secure=true`, no `Domain`, `path=/` — prevents
 | `TokenService` | JWT creation/decoding (HS256, access + refresh tokens) |
 | `PasswordService` | Bcrypt hashing via `passlib.CryptContext` |
 | `EmailService` | SMTP password reset emails (falls back to console logging in dev) |
+| `CacheService` | Singleton — Redis caching layer with graceful degradation (toggleable via `REDIS_ENABLED`) |
 | `TMDBService` | Singleton — movie search and details via TMDB API (`httpx.AsyncClient`) |
 | `MovieService` | Movie lookup, lazy `find_or_create_movie()` from TMDB |
 | `LogService` | Viewing log CRUD with movie fetching and poster auto-population |
@@ -233,6 +237,18 @@ The `UserRepository` provides two deletion strategies:
 - Base URL: `https://api.themoviedb.org/3/`
 - Auth: Bearer token via `Authorization` header
 - Client: `httpx.AsyncClient` (singleton, closed during app shutdown)
+
+## Caching
+
+`CacheService` provides an optional Redis caching layer:
+
+- **Toggle:** `REDIS_ENABLED` env var (default `false`) — when disabled, all methods return None/False immediately
+- **Graceful degradation:** All Redis calls are wrapped in try/except — the app never fails due to Redis unavailability
+- **Serialization:** Callers pass `model.model_dump(mode="json")` to `set()` and call `Model.model_validate()` after `get()` — keeps CacheService model-agnostic
+- **Key naming:** `cinelog:{entity}:{identifier}` — key construction is the caller's responsibility
+- **Default TTL:** 300 seconds (5 minutes), configurable via `REDIS_DEFAULT_TTL`
+- **Pattern invalidation:** Uses `SCAN` (not `KEYS`) for production-safe pattern-based cache invalidation
+- **Lifecycle:** Initialized during app startup in `app/__init__.py`, closed during shutdown
 
 ## MongoDB Connection
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -20,6 +20,8 @@ from app.models.log import Log
 from app.models.movie import Movie
 from app.models.movie_rating import MovieRating
 from app.models.user import User
+from app.config.redis import get_redis_config
+from app.services.cache_service import CacheService
 from app.services.tmdb_service import TMDBService
 
 
@@ -56,9 +58,11 @@ async def lifespan(_: FastAPI):
         database=mongo_client[mongodb_db],
         document_models=[User, Log, Movie, MovieRating],
     )
+    CacheService.initialize(get_redis_config())
     try:
         yield
     finally:
+        await CacheService.aclose_all()
         await TMDBService.aclose_all()
         await mongo_client.close()
 

--- a/app/config/redis.py
+++ b/app/config/redis.py
@@ -1,0 +1,23 @@
+import os
+from typing import TypedDict
+
+
+class RedisConfig(TypedDict):
+    enabled: bool
+    url: str
+    default_ttl: int
+
+
+def get_redis_config() -> RedisConfig:
+    """
+    Returns Redis configuration from environment variables.
+    """
+    enabled = os.getenv("REDIS_ENABLED", "false").lower() == "true"
+    url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+    default_ttl = int(os.getenv("REDIS_DEFAULT_TTL", "300"))
+
+    return {
+        "enabled": enabled,
+        "url": url,
+        "default_ttl": default_ttl,
+    }

--- a/app/services/cache_service.py
+++ b/app/services/cache_service.py
@@ -1,0 +1,126 @@
+import json
+import logging
+from threading import Lock
+from typing import Any
+
+import redis.asyncio as aioredis
+
+from app.config.redis import RedisConfig
+
+logger = logging.getLogger(__name__)
+
+CacheValue = dict[str, Any] | list[Any]
+
+
+class CacheService:
+    _singleton: "CacheService | None" = None
+    _singleton_lock = Lock()
+
+    def __init__(self, enabled: bool, url: str, default_ttl: int):
+        self._enabled = enabled
+        self._default_ttl = default_ttl
+        self._client: aioredis.Redis | None = None
+
+        if enabled:
+            self._client = aioredis.from_url(url, decode_responses=True)
+
+    @classmethod
+    def initialize(cls, config: RedisConfig) -> "CacheService":
+        with cls._singleton_lock:
+            cls._singleton = cls(
+                enabled=config["enabled"],
+                url=config["url"],
+                default_ttl=config["default_ttl"],
+            )
+            return cls._singleton
+
+    @classmethod
+    def get_instance(cls) -> "CacheService":
+        with cls._singleton_lock:
+            if cls._singleton is None:
+                raise RuntimeError(
+                    "CacheService not initialized. Call initialize() first."
+                )
+            return cls._singleton
+
+    async def get(self, key: str) -> CacheValue | None:
+        if not self._enabled or self._client is None:
+            return None
+        try:
+            data = await self._client.get(key)
+            if data is None:
+                return None
+            result: CacheValue = json.loads(data)
+            return result
+        except Exception:
+            logger.exception("Cache get failed for key=%s", key)
+            return None
+
+    async def set(self, key: str, value: CacheValue, ttl: int | None = None) -> bool:
+        if not self._enabled or self._client is None:
+            return False
+        try:
+            serialized = json.dumps(value)
+            await self._client.set(key, serialized, ex=ttl or self._default_ttl)
+            return True
+        except Exception:
+            logger.exception("Cache set failed for key=%s", key)
+            return False
+
+    async def delete(self, key: str) -> bool:
+        if not self._enabled or self._client is None:
+            return False
+        try:
+            result = await self._client.delete(key)
+            return result > 0
+        except Exception:
+            logger.exception("Cache delete failed for key=%s", key)
+            return False
+
+    async def delete_many(self, keys: list[str]) -> int:
+        if not self._enabled or self._client is None or not keys:
+            return 0
+        try:
+            return await self._client.delete(*keys)
+        except Exception:
+            logger.exception("Cache delete_many failed")
+            return 0
+
+    async def invalidate_pattern(self, pattern: str) -> int:
+        if not self._enabled or self._client is None:
+            return 0
+        try:
+            keys: list[str] = []
+            async for key in self._client.scan_iter(match=pattern):
+                keys.append(key)
+            if not keys:
+                return 0
+            return await self._client.delete(*keys)
+        except Exception:
+            logger.exception("Cache invalidate_pattern failed for pattern=%s", pattern)
+            return 0
+
+    async def health_check(self) -> bool:
+        if not self._enabled or self._client is None:
+            return False
+        try:
+            return await self._client.ping()
+        except Exception:
+            logger.exception("Cache health check failed")
+            return False
+
+    async def aclose(self) -> None:
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+        with CacheService._singleton_lock:
+            if CacheService._singleton is self:
+                CacheService._singleton = None
+
+    @classmethod
+    async def aclose_all(cls) -> None:
+        with cls._singleton_lock:
+            singleton = cls._singleton
+            cls._singleton = None
+        if singleton is not None:
+            await singleton.aclose()

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -15,6 +15,19 @@ services:
       timeout: 5s
       retries: 5
 
+  redis:
+    image: redis:7-alpine
+    container_name: cinelog_redis_local
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
   api:
     build:
       context: .
@@ -33,10 +46,16 @@ services:
       - MONGODB_DB=cinelog_db
       - SMTP_SERVER=mailpit
       - SMTP_PORT=1025
+      - REDIS_ENABLED=true
+      - REDIS_URL=redis://redis:6379/0
     command: uv run uvicorn app:app --host 0.0.0.0 --port 5009 --reload --reload-dir app
     depends_on:
-      - mongo-init-replica
-      - mailpit
+      mongo-init-replica:
+        condition: service_started
+      mailpit:
+        condition: service_started
+      redis:
+        condition: service_healthy
 
   mongo-init-replica:
     image: mongo:8
@@ -61,4 +80,5 @@ services:
 
 volumes:
   mongo_data:
+  redis_data:
   api_venv:

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ Welcome to the Cinelog Server documentation.
 | [E2E Testing](e2e-testing.md) | Setup and run end-to-end tests |
 | [CORS Configuration](cors-configuration.md) | CORS environment and behavior specification |
 | [Authentication](authentication.md) | Auth system (JWT, Cookies, CSRF) |
+| [Redis Caching](redis-caching.md) | Cache layer configuration, design, and usage |
 
 ## Quick Links
 

--- a/docs/redis-caching.md
+++ b/docs/redis-caching.md
@@ -1,0 +1,96 @@
+# Redis Caching
+
+This document covers the Redis caching layer in the Cinelog API.
+
+## Configuration
+
+Redis caching is controlled via environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `REDIS_ENABLED` | `false` | Enable/disable the cache layer |
+| `REDIS_URL` | `redis://localhost:6379/0` | Redis connection URL |
+| `REDIS_DEFAULT_TTL` | `300` | Default TTL in seconds (5 minutes) |
+
+Configuration is read by `app/config/redis.py` and passed to `CacheService.initialize()` during app startup.
+
+## CacheService Design
+
+`CacheService` (`app/services/cache_service.py`) is a singleton that wraps `redis.asyncio` operations.
+
+### Singleton Lifecycle
+
+- **Initialization:** `CacheService.initialize(config)` is called during the FastAPI lifespan startup (in `app/__init__.py`), after Beanie initialization
+- **Access:** `CacheService.get_instance()` returns the singleton — raises `RuntimeError` if not initialized
+- **Shutdown:** `CacheService.aclose_all()` closes the Redis client and clears the singleton
+
+### Methods
+
+| Method | Return | Description |
+|--------|--------|-------------|
+| `get(key)` | `dict \| list \| None` | Retrieve and deserialize a cached value |
+| `set(key, value, ttl?)` | `bool` | Serialize and store a value with TTL |
+| `delete(key)` | `bool` | Delete a single cached key |
+| `delete_many(keys)` | `int` | Bulk delete multiple keys |
+| `invalidate_pattern(pattern)` | `int` | Delete all keys matching a glob pattern (uses `SCAN`) |
+| `health_check()` | `bool` | Ping Redis to verify connectivity |
+| `aclose()` | `None` | Close the Redis client |
+
+### Disabled Mode
+
+When `REDIS_ENABLED=false`, `CacheService` is still initialized but all methods return immediately (`None`, `False`, or `0`) without making any Redis calls. This means callers don't need conditional logic.
+
+## Key Naming Convention
+
+Cache keys follow the pattern: `cinelog:{entity}:{identifier}`
+
+Examples:
+- `cinelog:movie:550` — movie with TMDB ID 550
+- `cinelog:user:abc123:logs` — logs for a specific user
+- `cinelog:stats:abc123` — stats for a specific user
+
+Key construction is the caller's responsibility — `CacheService` is key-agnostic.
+
+## TTL Strategy
+
+- **Default TTL:** 300 seconds (5 minutes), configurable via `REDIS_DEFAULT_TTL`
+- **Per-call TTL:** Callers can override the default by passing a `ttl` parameter to `set()`
+- Frequently changing data (e.g., user stats) may use shorter TTLs
+- Rarely changing data (e.g., movie details from TMDB) may use longer TTLs
+
+## Graceful Degradation
+
+Every `CacheService` method wraps Redis calls in try/except:
+
+- On failure, errors are logged via `logger.exception()`
+- Methods return safe defaults (`None`, `False`, `0`)
+- The application continues to function without caching
+- No exceptions propagate to callers
+
+This design ensures Redis unavailability never causes API errors.
+
+## Serialization
+
+`CacheService` is model-agnostic — it stores and retrieves raw JSON:
+
+- **Writing:** Callers serialize Pydantic models with `model.model_dump(mode="json")` before calling `set()`
+- **Reading:** Callers deserialize with `Model.model_validate()` after calling `get()`
+- **Internal format:** Values are stored as JSON strings via `json.dumps()`/`json.loads()`
+
+## Docker Setup
+
+The local Docker Compose stack (`docker-compose.local.yml`) includes a Redis service:
+
+- Image: `redis:7-alpine`
+- Port: `6379`
+- Health check: `redis-cli ping`
+- Data persisted in `redis_data` volume
+- API service has `REDIS_ENABLED=true` and `REDIS_URL=redis://redis:6379/0` set automatically
+
+## Pattern Invalidation
+
+`invalidate_pattern()` uses Redis `SCAN` (not `KEYS`) for production safety:
+
+- `SCAN` is non-blocking and iterates incrementally
+- `KEYS` blocks the Redis server and should not be used in production
+- Matched keys are collected and deleted in a single `DELETE` call

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "PyJWT==2.11.0",
     "python-dotenv==1.1.1",
     "python-multipart==0.0.22",
+    "redis[hiredis]==5.2.1",
     "uvicorn==0.34.3",
 ]
 

--- a/tests/units/config/test_redis.py
+++ b/tests/units/config/test_redis.py
@@ -1,0 +1,42 @@
+import os
+from unittest.mock import patch
+
+from app.config.redis import get_redis_config
+
+
+def test_get_redis_config_defaults():
+    with patch.dict(os.environ, {}, clear=True):
+        config = get_redis_config()
+        assert config["enabled"] is False
+        assert config["url"] == "redis://localhost:6379/0"
+        assert config["default_ttl"] == 300
+
+
+def test_get_redis_config_enabled_true():
+    with patch.dict(os.environ, {"REDIS_ENABLED": "true"}):
+        config = get_redis_config()
+        assert config["enabled"] is True
+
+
+def test_get_redis_config_enabled_true_uppercase():
+    with patch.dict(os.environ, {"REDIS_ENABLED": "TRUE"}):
+        config = get_redis_config()
+        assert config["enabled"] is True
+
+
+def test_get_redis_config_enabled_false():
+    with patch.dict(os.environ, {"REDIS_ENABLED": "false"}):
+        config = get_redis_config()
+        assert config["enabled"] is False
+
+
+def test_get_redis_config_custom_url():
+    with patch.dict(os.environ, {"REDIS_URL": "redis://myhost:6380/1"}):
+        config = get_redis_config()
+        assert config["url"] == "redis://myhost:6380/1"
+
+
+def test_get_redis_config_custom_ttl():
+    with patch.dict(os.environ, {"REDIS_DEFAULT_TTL": "600"}):
+        config = get_redis_config()
+        assert config["default_ttl"] == 600

--- a/tests/units/services/test_cache_service.py
+++ b/tests/units/services/test_cache_service.py
@@ -1,0 +1,228 @@
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+
+from app.services.cache_service import CacheService
+
+
+class TestCacheServiceDisabled:
+    """Tests for CacheService when disabled."""
+
+    @pytest_asyncio.fixture
+    async def service(self):
+        svc = CacheService(enabled=False, url="redis://localhost:6379/0", default_ttl=300)
+        yield svc
+
+    @pytest.mark.asyncio
+    async def test_get_returns_none(self, service):
+        assert await service.get("key") is None
+
+    @pytest.mark.asyncio
+    async def test_set_returns_false(self, service):
+        assert await service.set("key", {"a": 1}) is False
+
+    @pytest.mark.asyncio
+    async def test_delete_returns_false(self, service):
+        assert await service.delete("key") is False
+
+    @pytest.mark.asyncio
+    async def test_delete_many_returns_zero(self, service):
+        assert await service.delete_many(["k1", "k2"]) == 0
+
+    @pytest.mark.asyncio
+    async def test_invalidate_pattern_returns_zero(self, service):
+        assert await service.invalidate_pattern("cinelog:*") == 0
+
+    @pytest.mark.asyncio
+    async def test_health_check_returns_false(self, service):
+        assert await service.health_check() is False
+
+
+class TestCacheServiceEnabled:
+    """Tests for CacheService with mocked Redis client."""
+
+    @pytest_asyncio.fixture
+    async def service(self):
+        with patch("app.services.cache_service.aioredis.from_url") as mock_from_url:
+            mock_client = AsyncMock()
+            mock_from_url.return_value = mock_client
+            svc = CacheService(
+                enabled=True, url="redis://localhost:6379/0", default_ttl=300
+            )
+            svc._mock_client = mock_client  # type: ignore[attr-defined]
+            yield svc
+
+    @pytest.mark.asyncio
+    async def test_get_returns_data(self, service):
+        data = {"title": "Fight Club"}
+        service._mock_client.get = AsyncMock(return_value=json.dumps(data))
+        result = await service.get("cinelog:movie:550")
+        assert result == data
+        service._mock_client.get.assert_awaited_once_with("cinelog:movie:550")
+
+    @pytest.mark.asyncio
+    async def test_get_returns_none_on_miss(self, service):
+        service._mock_client.get = AsyncMock(return_value=None)
+        result = await service.get("cinelog:movie:999")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_set_stores_data(self, service):
+        service._mock_client.set = AsyncMock()
+        data = {"title": "Fight Club"}
+        result = await service.set("cinelog:movie:550", data, ttl=60)
+        assert result is True
+        service._mock_client.set.assert_awaited_once_with(
+            "cinelog:movie:550", json.dumps(data), ex=60
+        )
+
+    @pytest.mark.asyncio
+    async def test_set_uses_default_ttl(self, service):
+        service._mock_client.set = AsyncMock()
+        await service.set("key", {"a": 1})
+        service._mock_client.set.assert_awaited_once_with(
+            "key", json.dumps({"a": 1}), ex=300
+        )
+
+    @pytest.mark.asyncio
+    async def test_delete_existing_key(self, service):
+        service._mock_client.delete = AsyncMock(return_value=1)
+        result = await service.delete("cinelog:movie:550")
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_delete_missing_key(self, service):
+        service._mock_client.delete = AsyncMock(return_value=0)
+        result = await service.delete("cinelog:movie:999")
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_delete_many(self, service):
+        service._mock_client.delete = AsyncMock(return_value=3)
+        result = await service.delete_many(["k1", "k2", "k3"])
+        assert result == 3
+        service._mock_client.delete.assert_awaited_once_with("k1", "k2", "k3")
+
+    @pytest.mark.asyncio
+    async def test_delete_many_empty_list(self, service):
+        result = await service.delete_many([])
+        assert result == 0
+
+    @pytest.mark.asyncio
+    async def test_invalidate_pattern(self, service):
+        async def mock_scan_iter(match=None):
+            for key in ["cinelog:movie:1", "cinelog:movie:2"]:
+                yield key
+
+        service._mock_client.scan_iter = mock_scan_iter
+        service._mock_client.delete = AsyncMock(return_value=2)
+        result = await service.invalidate_pattern("cinelog:movie:*")
+        assert result == 2
+        service._mock_client.delete.assert_awaited_once_with(
+            "cinelog:movie:1", "cinelog:movie:2"
+        )
+
+    @pytest.mark.asyncio
+    async def test_invalidate_pattern_no_matches(self, service):
+        async def mock_scan_iter(match=None):
+            return
+            yield  # noqa: unreachable
+
+        service._mock_client.scan_iter = mock_scan_iter
+        result = await service.invalidate_pattern("cinelog:nothing:*")
+        assert result == 0
+
+    @pytest.mark.asyncio
+    async def test_health_check(self, service):
+        service._mock_client.ping = AsyncMock(return_value=True)
+        assert await service.health_check() is True
+
+    @pytest.mark.asyncio
+    async def test_aclose(self, service):
+        service._mock_client.aclose = AsyncMock()
+        await service.aclose()
+        service._mock_client.aclose.assert_awaited_once()
+        assert service._client is None
+
+
+class TestCacheServiceGracefulDegradation:
+    """Tests that Redis errors are caught and don't crash the app."""
+
+    @pytest_asyncio.fixture
+    async def service(self):
+        with patch("app.services.cache_service.aioredis.from_url") as mock_from_url:
+            mock_client = AsyncMock()
+            mock_from_url.return_value = mock_client
+            svc = CacheService(
+                enabled=True, url="redis://localhost:6379/0", default_ttl=300
+            )
+            svc._mock_client = mock_client  # type: ignore[attr-defined]
+            yield svc
+
+    @pytest.mark.asyncio
+    async def test_get_handles_connection_error(self, service):
+        service._mock_client.get = AsyncMock(side_effect=ConnectionError("refused"))
+        result = await service.get("key")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_set_handles_connection_error(self, service):
+        service._mock_client.set = AsyncMock(side_effect=ConnectionError("refused"))
+        result = await service.set("key", {"a": 1})
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_delete_handles_connection_error(self, service):
+        service._mock_client.delete = AsyncMock(side_effect=ConnectionError("refused"))
+        result = await service.delete("key")
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_delete_many_handles_connection_error(self, service):
+        service._mock_client.delete = AsyncMock(side_effect=ConnectionError("refused"))
+        result = await service.delete_many(["k1"])
+        assert result == 0
+
+    @pytest.mark.asyncio
+    async def test_invalidate_pattern_handles_connection_error(self, service):
+        async def failing_scan(match=None):
+            raise ConnectionError("refused")
+            yield  # noqa: unreachable
+
+        service._mock_client.scan_iter = failing_scan
+        result = await service.invalidate_pattern("cinelog:*")
+        assert result == 0
+
+    @pytest.mark.asyncio
+    async def test_health_check_handles_connection_error(self, service):
+        service._mock_client.ping = AsyncMock(side_effect=ConnectionError("refused"))
+        assert await service.health_check() is False
+
+
+class TestCacheServiceSingleton:
+    """Tests for singleton lifecycle."""
+
+    def setup_method(self):
+        CacheService._singleton = None
+
+    def teardown_method(self):
+        CacheService._singleton = None
+
+    def test_initialize_creates_singleton(self):
+        config = {"enabled": False, "url": "redis://localhost:6379/0", "default_ttl": 300}
+        instance = CacheService.initialize(config)
+        assert CacheService.get_instance() is instance
+
+    def test_get_instance_raises_without_initialize(self):
+        with pytest.raises(RuntimeError, match="not initialized"):
+            CacheService.get_instance()
+
+    @pytest.mark.asyncio
+    async def test_aclose_all_clears_singleton(self):
+        config = {"enabled": False, "url": "redis://localhost:6379/0", "default_ttl": 300}
+        CacheService.initialize(config)
+        await CacheService.aclose_all()
+        with pytest.raises(RuntimeError):
+            CacheService.get_instance()

--- a/uv.lock
+++ b/uv.lock
@@ -228,6 +228,7 @@ dependencies = [
     { name = "pyjwt" },
     { name = "python-dotenv" },
     { name = "python-multipart" },
+    { name = "redis", extra = ["hiredis"] },
     { name = "uvicorn" },
 ]
 
@@ -256,6 +257,7 @@ requires-dist = [
     { name = "pyjwt", specifier = "==2.11.0" },
     { name = "python-dotenv", specifier = "==1.1.1" },
     { name = "python-multipart", specifier = "==0.0.22" },
+    { name = "redis", extras = ["hiredis"], specifier = "==5.2.1" },
     { name = "uvicorn", specifier = "==0.34.3" },
 ]
 
@@ -467,6 +469,66 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "hiredis"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/97/d6/9bef6dc3052c168c93fbf7e6c0f2b12c45f0f741a2d30fd919096774343a/hiredis-3.3.1.tar.gz", hash = "sha256:da6f0302360e99d32bc2869772692797ebadd536e1b826d0103c72ba49d38698", size = 89101, upload-time = "2026-03-16T15:21:08.092Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/1d/1a7d925d886211948ab9cca44221b1d9dd4d3481d015511e98794e37d369/hiredis-3.3.1-cp312-cp312-macosx_10_15_universal2.whl", hash = "sha256:60543f3b068b16a86e99ed96b7fdae71cdc1d8abdfe9b3f82032a555e52ece7e", size = 82023, upload-time = "2026-03-16T15:19:34.157Z" },
+    { url = "https://files.pythonhosted.org/packages/13/2f/a6017fe1db47cd63a4aefc0dd21dd4dcb0c4e857bfbcfaa27329745f24a3/hiredis-3.3.1-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:2611bfaaadc5e8d43fb7967f9bbf1110c8beaa83aee2f2d812c76f11cfb56c6a", size = 46215, upload-time = "2026-03-16T15:19:35.068Z" },
+    { url = "https://files.pythonhosted.org/packages/77/4b/35a71d088c6934e162aa81c7e289fa3110a3aca84ab695d88dbd488c74a2/hiredis-3.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8e3754ce60e1b11b0afad9a053481ff184d2ee24bea47099107156d1b84a84aa", size = 41861, upload-time = "2026-03-16T15:19:36.32Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/54/904bc723a95926977764fefd6f0d46067579bac38fffc32b806f3f2c05c0/hiredis-3.3.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e89dabf436ee79b358fd970dcbed6333a36d91db73f27069ca24a02fb138a404", size = 170196, upload-time = "2026-03-16T15:19:37.274Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/01/4e840cd4cb53c28578234708b08fb9ec9e41c2880acc0e269a7264e1b3af/hiredis-3.3.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4f7e242eab698ad0be5a4b2ec616fa856569c57455cc67c625fd567726290e5f", size = 181808, upload-time = "2026-03-16T15:19:38.637Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0d/fc845f06f8203ab76c401d4d2b97f9fb768e644b053a40f441f7dcc71f2d/hiredis-3.3.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:53148a4e21057541b6d8e493b2ea1b500037ddf34433c391970036f3cbce00e3", size = 180577, upload-time = "2026-03-16T15:19:39.749Z" },
+    { url = "https://files.pythonhosted.org/packages/52/3a/859afe2620666bf6d58eb977870c47d98af4999d473b50528b323918f3f7/hiredis-3.3.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c25132902d3eff38781e0d54f27a0942ec849e3c07dbdce83c4d92b7e43c8dce", size = 172507, upload-time = "2026-03-16T15:19:40.87Z" },
+    { url = "https://files.pythonhosted.org/packages/60/a8/004349708ad8bf0d188d46049f846d3fe2d4a7a8d0d5a6a8ba024017d8b3/hiredis-3.3.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3fb6573efa15a29c12c0c0f7170b14e7c1347fe4bb39b6a15b779f46015cc929", size = 166339, upload-time = "2026-03-16T15:19:41.912Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/fb/bfc6df29381830c99bfd9e97ed3b6d75d9303866a28c23d51ab8c50f63e3/hiredis-3.3.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:487658e1db83c1ee9fbbac6a43039ea76957767a5987ffb16b590613f9e68297", size = 176766, upload-time = "2026-03-16T15:19:42.981Z" },
+    { url = "https://files.pythonhosted.org/packages/53/e7/f54aaad4559a413ec8b1043a89567a5a1f898426e4091b9af5e0f2120371/hiredis-3.3.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:a1d190790ee39b8b7adeeb10fc4090dc4859eb4e75ed27bd8108710eef18f358", size = 170313, upload-time = "2026-03-16T15:19:44.082Z" },
+    { url = "https://files.pythonhosted.org/packages/60/51/b80394db4c74d4cba342fa4208f690a2739c16f1125c2a62ba1701b8e2b7/hiredis-3.3.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a42c7becd4c9ec4ab5769c754eb61112777bdc6e1c1525e2077389e193b5f5aa", size = 167964, upload-time = "2026-03-16T15:19:45.237Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ef/5e438d1e058be57cdc1bafc1b1ec8ab43cc890c61447e88f8b878a0e32c3/hiredis-3.3.1-cp312-cp312-win32.whl", hash = "sha256:17ec8b524055a88b80d76c177dbbbe475a25c17c5bf4b67bdbdbd0629bcae838", size = 20532, upload-time = "2026-03-16T15:19:46.233Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/c6/39994b9c5646e7bf7d5e92170c07fd5f224ae9f34d95ff202f31845eb94b/hiredis-3.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:0fac4af8515e6cca74fc701169ae4dc9a71a90e9319c9d21006ec9454b43aa2f", size = 22381, upload-time = "2026-03-16T15:19:47.082Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/4b/c7f4d6d6643622f296395269e24b02c69d4ac72822f052b8cae16fa3af03/hiredis-3.3.1-cp313-cp313-macosx_10_15_universal2.whl", hash = "sha256:afe3c3863f16704fb5d7c2c6ff56aaf9e054f6d269f7b4c9074c5476178d1aba", size = 82027, upload-time = "2026-03-16T15:19:48.002Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/45/198be960a7443d6eb5045751e929480929c0defbca316ce1a47d15187330/hiredis-3.3.1-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:f19ee7dc1ef8a6497570d91fa4057ba910ad98297a50b8c44ff37589f7c89d17", size = 46220, upload-time = "2026-03-16T15:19:48.953Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/a4/6ab925177f289830008dbe1488a9858675e2e234f48c9c1653bd4d0eaddc/hiredis-3.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:09f5e510f637f2c72d2a79fb3ad05f7b6211e057e367ca5c4f97bb3d8c9d71f4", size = 41858, upload-time = "2026-03-16T15:19:49.939Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c8/a0ddbb9e9c27fcb0022f7b7e93abc75727cb634c6a5273ca5171033dac78/hiredis-3.3.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b46e96b50dad03495447860510daebd2c96fd44ed25ba8ccb03e9f89eaa9d34", size = 170095, upload-time = "2026-03-16T15:19:51.216Z" },
+    { url = "https://files.pythonhosted.org/packages/94/06/618d509cc454912028f71995f3dd6eb54606f0aa8163ff79c5b7ec1f2bda/hiredis-3.3.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b4fe7f38aa8956fcc1cea270e62601e0e11066aff78e384be70fd283d30293b6", size = 181745, upload-time = "2026-03-16T15:19:52.72Z" },
+    { url = "https://files.pythonhosted.org/packages/06/14/75b2deb62a61fc75a41ce1a6a781fe239133bbc88fef404d32a148ad152a/hiredis-3.3.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2b96da7e365d6488d2a75266a662cbe3cc14b28c23dd9b0c9aa04b5bc5c20192", size = 180465, upload-time = "2026-03-16T15:19:53.847Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/8c/8e03dcbfde8e2ca3f880fce06ad0877b3f098ed5fdfb17cf3b821a32323a/hiredis-3.3.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:52d5641027d6731bc7b5e7d126a5158a99784a9f8c6de3d97ca89aca4969e9f8", size = 172419, upload-time = "2026-03-16T15:19:54.959Z" },
+    { url = "https://files.pythonhosted.org/packages/03/05/843005d68403a3805309075efc6638360a3ababa6cb4545163bf80c8e7f7/hiredis-3.3.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:eddeb9a153795cf6e615f9f3cef66a1d573ff3b6ee16df2b10d1d1c2f2baeaa8", size = 166398, upload-time = "2026-03-16T15:19:56.36Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/23/abe2476244fd792f5108009ec0ae666eaa5b2165ca19f2e86638d8324ac9/hiredis-3.3.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:011a9071c3df4885cac7f58a2623feac6c8e2ad30e6ba93c55195af05ce61ff5", size = 176844, upload-time = "2026-03-16T15:19:57.462Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/47/e1cdccc559b98e548bcff0868c3938d375663418c0adca465895ee1f72e7/hiredis-3.3.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:264ee7e9cb6c30dc78da4ecf71d74cf14ca122817c665d838eda8b4384bce1b0", size = 170366, upload-time = "2026-03-16T15:19:58.548Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/e1/fda8325f51d06877e8e92500b15d4aff3855b4c3c91dbd9636a82e4591f2/hiredis-3.3.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d1434d0bcc1b3ef048bae53f26456405c08aeed9827e65b24094f5f3a6793f1", size = 168023, upload-time = "2026-03-16T15:19:59.727Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/21/2839d1625095989c116470e2b6841bbe1a2a5509585e82a4f3f5cd47f511/hiredis-3.3.1-cp313-cp313-win32.whl", hash = "sha256:f915a34fb742e23d0d61573349aa45d6f74037fde9d58a9f340435eff8d62736", size = 20535, upload-time = "2026-03-16T15:20:00.938Z" },
+    { url = "https://files.pythonhosted.org/packages/84/f9/534c2a89b24445a9a9623beb4697fd72b8c8f16286f6f3bda012c7af004a/hiredis-3.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:d8e56e0d1fe607bfff422633f313aec9191c3859ab99d11ff097e3e6e068000c", size = 22383, upload-time = "2026-03-16T15:20:01.865Z" },
+    { url = "https://files.pythonhosted.org/packages/03/72/0450d6b449da58120c5497346eb707738f8f67b9e60c28a8ef90133fc81f/hiredis-3.3.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:439f9a5cc8f9519ce208a24cdebfa0440fef26aa682a40ba2c92acb10a53f5e0", size = 82112, upload-time = "2026-03-16T15:20:02.865Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c0/0be33a29bcd463e6cbb0282515dd4d0cdfe33c30c7afc6d4d8c460e23266/hiredis-3.3.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3724f0e58c6ff76fd683429945491de71324ab1bc0ad943a8d68cb0932d24075", size = 46238, upload-time = "2026-03-16T15:20:03.896Z" },
+    { url = "https://files.pythonhosted.org/packages/62/f2/f999854bfaf3bcbee0f797f24706c182ecfaca825f6a582f6281a6aa97e0/hiredis-3.3.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:29fe35e3c6fe03204e75c86514f452591957a1e06b05d86e10d795455b71c355", size = 41891, upload-time = "2026-03-16T15:20:04.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c8/cd9ab90fec3a301d864d8ab6167aea387add8e2287969d89cbcd45d6b0e0/hiredis-3.3.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d42f3a13290f89191568fc113d95a3d2c8759cdd8c3672f021d8b7436f909e75", size = 170485, upload-time = "2026-03-16T15:20:06.284Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/9a/1ddf9ea236a292963146cbaf6722abeb9d503ca47d821267bb8b3b81c4f7/hiredis-3.3.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2afc675b831f7552da41116fffffca4340f387dc03f56d6ec0c7895ab0b59a10", size = 182030, upload-time = "2026-03-16T15:20:07.857Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/b8/e070a1dbf8a1bbb8814baa0b00836fbe3f10c7af8e11f942cc739c64e062/hiredis-3.3.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4106201cd052d9eabe3cb7b5a24b0fe37307792bda4fcb3cf6ddd72f697828e8", size = 180543, upload-time = "2026-03-16T15:20:09.096Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bb/b5f4f98e44626e2446cd8a52ce6cb1fc1c99786b6e2db3bf09cea97b90cd/hiredis-3.3.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8887bf0f31e4b550bd988c8863b527b6587d200653e9375cd91eea2b944b7424", size = 172356, upload-time = "2026-03-16T15:20:10.245Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/93/73a77b54ba94e82f76d02563c588d8a062513062675f483a033a43015f2c/hiredis-3.3.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1ac7697365dbe45109273b34227fee6826b276ead9a4a007e0877e1d3f0fcf21", size = 166433, upload-time = "2026-03-16T15:20:11.789Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c2/1b2dcbe5dc53a46a8cb05bed67d190a7e30bad2ad1f727ebe154dfeededd/hiredis-3.3.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2b6da6e07359107c653a809b3cff2d9ccaeedbafe33c6f16434aef6f53ce4a2b", size = 177220, upload-time = "2026-03-16T15:20:12.991Z" },
+    { url = "https://files.pythonhosted.org/packages/02/09/f4314cf096552568b5ea785ceb60c424771f4d35a76c410ad39d258f74bc/hiredis-3.3.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:ce334915f5d31048f76a42c607bf26687cf045eb1bc852b7340f09729c6a64fc", size = 170475, upload-time = "2026-03-16T15:20:14.519Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/2e/3f56e438efc8fc27ed4a3dbad58c0280061466473ec35d8f86c90c841a84/hiredis-3.3.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ee11fd431f83d8a5b29d370b9d79a814d3218d30113bdcd44657e9bdf715fc92", size = 167913, upload-time = "2026-03-16T15:20:15.672Z" },
+    { url = "https://files.pythonhosted.org/packages/56/34/053e5ee91d6dc478faac661996d1fd4886c5acb7a1b5ac30e7d3c794bb51/hiredis-3.3.1-cp314-cp314-win32.whl", hash = "sha256:e0356561b4a97c83b9ee3de657a41b8d1a1781226853adaf47b550bb988fda6f", size = 21167, upload-time = "2026-03-16T15:20:17.013Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/33/06776c641d17881a9031e337e81b3b934c38c2adbb83c85062d6b5f83b72/hiredis-3.3.1-cp314-cp314-win_amd64.whl", hash = "sha256:80aba5f85d6227faee628ae28d1c3b69c661806a0636548ac56c68782606454f", size = 23000, upload-time = "2026-03-16T15:20:17.966Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/5a/94f9a505b2ff5376d4a05fb279b69d89bafa7219dd33f6944026e3e56f80/hiredis-3.3.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:907f7b5501a534030738f0f27459a612d2266fd0507b007bb8f3e6de08167920", size = 83039, upload-time = "2026-03-16T15:20:19.316Z" },
+    { url = "https://files.pythonhosted.org/packages/93/ae/d3752a8f03a1fca43d402389d2a2d234d3db54c4d1f07f26c1041ca3c5de/hiredis-3.3.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:de94b409f49eb6a588ebdd5872e826caec417cd77c17af0fb94f2128427f1a2a", size = 46703, upload-time = "2026-03-16T15:20:20.401Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/76/e32c868a2fa23cd82bacaffd38649d938173244a0e717ec1c0c76874dbdd/hiredis-3.3.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:79cd03e7ff550c17758a7520bf437c156d3d4c8bb74214deeafa69cda49c85a4", size = 42379, upload-time = "2026-03-16T15:20:21.705Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/f6/d687d36a74ce6cf448826cf2e8edfc1eb37cc965308f74eb696aa97c69df/hiredis-3.3.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6ffa7ba2e2da1f806f3181b9730b3e87ba9dbfec884806725d4584055ba3faa6", size = 180311, upload-time = "2026-03-16T15:20:23.037Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ac/f520dc0066a62a15aa920c7dd0a2028c213f4862d5f901409ae92ee5d785/hiredis-3.3.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ee37fe8cf081b72dea72f96a0ee604f492ec02252eb77dc26ff6eec3f997b580", size = 190488, upload-time = "2026-03-16T15:20:24.357Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/f5/ae10fff82d0f291e90c41bf10a5d6543a96aae00cccede01bf2b6f7e178d/hiredis-3.3.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9bfdeff778d3f7ff449ca5922ab773899e7d31e26a576028b06a5e9cf0ed8c34", size = 189210, upload-time = "2026-03-16T15:20:25.51Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/8f/5be4344e542aa8d349a03d05486c59d9ca26f69c749d11e114bf34b84d50/hiredis-3.3.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:027ce4fabfeff5af5b9869d5524770877f9061d118bc36b85703ae3faf5aad8e", size = 180971, upload-time = "2026-03-16T15:20:26.631Z" },
+    { url = "https://files.pythonhosted.org/packages/41/a2/29e230226ec2a31f13f8a832fbafe366e263f3b090553ebe49bb4581a7bd/hiredis-3.3.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:dcea8c3f53674ae68e44b12e853b844a1d315250ca6677b11ec0c06aff85e86c", size = 175314, upload-time = "2026-03-16T15:20:27.848Z" },
+    { url = "https://files.pythonhosted.org/packages/89/2e/bf241707ad86b9f3ebfbc7ab89e19d5ec243ff92ca77644a383622e8740b/hiredis-3.3.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0b5ff2f643f4b452b0597b7fe6aa35d398cb31d8806801acfafb1558610ea2aa", size = 185652, upload-time = "2026-03-16T15:20:29.364Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c1/b39170d8bcccd01febd45af4ac6b43ff38e134a868e2ec167a82a036fb35/hiredis-3.3.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:3586c8a5f56d34b9dddaaa9e76905f31933cac267251006adf86ec0eef7d0400", size = 179033, upload-time = "2026-03-16T15:20:30.549Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/3a/4fe39a169115434f911abff08ff485b9b6201c168500e112b3f6a8110c0a/hiredis-3.3.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a110d19881ca78a88583d3b07231e7c6864864f5f1f3491b638863ea45fa8708", size = 176126, upload-time = "2026-03-16T15:20:31.958Z" },
+    { url = "https://files.pythonhosted.org/packages/44/99/c1d0b0bc4f9e9150e24beb0dca2e186e32d5e749d0022e0d26453749ed51/hiredis-3.3.1-cp314-cp314t-win32.whl", hash = "sha256:98fd5b39410e9d69e10e90d0330e35650becaa5dd2548f509b9598f1f3c6124d", size = 22028, upload-time = "2026-03-16T15:20:33.33Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d6/191e6741addc97bcf5e755661f8c82f0fd0aa35f07ece56e858da689b57e/hiredis-3.3.1-cp314-cp314t-win_amd64.whl", hash = "sha256:ab1f646ff531d70bfd25f01e60708dfa3d105eb458b7dedd9fe9a443039fd809", size = 23811, upload-time = "2026-03-16T15:20:34.292Z" },
 ]
 
 [[package]]
@@ -1124,6 +1186,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "redis"
+version = "5.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/da/d283a37303a995cd36f8b92db85135153dc4f7a8e4441aa827721b442cfb/redis-5.2.1.tar.gz", hash = "sha256:16f2e22dff21d5125e8481515e386711a34cbec50f0e44413dd7d9c060a54e0f", size = 4608355, upload-time = "2024-12-06T09:50:41.956Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/5f/fa26b9b2672cbe30e07d9a5bdf39cf16e3b80b42916757c5f92bca88e4ba/redis-5.2.1-py3-none-any.whl", hash = "sha256:ee7e1056b9aea0f04c6c2ed59452947f34c4940ee025f5dd83e6a6418b6989e4", size = 261502, upload-time = "2024-12-06T09:50:39.656Z" },
+]
+
+[package.optional-dependencies]
+hiredis = [
+    { name = "hiredis" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Introduced unit tests for Redis configuration retrieval in `test_redis.py`, covering default values, environment variable overrides, and custom settings.
- Implemented comprehensive tests for the `CacheService` in `test_cache_service.py`, including scenarios for both enabled and disabled states, graceful degradation on connection errors, and singleton lifecycle management.
- Updated `uv.lock` to include the `redis` package with `hiredis` as an optional dependency, ensuring compatibility with the caching service.