### PR TITLE
feat(log): add DELETE /v1/logs/{log_id} endpoint

### DIFF
--- a/app/controllers/log_controller.py
+++ b/app/controllers/log_controller.py
@@ -1,5 +1,5 @@
 from beanie import PydanticObjectId
-from fastapi import APIRouter, Depends, Request, Response
+from fastapi import APIRouter, Depends, Request, Response, status
 
 from app.config.rate_limiter import limiter
 from app.repository.log_repository import LogRepository
@@ -53,6 +53,27 @@ async def update_log(
     return await log_service.update_log(
         user_id=user_id, log_id=log_id, request=request_body
     )
+
+
+@router.delete(
+    "/{log_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+)
+@limiter.limit("20/minute")
+async def delete_log(
+    request: Request,
+    response: Response,
+    log_id: str,
+    user_id: PydanticObjectId = Depends(auth_dependency),
+) -> None:
+    """
+    Delete a viewing log entry.
+
+    Requires authentication via Cookie token.
+    Only the owner of the log can delete it.
+    """
+    await log_service.delete_log(user_id=user_id, log_id=log_id)
 
 
 @router.get("/{handle}", response_model=LogListResponse)

--- a/app/repository/log_repository.py
+++ b/app/repository/log_repository.py
@@ -131,14 +131,13 @@ class LogRepository:
     @staticmethod
     async def delete_log(log_id: str, user_id: PydanticObjectId) -> bool:
         """
-        Delete a log entry (soft delete).
+        Delete a log entry (hard delete).
         """
         log = await LogRepository.find_log_by_id(log_id, user_id)
         if not log:
             return False
 
-        log.deleted = True
-        await log.save()
+        await log.delete()
         return True
 
     @staticmethod

--- a/app/services/log_service.py
+++ b/app/services/log_service.py
@@ -130,6 +130,16 @@ class LogService:
             watched_where=log.watched_where,
         )
 
+    async def delete_log(self, user_id: PydanticObjectId, log_id: str) -> None:
+        """
+        Delete a viewing log entry owned by the given user.
+        """
+        deleted = await self.log_repository.delete_log(log_id=log_id, user_id=user_id)
+        if not deleted:
+            raise AppException(ErrorCodes.LOG_NOT_FOUND)
+
+        await self.stats_cache_service.invalidate_user_stats(user_id)
+
     async def get_user_logs(
         self, user_id: PydanticObjectId, request: LogListRequest
     ) -> LogListResponse:

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ User-facing documentation covering features, flows, and API usage from the consu
 | Document | Description |
 |----------|-------------|
 | [Authentication](functional/authentication.md) | Auth flows, API usage, CSRF guide |
+| [Logs API](functional/logs-api.md) | Create, update, delete, and list viewing logs |
 | [Profile Visibility](functional/profile-visibility.md) | User profile visibility settings and public profile lookup |
 | [Rate Limiting](functional/rate-limiting.md) | Rate limits per endpoint, response headers, and 429 behavior |
 | [TMDB Movie Service](functional/tmdb-service.md) | Movie search and details endpoints, data flow, response fields |

--- a/docs/functional/logs-api.md
+++ b/docs/functional/logs-api.md
@@ -1,0 +1,58 @@
+# Logs API
+
+The viewing log endpoints let authenticated users record, update, list, and delete their own movie-watching history.
+
+All endpoints are under `/v1/logs` and require a valid session:
+
+- `__Host-access_token` cookie (JWT)
+- `X-CSRF-Token` header matching the `__Host-csrf_token` cookie — required on `POST`, `PUT`, and `DELETE`
+
+## Endpoints
+
+| Method | Path | Purpose | Rate Limit |
+|--------|------|---------|------------|
+| `POST` | `/v1/logs/` | Create a new viewing log | 20 / minute |
+| `PUT` | `/v1/logs/{log_id}` | Update an existing log the caller owns | 10 / minute |
+| `DELETE` | `/v1/logs/{log_id}` | Delete an existing log the caller owns | 20 / minute |
+| `GET` | `/v1/logs/{handle}` | List logs for a user by handle (respects profile visibility) | — |
+
+## DELETE `/v1/logs/{log_id}`
+
+Permanently removes a viewing log owned by the authenticated user. Deletion is a **hard delete** — the document is removed from the database and cannot be recovered. After success, the user's cached statistics are invalidated so the next stats read reflects the deletion.
+
+### Request
+
+```
+DELETE /v1/logs/{log_id}
+Cookie: __Host-access_token=<jwt>; __Host-csrf_token=<csrf>
+X-CSRF-Token: <csrf>
+```
+
+No request body.
+
+### Responses
+
+| Status | When |
+|--------|------|
+| `204 No Content` | Log was deleted successfully. Response body is empty. |
+| `401 Unauthorized` | No valid `__Host-access_token` cookie. |
+| `403 Forbidden` | CSRF validation failed (missing or mismatched `X-CSRF-Token`). |
+| `404 Not Found` | No log with `log_id` exists, or the log belongs to a different user. Both cases return the same `LOG_NOT_FOUND` error to avoid leaking existence. |
+| `429 Too Many Requests` | Rate limit (20/min) exceeded. See [Rate Limiting](rate-limiting.md). |
+
+### Example — 404 error body
+
+```json
+{
+  "error_code_name": "LOG_NOT_FOUND",
+  "error_code": 404,
+  "error_message": "Log not found",
+  "error_description": "The requested log entry was not found."
+}
+```
+
+## See Also
+
+- [Authentication](authentication.md) — cookie and CSRF setup
+- [Rate Limiting](rate-limiting.md) — per-endpoint limits and 429 behavior
+- [Stats Caching (technical)](../technical/stats-caching.md) — how log deletion invalidates cached stats

--- a/docs/functional/rate-limiting.md
+++ b/docs/functional/rate-limiting.md
@@ -14,6 +14,7 @@ The Cinelog API enforces rate limits on authentication and key data endpoints to
 | `GET /v1/movies/search` | 20 requests per minute |
 | `POST /v1/logs/` | 20 requests per minute |
 | `PUT /v1/logs/{log_id}` | 10 requests per minute |
+| `DELETE /v1/logs/{log_id}` | 20 requests per minute |
 
 Some authentication endpoints apply multiple rate-limit layers. `POST /v1/auth/login`, `POST /v1/auth/forgot-password`, and `POST /v1/auth/reset-password` can also be blocked by anonymous-session or email-hash account buckets before the outer IP window is exhausted.
 

--- a/docs/technical/stats-caching.md
+++ b/docs/technical/stats-caching.md
@@ -45,11 +45,8 @@ When data that affects stats is modified, all cached stats for that user are inv
 |---------|--------|---------|
 | `LogService` | `create_log` | New viewing log created |
 | `LogService` | `update_log` | Existing viewing log updated |
+| `LogService` | `delete_log` | Existing viewing log deleted |
 | `MovieRatingService` | `create_update_movie_rating` | Rating created or updated |
-
-### Gap to be aware of
-
-`LogRepository` has a `delete_log` method that is not currently exposed via any API endpoint. If a delete log endpoint is added in the future, it must also call `invalidate_user_stats`.
 
 ## Graceful Degradation
 

--- a/tests/e2e/test_log_e2e.py
+++ b/tests/e2e/test_log_e2e.py
@@ -494,6 +494,129 @@ class TestLogE2E:
         data = response.json()
         assert data["error_code_name"] == "PROFILE_NOT_PUBLIC"
 
+    async def test_delete_log_success(self, async_client):
+        """Test successful deletion removes the log (hard delete)."""
+        user_data = {
+            "email": "delete_log_success_test@example.com",
+            "password": "securepassword123",
+            "firstName": "DeleteLog",
+            "lastName": "Test",
+            "handle": "deletelogtest",
+            "dateOfBirth": "1990-01-01",
+            "profile_visibility": "public",
+        }
+        login_data = await register_and_login(async_client, user_data)
+        csrf_token = login_data["csrfToken"]
+        handle = login_data["handle"]
+
+        create_resp = await async_client.post(
+            "/v1/logs/",
+            headers={"X-CSRF-Token": csrf_token},
+            json={"tmdbId": 550, "dateWatched": "2024-01-15", "watchedWhere": "cinema"},
+        )
+        assert create_resp.status_code == 201
+        log_id = create_resp.json()["id"]
+
+        delete_resp = await async_client.delete(
+            f"/v1/logs/{log_id}",
+            headers={"X-CSRF-Token": csrf_token},
+        )
+        assert delete_resp.status_code == 204
+        assert delete_resp.content == b""
+
+        # Hard delete: the log is gone, not just hidden
+        list_resp = await async_client.get(f"/v1/logs/{handle}")
+        assert list_resp.status_code == 200
+        assert list_resp.json()["logs"] == []
+
+        # Second delete on the same id returns 404
+        second_delete = await async_client.delete(
+            f"/v1/logs/{log_id}",
+            headers={"X-CSRF-Token": csrf_token},
+        )
+        assert second_delete.status_code == 404
+        assert (
+            second_delete.json()["error_code_name"]
+            == ErrorCodes.LOG_NOT_FOUND.error_code_name
+        )
+
+    async def test_delete_log_invalid_id_returns_not_found(self, async_client):
+        """Test deleting a non-existent log ID returns LOG_NOT_FOUND."""
+        user_data = {
+            "email": "delete_invalidid_test@example.com",
+            "password": "securepassword123",
+            "firstName": "DeleteInvalid",
+            "lastName": "Test",
+            "handle": "deleteinvalidtest",
+            "dateOfBirth": "1990-01-01",
+            "profile_visibility": "public",
+        }
+        login_data = await register_and_login(async_client, user_data)
+        csrf_token = login_data["csrfToken"]
+
+        response = await async_client.delete(
+            "/v1/logs/507f1f77bcf86cd799439011",
+            headers={"X-CSRF-Token": csrf_token},
+        )
+
+        assert response.status_code == 404
+        data = response.json()
+        assert data["error_code_name"] == ErrorCodes.LOG_NOT_FOUND.error_code_name
+
+    async def test_delete_log_of_other_user_returns_not_found(self, async_client):
+        """Test that a user cannot delete another user's log."""
+        user_a = {
+            "email": "delete_owner_test@example.com",
+            "password": "securepassword123",
+            "firstName": "DeleteOwner",
+            "lastName": "User",
+            "handle": "deleteownertest",
+            "dateOfBirth": "1990-01-01",
+            "profile_visibility": "public",
+        }
+        login_a = await register_and_login(async_client, user_a)
+        csrf_token_a = login_a["csrfToken"]
+        handle_a = login_a["handle"]
+
+        create_response = await async_client.post(
+            "/v1/logs/",
+            headers={"X-CSRF-Token": csrf_token_a},
+            json={"tmdbId": 550, "dateWatched": "2024-01-15", "watchedWhere": "cinema"},
+        )
+        assert create_response.status_code == 201
+        log_id = create_response.json()["id"]
+
+        user_b = {
+            "email": "delete_intruder_test@example.com",
+            "password": "securepassword123",
+            "firstName": "DeleteIntruder",
+            "lastName": "User",
+            "handle": "deleteintrudertest",
+            "dateOfBirth": "1990-01-01",
+            "profile_visibility": "public",
+        }
+        login_b = await register_and_login(async_client, user_b)
+        csrf_token_b = login_b["csrfToken"]
+
+        response = await async_client.delete(
+            f"/v1/logs/{log_id}",
+            headers={"X-CSRF-Token": csrf_token_b},
+        )
+
+        assert response.status_code == 404
+        data = response.json()
+        assert data["error_code_name"] == ErrorCodes.LOG_NOT_FOUND.error_code_name
+
+        # The log still exists for the real owner
+        list_resp = await async_client.get(f"/v1/logs/{handle_a}")
+        assert list_resp.status_code == 200
+        assert len(list_resp.json()["logs"]) == 1
+
+    async def test_delete_log_unauthorized(self, async_client):
+        """Test deleting a log without authentication."""
+        response = await async_client.delete("/v1/logs/507f1f77bcf86cd799439011")
+        assert response.status_code in [401, 403]
+
     async def test_friends_only_profile_other_user_logs(self, async_client):
         """Test that a friends-only profile's logs are not accessible by a non-friend."""
         # Create User A with friends_only profile (no login needed)

--- a/tests/units/controllers/test_log_controller.py
+++ b/tests/units/controllers/test_log_controller.py
@@ -3,7 +3,8 @@ from fastapi.testclient import TestClient
 from unittest.mock import AsyncMock, patch
 from datetime import date, datetime
 from beanie import PydanticObjectId
-
+from app.utils.exceptions_utils import AppException
+from app.utils.error_codes_utils import ErrorCodes
 from app import app
 from app.schemas.log_schemas import (
     LogCreateResponse,
@@ -197,6 +198,67 @@ class TestUpdateLog:
         response = client.put(
             "/v1/logs/log123",
             json=update_request,
+            cookies={"__Host-csrf_token": "test-token"},
+            headers={"X-CSRF-Token": "test-token"},
+        )
+
+        assert response.status_code == 401
+
+
+class TestDeleteLog:
+    """Tests for DELETE /v1/logs/{log_id} endpoint."""
+
+    @patch(
+        "app.controllers.log_controller.log_service.delete_log", new_callable=AsyncMock
+    )
+    def test_delete_log_success_returns_204(
+        self, mock_delete_log, client, override_auth
+    ):
+        """Successful deletion returns 204 No Content with empty body."""
+        app.dependency_overrides[auth_dependency] = override_auth
+        mock_delete_log.return_value = None
+
+        response = client.delete(
+            "/v1/logs/log123",
+            cookies={"__Host-access_token": "token", "__Host-csrf_token": "test-token"},
+            headers={"X-CSRF-Token": "test-token"},
+        )
+
+        app.dependency_overrides = {}
+
+        assert response.status_code == 204
+        assert response.content == b""
+        mock_delete_log.assert_called_once()
+
+    @patch(
+        "app.controllers.log_controller.log_service.delete_log", new_callable=AsyncMock
+    )
+    def test_delete_log_not_found_returns_404(
+        self, mock_delete_log, client, override_auth
+    ):
+        """Deleting a missing or non-owned log returns 404."""
+        app.dependency_overrides[auth_dependency] = override_auth
+        mock_delete_log.side_effect = AppException(ErrorCodes.LOG_NOT_FOUND)
+
+        response = client.delete(
+            "/v1/logs/log123",
+            cookies={"__Host-access_token": "token", "__Host-csrf_token": "test-token"},
+            headers={"X-CSRF-Token": "test-token"},
+        )
+
+        app.dependency_overrides = {}
+
+        assert response.status_code == 404
+        assert (
+            response.json()["error_code_name"]
+            == ErrorCodes.LOG_NOT_FOUND.error_code_name
+        )
+
+    def test_delete_log_unauthorized(self, client):
+        """Delete without access token returns 401."""
+        app.dependency_overrides = {}
+        response = client.delete(
+            "/v1/logs/log123",
             cookies={"__Host-csrf_token": "test-token"},
             headers={"X-CSRF-Token": "test-token"},
         )

--- a/tests/units/repository/test_log_repository.py
+++ b/tests/units/repository/test_log_repository.py
@@ -373,9 +373,8 @@ async def test_delete_log_success(
     log = await log_repository.create_log(user_id, movie_create_request)
     result = await log_repository.delete_log(str(log.id), user_id)
     assert result is True
-    updated_log = await Log.get(log.id)
-    assert updated_log is not None
-    assert updated_log.deleted is True
+    deleted_log = await Log.get(log.id)
+    assert deleted_log is None
 
 
 @pytest.mark.asyncio

--- a/tests/units/services/test_log_service.py
+++ b/tests/units/services/test_log_service.py
@@ -266,6 +266,35 @@ class TestLogService:
             await log_service.update_log("user123", "nonexistent_log", request)
 
     @pytest.mark.asyncio
+    async def test_delete_log_success(
+        self, log_service, mock_log_repository, mock_stats_cache_service
+    ):
+        """Test successful log deletion invalidates the stats cache."""
+        user_id = PydanticObjectId()
+        mock_log_repository.delete_log.return_value = True
+
+        await log_service.delete_log(user_id=user_id, log_id="log123")
+
+        mock_log_repository.delete_log.assert_awaited_once_with(
+            log_id="log123", user_id=user_id
+        )
+        mock_stats_cache_service.invalidate_user_stats.assert_awaited_once_with(user_id)
+
+    @pytest.mark.asyncio
+    async def test_delete_log_not_found_raises(
+        self, log_service, mock_log_repository, mock_stats_cache_service
+    ):
+        """Test deleting a missing log raises LOG_NOT_FOUND and does not invalidate cache."""
+        user_id = PydanticObjectId()
+        mock_log_repository.delete_log.return_value = False
+
+        with pytest.raises(AppException) as exc_info:
+            await log_service.delete_log(user_id=user_id, log_id="nonexistent")
+
+        assert exc_info.value.error.error_code == ErrorCodes.LOG_NOT_FOUND.error_code
+        mock_stats_cache_service.invalidate_user_stats.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_get_user_logs(
         self, log_service, mock_log_repository, mock_movie_service
     ):


### PR DESCRIPTION
## Summary
- add `DELETE /v1/logs/{log_id}` for authenticated users to permanently remove their own viewing logs with `204 No Content` on success
- change log deletion from a soft delete to a hard delete and invalidate cached user stats after successful deletion
- add unit and end-to-end coverage plus documentation updates for logs, rate limiting, and stats caching

## Testing
- Not run in this session

Closes #140