### PR TITLE
ci(code-style): add ruff lint and format checks

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -1,0 +1,57 @@
+name: Code Style
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install Dependencies
+        run: |
+          uv sync --frozen --group dev
+
+      - name: Run Ruff Lint
+        run: |
+          make lint
+
+  format:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install Dependencies
+        run: |
+          uv sync --frozen --group dev
+
+      - name: Run Ruff Format Check
+        run: |
+          make format-check

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install dev hooks test-unit test-e2e lint format typecheck security dependency-audit run docker-up docker-down docker-build-prod docker-prod-up docker-prod-down migrate migrate-dry-run
+.PHONY: install dev hooks test-unit test-e2e lint format format-check typecheck security dependency-audit run docker-up docker-down docker-build-prod docker-prod-up docker-prod-down migrate migrate-dry-run
 
 install:
 	uv sync
@@ -23,6 +23,9 @@ lint:
 format:
 	uv run ruff format .
 	uv run ruff check --fix .
+
+format-check:
+	uv run ruff format --check .
 
 typecheck:
 	uv run mypy app/

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ Developer-facing documentation covering infrastructure, implementation details, 
 | Document | Description |
 |----------|-------------|
 | [Authentication](technical/authentication.md) | Auth implementation internals, middleware, cookie config |
+| [Code Quality CI](technical/code-quality-ci.md) | GitHub Actions quality gates for lint, format, type checking, and security |
 | [CORS Configuration](technical/cors-configuration.md) | CORS environment variables and behavior |
 | [E2E Testing](technical/e2e-testing.md) | Setup and run end-to-end tests |
 | [Migrations](technical/migrations.md) | Database migration system |
@@ -50,6 +51,7 @@ Developer-facing documentation covering infrastructure, implementation details, 
 | `make migrate-dry-run` | Preview pending migrations without applying changes |
 | `make lint` | Run Ruff linter |
 | `make format` | Format code with Ruff and apply auto-fixes |
+| `make format-check` | Check Ruff formatting without modifying files |
 | `make typecheck` | Run mypy type checking for `app/` |
 | `make security` | Run Bandit security scan and pip-audit dependency scan |
 | `make run` | Run API locally via `python main.py` |

--- a/docs/technical/code-quality-ci.md
+++ b/docs/technical/code-quality-ci.md
@@ -1,0 +1,40 @@
+# Code Quality CI
+
+## Overview
+
+The code quality pipeline runs static checks before changes are merged. The checks are split across focused GitHub Actions workflows so each job can report independently and run in parallel where possible.
+
+## Code Style Workflow
+
+The Code Style workflow is defined in `.github/workflows/code_style.yml` and runs on:
+
+- Pull requests targeting `main`
+- Pushes to `main`
+- Manual `workflow_dispatch` runs
+
+It has two parallel jobs:
+
+- `lint`: runs `make lint`, which executes `uv run ruff check .`
+- `format`: runs `make format-check`, which executes `uv run ruff format --check .`
+
+The format job is check-only and does not modify files in CI.
+
+## Related Workflows
+
+Other quality gates are handled by separate workflows:
+
+- Type checking: `.github/workflows/typecheck.yml`, which runs `make typecheck`
+- Security scanning: `.github/workflows/security.yml`, which runs Bandit against `app/`
+
+## Local Usage
+
+Run the same checks locally before opening or updating a pull request:
+
+```bash
+make lint
+make format-check
+make typecheck
+make security
+```
+
+Use `make format` when local files need to be reformatted or auto-fixed.


### PR DESCRIPTION
## Summary

- Add a separate Code Style workflow for Ruff lint and format checks
- Add `make format-check` for dry-run formatting checks in CI
- Document code quality CI workflows and link the new Make target

## Verification

- `make lint`
- `make format-check`

Refs #59
