### PR TITLE
feat(logs): add Redis log cache repository

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,7 @@ SMTP_FROM_EMAIL=noreply@cinelog.app
 # Redis Configuration (required — used for caching and rate limiting)
 REDIS_URL=redis://localhost:6379/0
 # REDIS_DEFAULT_TTL=300
+# LOG_CACHE_TTL=86400
 # STATS_CACHE_TTL=259200
 
 # TMDB Configuration

--- a/app/controllers/log_controller.py
+++ b/app/controllers/log_controller.py
@@ -3,7 +3,7 @@ from fastapi import APIRouter, Depends, Request, Response, status
 
 from app.config.rate_limiter import limiter
 from app.dependencies.auth_dependency import auth_dependency
-from app.repository.log_repository import LogRepository
+from app.repository.log_cache_repository import LogCacheRepository
 from app.schemas.log_schemas import (
     LogCreateRequest,
     LogCreateResponse,
@@ -15,7 +15,7 @@ from app.services.log_service import LogService
 
 router = APIRouter()
 
-log_repository = LogRepository()
+log_repository = LogCacheRepository()
 log_service = LogService(log_repository)
 
 

--- a/app/repository/log_cache_repository.py
+++ b/app/repository/log_cache_repository.py
@@ -1,0 +1,220 @@
+import logging
+import os
+from datetime import date
+from typing import Any, cast
+
+from beanie import PydanticObjectId
+
+from app.models.log import Log
+from app.repository.log_repository import LogRepository
+from app.schemas.log_schemas import LogCreateRequest, LogUpdateRequest
+from app.services.cache_service import CacheService
+
+logger = logging.getLogger(__name__)
+
+LOG_CACHE_TTL = int(os.getenv("LOG_CACHE_TTL", "86400"))
+
+
+class LogCacheRepository(LogRepository):
+    """Redis-backed decorator for raw log repository lookups."""
+
+    @property
+    def _cache(self) -> CacheService:
+        return CacheService.get_instance()
+
+    @staticmethod
+    def build_log_key(log_id: str, user_id: PydanticObjectId) -> str:
+        return f"cinelog:logs:id:{user_id}:{log_id}"
+
+    @staticmethod
+    def build_user_logs_key(
+        user_id: PydanticObjectId,
+        watched_where: str | None = None,
+        date_watched_from: date | None = None,
+        date_watched_to: date | None = None,
+        sort_by: str = "dateWatched",
+        sort_order: str = "desc",
+    ) -> str:
+        watched_where_part = watched_where or "all"
+        from_part = date_watched_from.isoformat() if date_watched_from is not None else "any"
+        to_part = date_watched_to.isoformat() if date_watched_to is not None else "any"
+        return (
+            f"cinelog:logs:user:{user_id}:where:{watched_where_part}:"
+            f"from:{from_part}:to:{to_part}:sort:{sort_by}:{sort_order}"
+        )
+
+    @staticmethod
+    def build_movie_logs_key(movie_id: str, user_id: PydanticObjectId | None = None) -> str:
+        user_part = str(user_id) if user_id is not None else "all"
+        return f"cinelog:logs:movie:{movie_id}:user:{user_part}"
+
+    @staticmethod
+    def build_user_logs_pattern(user_id: PydanticObjectId) -> str:
+        return f"cinelog:logs:user:{user_id}:*"
+
+    @staticmethod
+    def build_movie_logs_pattern(movie_id: PydanticObjectId | str) -> str:
+        return f"cinelog:logs:movie:{movie_id}:*"
+
+    @staticmethod
+    def _serialize_log(log: Log) -> dict[str, Any]:
+        return cast(dict[str, Any], log.model_dump(mode="json", by_alias=True))
+
+    @classmethod
+    def _serialize_logs(cls, logs: list[Log]) -> list[dict[str, Any]]:
+        return [cls._serialize_log(log) for log in logs]
+
+    @staticmethod
+    def _deserialize_log(data: dict[str, Any]) -> Log:
+        return cast(Log, Log.model_validate(data))
+
+    @classmethod
+    def _deserialize_logs(cls, data: list[Any]) -> list[Log]:
+        return [cls._deserialize_log(item) for item in data]
+
+    async def _get_log(self, key: str) -> Log | None:
+        try:
+            data = await self._cache.get(key)
+            if data is None:
+                logger.debug("Log cache miss for key=%s", key)
+                return None
+            if not isinstance(data, dict):
+                logger.warning("Invalid log cache payload for key=%s", key)
+                return None
+            logger.debug("Log cache hit for key=%s", key)
+            return self._deserialize_log(data)
+        except Exception:
+            logger.exception("Log cache read failed for key=%s", key)
+            return None
+
+    async def _get_logs(self, key: str) -> list[Log] | None:
+        try:
+            data = await self._cache.get(key)
+            if data is None:
+                logger.debug("Log cache miss for key=%s", key)
+                return None
+            if not isinstance(data, list):
+                logger.warning("Invalid log list cache payload for key=%s", key)
+                return None
+            logger.debug("Log cache hit for key=%s", key)
+            return self._deserialize_logs(data)
+        except Exception:
+            logger.exception("Log cache read failed for key=%s", key)
+            return None
+
+    async def _set_log(self, key: str, log: Log) -> None:
+        try:
+            await self._cache.set(key, self._serialize_log(log), ttl=LOG_CACHE_TTL)
+            logger.debug("Log cache set for key=%s", key)
+        except Exception:
+            logger.exception("Log cache write failed for key=%s", key)
+
+    async def _set_logs(self, key: str, logs: list[Log]) -> None:
+        try:
+            await self._cache.set(key, self._serialize_logs(logs), ttl=LOG_CACHE_TTL)
+            logger.debug("Log cache set for key=%s", key)
+        except Exception:
+            logger.exception("Log cache write failed for key=%s", key)
+
+    async def _delete_key(self, key: str) -> None:
+        try:
+            await self._cache.delete(key)
+            logger.debug("Log cache deleted for key=%s", key)
+        except Exception:
+            logger.exception("Log cache delete failed for key=%s", key)
+
+    async def _invalidate_pattern(self, pattern: str) -> None:
+        try:
+            await self._cache.invalidate_pattern(pattern)
+            logger.debug("Log cache invalidated for pattern=%s", pattern)
+        except Exception:
+            logger.exception("Log cache invalidation failed for pattern=%s", pattern)
+
+    async def _invalidate_user_logs(self, user_id: PydanticObjectId) -> None:
+        await self._invalidate_pattern(self.build_user_logs_pattern(user_id))
+
+    async def _invalidate_movie_logs(self, movie_id: PydanticObjectId | str) -> None:
+        await self._invalidate_pattern(self.build_movie_logs_pattern(movie_id))
+
+    async def _invalidate_log(self, log: Log) -> None:
+        await self._delete_key(self.build_log_key(str(log.id), log.user_id))
+        await self._invalidate_user_logs(log.user_id)
+        await self._invalidate_movie_logs(log.movie_id)
+
+    async def create_log(self, user_id: PydanticObjectId, create_log_request: LogCreateRequest) -> Log:
+        log = await super().create_log(user_id, create_log_request)
+        await self._invalidate_user_logs(log.user_id)
+        await self._invalidate_movie_logs(log.movie_id)
+        return log
+
+    async def find_log_by_id(self, log_id: str, user_id: PydanticObjectId) -> Log | None:
+        key = self.build_log_key(log_id, user_id)
+        cached = await self._get_log(key)
+        if cached is not None:
+            return cached
+
+        log = await super().find_log_by_id(log_id, user_id)
+        if log is not None:
+            await self._set_log(key, log)
+        return log
+
+    async def update_log(self, log_id: str, user_id: PydanticObjectId, update_request: LogUpdateRequest) -> Log | None:
+        log = await super().update_log(log_id, user_id, update_request)
+        if log is not None:
+            await self._invalidate_log(log)
+        return log
+
+    async def find_logs_by_user_id(
+        self,
+        user_id: PydanticObjectId,
+        watched_where: str | None = None,
+        date_watched_from: date | None = None,
+        date_watched_to: date | None = None,
+        sort_by: str = "dateWatched",
+        sort_order: str = "desc",
+    ) -> list[Log]:
+        key = self.build_user_logs_key(
+            user_id=user_id,
+            watched_where=watched_where,
+            date_watched_from=date_watched_from,
+            date_watched_to=date_watched_to,
+            sort_by=sort_by,
+            sort_order=sort_order,
+        )
+        cached = await self._get_logs(key)
+        if cached is not None:
+            return cached
+
+        logs = cast(
+            list[Log],
+            await super().find_logs_by_user_id(
+                user_id=user_id,
+                watched_where=watched_where,
+                date_watched_from=date_watched_from,
+                date_watched_to=date_watched_to,
+                sort_by=sort_by,
+                sort_order=sort_order,
+            ),
+        )
+        await self._set_logs(key, logs)
+        return logs
+
+    async def find_logs_by_movie_id(self, movie_id: str, user_id: PydanticObjectId | None = None) -> list[Log]:
+        key = self.build_movie_logs_key(movie_id, user_id)
+        cached = await self._get_logs(key)
+        if cached is not None:
+            return cached
+
+        logs = await super().find_logs_by_movie_id(movie_id, user_id)
+        await self._set_logs(key, logs)
+        return logs
+
+    async def delete_log(self, log_id: str, user_id: PydanticObjectId) -> bool:
+        existing_log = await super().find_log_by_id(log_id, user_id)
+        if existing_log is None:
+            return False
+
+        deleted = await super()._delete_log(existing_log)
+        if deleted:
+            await self._invalidate_log(existing_log)
+        return deleted

--- a/app/repository/log_repository.py
+++ b/app/repository/log_repository.py
@@ -10,8 +10,7 @@ from app.utils.object_id_utils import to_object_id
 
 
 class LogRepository:
-    @staticmethod
-    async def create_log(user_id: PydanticObjectId, create_log_request: LogCreateRequest) -> Log:
+    async def create_log(self, user_id: PydanticObjectId, create_log_request: LogCreateRequest) -> Log:
         """
         Create a new log entry in the database.
         """
@@ -29,22 +28,23 @@ class LogRepository:
         await log.insert()
         return log
 
-    @staticmethod
-    async def find_log_by_id(log_id: str, user_id: PydanticObjectId) -> Log | None:
+    async def find_log_by_id(self, log_id: str, user_id: PydanticObjectId) -> Log | None:
         """
         Find a log entry by its ID, ensuring it belongs to the user.
         """
+        return await self._find_log_by_id(log_id, user_id)
+
+    async def _find_log_by_id(self, log_id: str, user_id: PydanticObjectId) -> Log | None:
         log_object_id = to_object_id(log_id)
         if log_object_id is None or user_id is None:
             return None
         return await Log.find_one(Log.active_filter({"_id": log_object_id, "userId": user_id}))
 
-    @staticmethod
-    async def update_log(log_id: str, user_id: PydanticObjectId, update_request: LogUpdateRequest) -> Log | None:
+    async def update_log(self, log_id: str, user_id: PydanticObjectId, update_request: LogUpdateRequest) -> Log | None:
         """
         Update an existing log entry.
         """
-        log = await LogRepository.find_log_by_id(log_id, user_id)
+        log = await self._find_log_by_id(log_id, user_id)
         if not log:
             return None
 
@@ -57,8 +57,8 @@ class LogRepository:
         await log.save()
         return log
 
-    @staticmethod
     async def find_logs_by_user_id(
+        self,
         user_id: PydanticObjectId,
         watched_where: str | None = None,
         date_watched_from: date | None = None,
@@ -99,8 +99,7 @@ class LogRepository:
 
         return await Log.find(filters).sort(sort_spec).to_list()
 
-    @staticmethod
-    async def find_logs_by_movie_id(movie_id: str, user_id: PydanticObjectId | None = None) -> list[Log]:
+    async def find_logs_by_movie_id(self, movie_id: str, user_id: PydanticObjectId | None = None) -> list[Log]:
         """
         Find all log entries for a specific movie by its ID.
         Optionally filter by user_id.
@@ -115,20 +114,22 @@ class LogRepository:
 
         return await Log.find(query_params).to_list()
 
-    @staticmethod
-    async def delete_log(log_id: str, user_id: PydanticObjectId) -> bool:
+    async def delete_log(self, log_id: str, user_id: PydanticObjectId) -> bool:
         """
         Delete a log entry (hard delete).
         """
-        log = await LogRepository.find_log_by_id(log_id, user_id)
+        log = await self._find_log_by_id(log_id, user_id)
         if not log:
             return False
 
+        return await self._delete_log(log)
+
+    async def _delete_log(self, log: Log) -> bool:
         await log.delete()
         return True
 
-    @staticmethod
     async def get_log_stats(
+        self,
         user_id: PydanticObjectId,
         date_from: date | None = None,
         date_to: date | None = None,

--- a/docs/technical/redis-caching.md
+++ b/docs/technical/redis-caching.md
@@ -10,6 +10,7 @@ Redis is **required** — the application will not start without a reachable Red
 |----------|---------|-------------|
 | `REDIS_URL` | `redis://localhost:6379/0` | Redis connection URL |
 | `REDIS_DEFAULT_TTL` | `300` | Default TTL in seconds (5 minutes) |
+| `LOG_CACHE_TTL` | `86400` | TTL in seconds for cached log repository lookups |
 
 Configuration is read by `app/config/redis.py` and passed to `CacheService.initialize()` during app startup.
 
@@ -39,7 +40,9 @@ Rate-limited auth routes also require `RATE_LIMIT_HMAC_SECRET` so account-based 
 
 ### Error Behavior
 
-Redis errors propagate directly to the caller — there is no graceful degradation. If Redis is unavailable, the operation will raise an exception. This makes failures visible and prevents silent cache misses from masking infrastructure issues.
+`CacheService` is a low-level wrapper, so Redis errors propagate directly from its methods. Higher-level cache layers decide whether to fail open or fail closed.
+
+`LogCacheRepository` fails open: cache errors are logged and the repository falls back to the database query. This keeps log create, update, delete, and lookup flows available when Redis is temporarily unavailable.
 
 ## Key Naming Convention
 
@@ -47,10 +50,47 @@ Cache keys follow the pattern: `cinelog:{entity}:{identifier}`
 
 Examples:
 - `cinelog:movie:550` — movie with TMDB ID 550
-- `cinelog:user:abc123:logs` — logs for a specific user
-- `cinelog:stats:abc123` — stats for a specific user
+- `cinelog:logs:id:{user_id}:{log_id}` — one log by ID, scoped to its owner
+- `cinelog:logs:user:{user_id}:where:{watched_where}:from:{from}:to:{to}:sort:{sort_by}:{sort_order}` — filtered user logs
+- `cinelog:logs:movie:{movie_id}:user:{user_id_or_all}` — logs for a movie, optionally scoped to a user
+- `cinelog:stats:{user_id}:all` — stats for a specific user
 
 Key construction is the caller's responsibility — `CacheService` is key-agnostic.
+
+## Cache Layer Boundaries
+
+Cinelog uses cache layers at the same boundary as the data being cached:
+
+- `*_cache_service.py` is for service-level, composed, or external API responses. Examples: `StatsCacheService` caches a `StatsResponse`, and `TMDBCacheService` caches TMDB API responses.
+- `*_cache_repository.py` is for raw persistence lookups. `LogCacheRepository` wraps `LogRepository` and caches raw `Log` documents before `LogService` enriches them with movie and rating data.
+
+Use the narrowest boundary that owns the data dependencies. If a response combines multiple repositories or services, caching it at that level also makes invalidation responsible for all of those dependencies.
+
+### Inheritance vs Composition
+
+Use inheritance only when the cache layer is a drop-in replacement for the uncached layer and exposes the same contract. `LogCacheRepository` extends `LogRepository` because callers can use it anywhere a log repository is expected.
+
+Use composition when the cache layer is only a helper for storing, reading, or invalidating cached payloads. `StatsService` composes `StatsCacheService`, and `TMDBService` composes `TMDBCacheService`; those cache services are not substitutes for the full service APIs.
+
+`CacheService` itself is infrastructure. Domain cache layers should use it through `CacheService.get_instance()` rather than inherit from it.
+
+## Log Repository Cache
+
+`LogCacheRepository` (`app/repository/log_cache_repository.py`) decorates `LogRepository` and caches:
+
+- `find_log_by_id(log_id, user_id)`
+- `find_logs_by_user_id(...)`
+- `find_logs_by_movie_id(movie_id, user_id?)`
+
+Log repository cache entries default to a one-day TTL. Explicit invalidation on writes is the primary freshness mechanism; the TTL is a safety net for entries that are not touched by a write path.
+
+Writes invalidate affected log cache entries:
+
+| Method | Invalidation |
+|--------|--------------|
+| `create_log` | User log-list keys and movie log-list keys |
+| `update_log` | Owner-scoped log ID key, user log-list keys, and movie log-list keys |
+| `delete_log` | Owner-scoped log ID key, user log-list keys, and movie log-list keys after successful delete |
 
 ## TTL Strategy
 

--- a/tests/units/repository/test_log_cache_repository.py
+++ b/tests/units/repository/test_log_cache_repository.py
@@ -1,0 +1,386 @@
+from datetime import UTC, date, datetime
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import pytest
+from beanie import PydanticObjectId
+
+from app.models.log import Log
+from app.repository.log_cache_repository import LOG_CACHE_TTL, LogCacheRepository
+from app.repository.log_repository import LogRepository
+from app.schemas.log_schemas import LogCreateRequest, LogUpdateRequest
+
+
+def _sample_log(
+    user_id: PydanticObjectId | None = None,
+    movie_id: PydanticObjectId | None = None,
+) -> Log:
+    return Log(
+        userId=user_id or PydanticObjectId(),
+        movieId=movie_id or PydanticObjectId(),
+        tmdbId=550,
+        dateWatched=datetime(2024, 1, 2, tzinfo=UTC),
+        viewingNotes="Cached viewing",
+        posterPath="/poster.jpg",
+        watchedWhere="streaming",
+    )
+
+
+def _mock_cache() -> MagicMock:
+    cache = MagicMock()
+    cache.get = AsyncMock(return_value=None)
+    cache.set = AsyncMock(return_value=True)
+    cache.delete = AsyncMock(return_value=True)
+    cache.invalidate_pattern = AsyncMock(return_value=1)
+    return cache
+
+
+def test_build_user_logs_key_includes_filters():
+    user_id = PydanticObjectId()
+
+    key = LogCacheRepository.build_user_logs_key(
+        user_id=user_id,
+        watched_where="cinema",
+        date_watched_from=date(2024, 1, 1),
+        date_watched_to=date(2024, 12, 31),
+        sort_by="watchedWhere",
+        sort_order="asc",
+    )
+
+    assert key == (f"cinelog:logs:user:{user_id}:where:cinema:from:2024-01-01:to:2024-12-31:sort:watchedWhere:asc")
+
+
+@pytest.mark.asyncio
+async def test_find_log_by_id_cache_hit_skips_repository(beanie_test_db):
+    log = _sample_log()
+    cache = _mock_cache()
+    cache.get.return_value = LogCacheRepository._serialize_log(log)
+
+    with (
+        patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache),
+        patch.object(LogRepository, "find_log_by_id", AsyncMock()) as find_log_by_id,
+    ):
+        repository = LogCacheRepository()
+        result = await repository.find_log_by_id(str(log.id), log.user_id)
+
+    assert result is not None
+    assert result.id == log.id
+    find_log_by_id.assert_not_awaited()
+    cache.get.assert_awaited_once_with(LogCacheRepository.build_log_key(str(log.id), log.user_id))
+
+
+@pytest.mark.asyncio
+async def test_find_log_by_id_cache_miss_queries_repository_and_sets_cache(beanie_test_db):
+    log = _sample_log()
+    cache = _mock_cache()
+
+    with (
+        patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache),
+        patch.object(LogRepository, "find_log_by_id", AsyncMock(return_value=log)) as find_log_by_id,
+    ):
+        repository = LogCacheRepository()
+        result = await repository.find_log_by_id(str(log.id), log.user_id)
+
+    expected_key = LogCacheRepository.build_log_key(str(log.id), log.user_id)
+    assert result == log
+    find_log_by_id.assert_awaited_once_with(str(log.id), log.user_id)
+    cache.set.assert_awaited_once_with(expected_key, LogCacheRepository._serialize_log(log), ttl=LOG_CACHE_TTL)
+
+
+@pytest.mark.asyncio
+async def test_find_logs_by_user_id_cache_miss_uses_filter_specific_key(beanie_test_db):
+    user_id = PydanticObjectId()
+    log = _sample_log(user_id=user_id)
+    cache = _mock_cache()
+
+    with (
+        patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache),
+        patch.object(LogRepository, "find_logs_by_user_id", AsyncMock(return_value=[log])) as find_logs_by_user_id,
+    ):
+        repository = LogCacheRepository()
+        result = await repository.find_logs_by_user_id(
+            user_id=user_id,
+            watched_where="streaming",
+            date_watched_from=date(2024, 1, 1),
+            date_watched_to=date(2024, 1, 31),
+            sort_by="dateWatched",
+            sort_order="desc",
+        )
+
+    expected_key = LogCacheRepository.build_user_logs_key(
+        user_id=user_id,
+        watched_where="streaming",
+        date_watched_from=date(2024, 1, 1),
+        date_watched_to=date(2024, 1, 31),
+        sort_by="dateWatched",
+        sort_order="desc",
+    )
+    assert result == [log]
+    find_logs_by_user_id.assert_awaited_once_with(
+        user_id=user_id,
+        watched_where="streaming",
+        date_watched_from=date(2024, 1, 1),
+        date_watched_to=date(2024, 1, 31),
+        sort_by="dateWatched",
+        sort_order="desc",
+    )
+    cache.set.assert_awaited_once_with(expected_key, LogCacheRepository._serialize_logs([log]), ttl=LOG_CACHE_TTL)
+
+
+@pytest.mark.asyncio
+async def test_find_logs_by_user_id_cache_hit_skips_repository(beanie_test_db):
+    user_id = PydanticObjectId()
+    log = _sample_log(user_id=user_id)
+    cache = _mock_cache()
+    cache.get.return_value = LogCacheRepository._serialize_logs([log])
+
+    with (
+        patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache),
+        patch.object(LogRepository, "find_logs_by_user_id", AsyncMock()) as find_logs_by_user_id,
+    ):
+        repository = LogCacheRepository()
+        result = await repository.find_logs_by_user_id(user_id=user_id)
+
+    assert len(result) == 1
+    assert result[0].id == log.id
+    find_logs_by_user_id.assert_not_awaited()
+    cache.get.assert_awaited_once_with(LogCacheRepository.build_user_logs_key(user_id=user_id))
+
+
+@pytest.mark.asyncio
+async def test_find_logs_by_movie_id_cache_hit_skips_repository(beanie_test_db):
+    log = _sample_log()
+    cache = _mock_cache()
+    cache.get.return_value = LogCacheRepository._serialize_logs([log])
+
+    with (
+        patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache),
+        patch.object(LogRepository, "find_logs_by_movie_id", AsyncMock()) as find_logs_by_movie_id,
+    ):
+        repository = LogCacheRepository()
+        result = await repository.find_logs_by_movie_id(str(log.movie_id), log.user_id)
+
+    assert len(result) == 1
+    assert result[0].id == log.id
+    find_logs_by_movie_id.assert_not_awaited()
+    cache.get.assert_awaited_once_with(LogCacheRepository.build_movie_logs_key(str(log.movie_id), log.user_id))
+
+
+@pytest.mark.asyncio
+async def test_find_logs_by_movie_id_cache_miss_queries_repository_and_sets_cache(beanie_test_db):
+    log = _sample_log()
+    cache = _mock_cache()
+
+    with (
+        patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache),
+        patch.object(LogRepository, "find_logs_by_movie_id", AsyncMock(return_value=[log])) as find_logs_by_movie_id,
+    ):
+        repository = LogCacheRepository()
+        result = await repository.find_logs_by_movie_id(str(log.movie_id), log.user_id)
+
+    expected_key = LogCacheRepository.build_movie_logs_key(str(log.movie_id), log.user_id)
+    assert result == [log]
+    find_logs_by_movie_id.assert_awaited_once_with(str(log.movie_id), log.user_id)
+    cache.set.assert_awaited_once_with(expected_key, LogCacheRepository._serialize_logs([log]), ttl=LOG_CACHE_TTL)
+
+
+@pytest.mark.asyncio
+async def test_cache_get_and_set_failures_fall_back_to_repository(beanie_test_db):
+    log = _sample_log()
+    cache = _mock_cache()
+    cache.get.side_effect = RuntimeError("redis down")
+    cache.set.side_effect = RuntimeError("redis down")
+
+    with (
+        patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache),
+        patch.object(LogRepository, "find_log_by_id", AsyncMock(return_value=log)) as find_log_by_id,
+    ):
+        repository = LogCacheRepository()
+        result = await repository.find_log_by_id(str(log.id), log.user_id)
+
+    assert result == log
+    cache.get.assert_awaited_once_with(LogCacheRepository.build_log_key(str(log.id), log.user_id))
+    cache.set.assert_awaited_once_with(
+        LogCacheRepository.build_log_key(str(log.id), log.user_id),
+        LogCacheRepository._serialize_log(log),
+        ttl=LOG_CACHE_TTL,
+    )
+    find_log_by_id.assert_awaited_once_with(str(log.id), log.user_id)
+
+
+@pytest.mark.asyncio
+async def test_create_log_invalidates_user_and_movie_lists(beanie_test_db):
+    log = _sample_log()
+    cache = _mock_cache()
+    request = LogCreateRequest(
+        movie_id=str(log.movie_id),
+        tmdb_id=log.tmdb_id,
+        date_watched=log.date_watched.date(),
+        watched_where=log.watched_where,
+    )
+
+    with (
+        patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache),
+        patch.object(LogRepository, "create_log", AsyncMock(return_value=log)),
+    ):
+        repository = LogCacheRepository()
+        result = await repository.create_log(log.user_id, request)
+
+    assert result == log
+    cache.invalidate_pattern.assert_has_awaits(
+        [
+            call(LogCacheRepository.build_user_logs_pattern(log.user_id)),
+            call(LogCacheRepository.build_movie_logs_pattern(log.movie_id)),
+        ]
+    )
+    assert cache.invalidate_pattern.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_update_log_invalidates_id_user_and_movie_cache(beanie_test_db):
+    log = _sample_log()
+    cache = _mock_cache()
+    request = LogUpdateRequest(viewing_notes="Updated")
+
+    with (
+        patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache),
+        patch.object(LogRepository, "update_log", AsyncMock(return_value=log)),
+    ):
+        repository = LogCacheRepository()
+        result = await repository.update_log(str(log.id), log.user_id, request)
+
+    assert result == log
+    cache.delete.assert_awaited_once_with(LogCacheRepository.build_log_key(str(log.id), log.user_id))
+    cache.invalidate_pattern.assert_has_awaits(
+        [
+            call(LogCacheRepository.build_user_logs_pattern(log.user_id)),
+            call(LogCacheRepository.build_movie_logs_pattern(log.movie_id)),
+        ]
+    )
+    assert cache.invalidate_pattern.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_update_log_uses_database_lookup_without_reading_cache(beanie_test_db):
+    log = _sample_log()
+    await log.insert()
+    cache = _mock_cache()
+    cache.get.return_value = LogCacheRepository._serialize_log(log)
+    request = LogUpdateRequest(viewing_notes="Updated from DB")
+
+    with patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache):
+        repository = LogCacheRepository()
+        result = await repository.update_log(str(log.id), log.user_id, request)
+
+    assert result is not None
+    assert result.viewing_notes == "Updated from DB"
+    cache.get.assert_not_awaited()
+    cache.delete.assert_awaited_once_with(LogCacheRepository.build_log_key(str(log.id), log.user_id))
+
+
+@pytest.mark.asyncio
+async def test_delete_log_invalidates_only_after_successful_delete(beanie_test_db):
+    log = _sample_log()
+    cache = _mock_cache()
+
+    with (
+        patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache),
+        patch.object(LogRepository, "find_log_by_id", AsyncMock(return_value=log)),
+        patch.object(LogRepository, "_delete_log", AsyncMock(return_value=True)) as delete_log,
+    ):
+        repository = LogCacheRepository()
+        result = await repository.delete_log(str(log.id), log.user_id)
+
+    assert result is True
+    delete_log.assert_awaited_once_with(log)
+    cache.delete.assert_awaited_once_with(LogCacheRepository.build_log_key(str(log.id), log.user_id))
+    cache.invalidate_pattern.assert_has_awaits(
+        [
+            call(LogCacheRepository.build_user_logs_pattern(log.user_id)),
+            call(LogCacheRepository.build_movie_logs_pattern(log.movie_id)),
+        ]
+    )
+    assert cache.invalidate_pattern.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_delete_log_uses_database_lookup_without_reading_cache(beanie_test_db):
+    log = _sample_log()
+    await log.insert()
+    cache = _mock_cache()
+    cache.get.return_value = LogCacheRepository._serialize_log(log)
+
+    with patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache):
+        repository = LogCacheRepository()
+        result = await repository.delete_log(str(log.id), log.user_id)
+
+    assert result is True
+    assert await Log.get(log.id) is None
+    cache.get.assert_not_awaited()
+    cache.delete.assert_awaited_once_with(LogCacheRepository.build_log_key(str(log.id), log.user_id))
+
+
+@pytest.mark.asyncio
+async def test_delete_log_not_found_skips_delete_and_invalidation(beanie_test_db):
+    user_id = PydanticObjectId()
+    cache = _mock_cache()
+
+    with (
+        patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache),
+        patch.object(LogRepository, "find_log_by_id", AsyncMock(return_value=None)),
+        patch.object(LogRepository, "_delete_log", AsyncMock()) as delete_log,
+    ):
+        repository = LogCacheRepository()
+        result = await repository.delete_log(str(PydanticObjectId()), user_id)
+
+    assert result is False
+    delete_log.assert_not_awaited()
+    cache.delete.assert_not_awaited()
+    cache.invalidate_pattern.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_delete_log_does_not_invalidate_when_delete_fails(beanie_test_db):
+    log = _sample_log()
+    cache = _mock_cache()
+
+    with (
+        patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache),
+        patch.object(LogRepository, "find_log_by_id", AsyncMock(return_value=log)),
+        patch.object(LogRepository, "_delete_log", AsyncMock(return_value=False)) as delete_log,
+    ):
+        repository = LogCacheRepository()
+        result = await repository.delete_log(str(log.id), log.user_id)
+
+    assert result is False
+    delete_log.assert_awaited_once_with(log)
+    cache.delete.assert_not_awaited()
+    cache.invalidate_pattern.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_invalidation_failure_does_not_raise(beanie_test_db):
+    log = _sample_log()
+    cache = _mock_cache()
+    cache.invalidate_pattern.side_effect = RuntimeError("redis down")
+    request = LogCreateRequest(
+        movie_id=str(log.movie_id),
+        tmdb_id=log.tmdb_id,
+        date_watched=log.date_watched.date(),
+        watched_where=log.watched_where,
+    )
+
+    with (
+        patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache),
+        patch.object(LogRepository, "create_log", AsyncMock(return_value=log)),
+    ):
+        repository = LogCacheRepository()
+        result = await repository.create_log(log.user_id, request)
+
+    assert result == log
+    cache.invalidate_pattern.assert_has_awaits(
+        [
+            call(LogCacheRepository.build_user_logs_pattern(log.user_id)),
+            call(LogCacheRepository.build_movie_logs_pattern(log.movie_id)),
+        ]
+    )
+    assert cache.invalidate_pattern.await_count == 2


### PR DESCRIPTION
## Summary
- add LogCacheRepository for raw LogRepository lookup caching
- cache log lookups by id, user, and movie with fail-open Redis behavior
- invalidate affected log cache keys on create, update, and delete
- document service-vs-repository cache boundaries and LOG_CACHE_TTL

Closes #93

## Verification
- make test-unit — 411 passed
- make lint — passed
- make typecheck — passed
- make test-e2e — 73 passed, including log e2e flows
- make format-check — passed