### PR TITLE
chore(ci): remove master branch references from workflows

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -2,9 +2,9 @@ name: E2E Tests
 
 on:
   push:
-    branches: [ "main", "master" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "main", "master" ]
+    branches: [ "main" ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -19,7 +19,6 @@ on:
   push:
     branches:
       - main
-      - master
     paths:
       - 'migrations/**'
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,9 +2,9 @@ name: Security Scanning
 
 on:
   push:
-    branches: [ "main", "master" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "main", "master" ]
+    branches: [ "main" ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -2,9 +2,9 @@ name: Unit Tests
 
 on:
   push:
-    branches: [ "main", "master" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "main", "master" ]
+    branches: [ "main" ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- Removed `master` from branch triggers in all four CI workflow files (`unit_tests.yml`, `e2e_tests.yml`, `security.yml`, `migrate.yml`)
- The project only uses `main`, so `master` references were unnecessary clutter

## Test plan
- [x] YAML syntax validated for all four files
- [x] Confirmed no remaining `master` references in `.github/workflows/`

Closes #89