### PR TITLE
refactor(repository): add protocol-backed repository dependencies

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -8,7 +8,7 @@ The codebase follows a clean layered architecture:
 
 1. **Controllers** (`app/controllers/`) — FastAPI route handlers that define API endpoints
 2. **Services** (`app/services/`) — Business logic layer that orchestrates repository operations and external integrations
-3. **Repositories** (`app/repositories/`) — Data access layer using Beanie ODM
+3. **Repositories** (`app/repository/`) — Data access layer using Beanie ODM
 4. **Models** (`app/models/`) — Beanie document models representing database entities
 5. **Schemas** (`app/schemas/`) — Pydantic models for request/response validation
 6. **Dependencies** (`app/dependencies/`) — FastAPI dependency injection (e.g., JWT auth)
@@ -52,9 +52,16 @@ All routes are registered under the `/v1/` prefix:
 
 **Dependency Flow:**
 
-- Controllers instantiate services with required repositories
-- Services contain business logic and call repositories
+- Controllers depend on services via `Depends(get_*_service)` from `app/dependencies/service_dependency.py`
+- Each `get_*_service` provider is `@lru_cache`-d and constructs the service with its repositories directly
+- Services own their repositories — no separate repository dependency layer
 - Repositories handle direct database operations using Beanie models
+- `LogCacheRepository` is a composition-based decorator over `LogRepository` and is wired in `get_log_service()` / `get_stats_service()`
+
+**Repository Conventions:**
+
+- Repository methods are instance methods; services should not call repository classes statically
+- Storage abstraction (protocols, alternative backends) is intentionally deferred until a second backend exists, which would also require splitting domain models from Beanie `Document` return types
 
 **Error Handling:**
 

--- a/app/controllers/auth_controller.py
+++ b/app/controllers/auth_controller.py
@@ -7,7 +7,10 @@ from fastapi.responses import JSONResponse
 
 from app.config.rate_limiter import limiter
 from app.dependencies.auth_dependency import auth_dependency
-from app.repository.user_repository import UserRepository
+from app.dependencies.service_dependency import (
+    get_auth_rate_limit_service,
+    get_auth_service,
+)
 from app.schemas.auth_schemas import (
     CsrfTokenResponse,
     ForgotPasswordRequest,
@@ -21,9 +24,7 @@ from app.schemas.auth_schemas import (
     ResetPasswordRequest,
     ResetPasswordResponse,
 )
-from app.services.auth_rate_limit_service import (
-    AuthRateLimitService,
-)
+from app.services.auth_rate_limit_service import AuthRateLimitService
 from app.services.auth_service import AuthService
 from app.services.token_service import TokenService
 from app.utils.auth_utils import (
@@ -41,15 +42,16 @@ from app.utils.rate_limit_utils import (
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
-user_repository = UserRepository()
-auth_service = AuthService(user_repository)
-auth_rate_limit_service = AuthRateLimitService()
-
 
 @router.post("/register", status_code=status.HTTP_201_CREATED, response_model=RegisterResponse)
 @limiter.limit("10/hour", key_func=get_ip_rate_limit_key)
 @limiter.limit("5/hour", key_func=get_session_rate_limit_key)
-async def register(request: Request, response: Response, request_body: RegisterRequest) -> RegisterResponse:
+async def register(
+    request: Request,
+    response: Response,
+    request_body: RegisterRequest,
+    auth_service: AuthService = Depends(get_auth_service),
+) -> RegisterResponse:
     """
     Handle user registration.
     User must login separately after registration.
@@ -64,6 +66,8 @@ async def login(
     request: Request,
     response: Response,
     request_body: LoginRequest,
+    auth_service: AuthService = Depends(get_auth_service),
+    auth_rate_limit_service: AuthRateLimitService = Depends(get_auth_rate_limit_service),
 ) -> LoginResponse:
     """
     Handle user login with email and password.
@@ -155,6 +159,8 @@ async def forgot_password(
     request: Request,
     response: Response,
     request_body: ForgotPasswordRequest,
+    auth_service: AuthService = Depends(get_auth_service),
+    auth_rate_limit_service: AuthRateLimitService = Depends(get_auth_rate_limit_service),
 ) -> ForgotPasswordResponse:
     """
     Initiate password recovery. Sends reset code via email.
@@ -177,6 +183,8 @@ async def reset_password(
     request: Request,
     response: Response,
     request_body: ResetPasswordRequest,
+    auth_service: AuthService = Depends(get_auth_service),
+    auth_rate_limit_service: AuthRateLimitService = Depends(get_auth_rate_limit_service),
 ) -> ResetPasswordResponse:
     """
     Complete password recovery with reset code.

--- a/app/controllers/log_controller.py
+++ b/app/controllers/log_controller.py
@@ -3,7 +3,7 @@ from fastapi import APIRouter, Depends, Request, Response, status
 
 from app.config.rate_limiter import limiter
 from app.dependencies.auth_dependency import auth_dependency
-from app.repository.log_cache_repository import LogCacheRepository
+from app.dependencies.service_dependency import get_log_service
 from app.schemas.log_schemas import (
     LogCreateRequest,
     LogCreateResponse,
@@ -15,9 +15,6 @@ from app.services.log_service import LogService
 
 router = APIRouter()
 
-log_repository = LogCacheRepository()
-log_service = LogService(log_repository)
-
 
 @router.post("/", response_model=LogCreateResponse, status_code=201)
 @limiter.limit("20/minute")
@@ -26,6 +23,7 @@ async def create_log(
     response: Response,
     request_body: LogCreateRequest,
     user_id: PydanticObjectId = Depends(auth_dependency),
+    log_service: LogService = Depends(get_log_service),
 ) -> LogCreateResponse:
     """
     Create a new viewing log entry.
@@ -43,6 +41,7 @@ async def update_log(
     log_id: str,
     request_body: LogUpdateRequest,
     user_id: PydanticObjectId = Depends(auth_dependency),
+    log_service: LogService = Depends(get_log_service),
 ) -> LogCreateResponse:
     """
     Update an existing viewing log entry.
@@ -64,6 +63,7 @@ async def delete_log(
     response: Response,
     log_id: str,
     user_id: PydanticObjectId = Depends(auth_dependency),
+    log_service: LogService = Depends(get_log_service),
 ) -> None:
     """
     Delete a viewing log entry.
@@ -80,6 +80,7 @@ async def get_logs_by_handle(
     request: Request,
     list_request: LogListRequest = Depends(),
     user_id: PydanticObjectId = Depends(auth_dependency),
+    log_service: LogService = Depends(get_log_service),
 ) -> LogListResponse:
     """
     Get list of a user's viewing logs by handle.

--- a/app/controllers/movie_rating_controller.py
+++ b/app/controllers/movie_rating_controller.py
@@ -4,22 +4,14 @@ from beanie import PydanticObjectId
 from fastapi import APIRouter, Depends, Request, Response, status
 
 from app.dependencies.auth_dependency import auth_dependency
-from app.repository.movie_rating_repository import MovieRatingRepository
-from app.repository.movie_repository import MovieRepository
+from app.dependencies.service_dependency import get_movie_rating_service
 from app.schemas.movie_rating_schemas import (
     MovieRatingCreateUpdateRequest,
     MovieRatingResponse,
 )
 from app.services.movie_rating_service import MovieRatingService
-from app.services.movie_service import MovieService
 
 router = APIRouter()
-
-movie_rating_repository = MovieRatingRepository()
-movie_repository = MovieRepository()
-movie_service = MovieService(movie_repository)
-
-movie_rating_service = MovieRatingService(movie_rating_repository=movie_rating_repository, movie_service=movie_service)
 
 
 @router.post("/")
@@ -27,6 +19,7 @@ async def create_movie_rating(
     request_body: MovieRatingCreateUpdateRequest,
     request: Request,
     user_id: Annotated[PydanticObjectId, Depends(auth_dependency)],
+    movie_rating_service: Annotated[MovieRatingService, Depends(get_movie_rating_service)],
 ) -> MovieRatingResponse:
     """
     Create or update a new movie rating entry.
@@ -45,6 +38,7 @@ async def create_movie_rating(
 async def get_movie_rating(
     tmdb_id: int,
     current_user_id: Annotated[PydanticObjectId, Depends(auth_dependency)],
+    movie_rating_service: Annotated[MovieRatingService, Depends(get_movie_rating_service)],
 ) -> MovieRatingResponse | Response:
     """
     Get a movie rating entry by TMDB ID.

--- a/app/controllers/stats_controller.py
+++ b/app/controllers/stats_controller.py
@@ -2,13 +2,12 @@ from beanie import PydanticObjectId
 from fastapi import APIRouter, Depends, HTTPException, Request
 
 from app.dependencies.auth_dependency import auth_dependency
+from app.dependencies.service_dependency import get_stats_service
 from app.schemas.stats_schemas import StatsRequest, StatsResponse
 from app.services.stats_service import StatsService
 from app.utils.exceptions_utils import AppException
 
 router = APIRouter()
-
-stats_service = StatsService()
 
 
 @router.get("/me", response_model=StatsResponse)
@@ -16,6 +15,7 @@ async def get_my_stats(
     request: Request,
     stats_request: StatsRequest = Depends(),
     user_id: PydanticObjectId = Depends(auth_dependency),
+    stats_service: StatsService = Depends(get_stats_service),
 ) -> StatsResponse:
     """
     Get stats for the logged in user.

--- a/app/controllers/user_controller.py
+++ b/app/controllers/user_controller.py
@@ -2,7 +2,7 @@ from beanie import PydanticObjectId
 from fastapi import APIRouter, Depends, Request
 
 from app.dependencies.auth_dependency import auth_dependency
-from app.repository.user_repository import UserRepository
+from app.dependencies.service_dependency import get_user_service
 from app.schemas.user_schemas import (
     ChangePasswordRequest,
     ChangePasswordResponse,
@@ -14,12 +14,13 @@ from app.services.user_service import UserService
 
 router = APIRouter()
 
-user_repository = UserRepository()
-user_service = UserService(user_repository=user_repository)
-
 
 @router.get("/info", response_model=UserResponse)
-async def get_user_info(request: Request, user_id: PydanticObjectId = Depends(auth_dependency)) -> UserResponse:
+async def get_user_info(
+    request: Request,
+    user_id: PydanticObjectId = Depends(auth_dependency),
+    user_service: UserService = Depends(get_user_service),
+) -> UserResponse:
     return await user_service.get_user_info(user_id)
 
 
@@ -28,6 +29,7 @@ async def get_public_profile(
     handle: str,
     request: Request,
     user_id: PydanticObjectId = Depends(auth_dependency),
+    user_service: UserService = Depends(get_user_service),
 ) -> UserProfileResponse:
     return await user_service.get_visible_profile(handle=handle, requester_id=user_id)
 
@@ -37,6 +39,7 @@ async def update_profile(
     request_body: UpdateProfileRequest,
     request: Request,
     user_id: PydanticObjectId = Depends(auth_dependency),
+    user_service: UserService = Depends(get_user_service),
 ) -> UserResponse:
     return await user_service.update_profile(user_id, request_body)
 
@@ -46,6 +49,7 @@ async def change_password(
     request_body: ChangePasswordRequest,
     request: Request,
     user_id: PydanticObjectId = Depends(auth_dependency),
+    user_service: UserService = Depends(get_user_service),
 ) -> ChangePasswordResponse:
     return await user_service.change_password(
         user_id=user_id,

--- a/app/dependencies/service_dependency.py
+++ b/app/dependencies/service_dependency.py
@@ -1,0 +1,70 @@
+"""Service dependencies for FastAPI ``Depends(...)``.
+
+Each ``get_*_service`` is wrapped with ``@lru_cache`` so it returns the
+same process-wide instance. Endpoints declare ``Depends(get_*_service)``.
+Tests can swap a whole service through
+``app.dependency_overrides[get_*_service] = ...``.
+"""
+
+from functools import lru_cache
+
+from app.repository.log_cache_repository import LogCacheRepository
+from app.repository.log_repository import LogRepository
+from app.repository.movie_rating_repository import MovieRatingRepository
+from app.repository.movie_repository import MovieRepository
+from app.repository.user_repository import UserRepository
+from app.services.auth_rate_limit_service import AuthRateLimitService
+from app.services.auth_service import AuthService
+from app.services.log_service import LogService
+from app.services.movie_rating_service import MovieRatingService
+from app.services.movie_service import MovieService
+from app.services.stats_service import StatsService
+from app.services.user_service import UserService
+
+
+@lru_cache
+def get_auth_service() -> AuthService:
+    return AuthService(UserRepository())
+
+
+@lru_cache
+def get_auth_rate_limit_service() -> AuthRateLimitService:
+    return AuthRateLimitService()
+
+
+@lru_cache
+def get_user_service() -> UserService:
+    return UserService(user_repository=UserRepository())
+
+
+@lru_cache
+def get_movie_service() -> MovieService:
+    return MovieService(MovieRepository())
+
+
+@lru_cache
+def get_movie_rating_service() -> MovieRatingService:
+    return MovieRatingService(
+        movie_rating_repository=MovieRatingRepository(),
+        movie_service=get_movie_service(),
+    )
+
+
+@lru_cache
+def get_log_service() -> LogService:
+    return LogService(
+        log_repository=LogCacheRepository(LogRepository()),
+        movie_service=get_movie_service(),
+        movie_repository=MovieRepository(),
+        movie_rating_repository=MovieRatingRepository(),
+        user_repository=UserRepository(),
+    )
+
+
+@lru_cache
+def get_stats_service() -> StatsService:
+    return StatsService(
+        log_repository=LogCacheRepository(LogRepository()),
+        movie_rating_repository=MovieRatingRepository(),
+        movie_repository=MovieRepository(),
+    )

--- a/app/repository/log_cache_repository.py
+++ b/app/repository/log_cache_repository.py
@@ -8,6 +8,7 @@ from beanie import PydanticObjectId
 from app.models.log import Log
 from app.repository.log_repository import LogRepository
 from app.schemas.log_schemas import LogCreateRequest, LogUpdateRequest
+from app.schemas.stats_schemas import LogStats
 from app.services.cache_service import CacheService
 
 logger = logging.getLogger(__name__)
@@ -15,19 +16,21 @@ logger = logging.getLogger(__name__)
 LOG_CACHE_TTL = int(os.getenv("LOG_CACHE_TTL", "86400"))
 
 
-class LogCacheRepository(LogRepository):
+class LogCacheRepository:
     """Redis-backed decorator for raw log repository lookups."""
+
+    def __init__(self, repository: LogRepository | None = None):
+        self.repository = repository or LogRepository()
 
     @property
     def _cache(self) -> CacheService:
         return CacheService.get_instance()
 
-    @staticmethod
-    def build_log_key(log_id: str, user_id: PydanticObjectId) -> str:
+    def build_log_key(self, log_id: str, user_id: PydanticObjectId) -> str:
         return f"cinelog:logs:id:{user_id}:{log_id}"
 
-    @staticmethod
     def build_user_logs_key(
+        self,
         user_id: PydanticObjectId,
         watched_where: str | None = None,
         date_watched_from: date | None = None,
@@ -43,34 +46,27 @@ class LogCacheRepository(LogRepository):
             f"from:{from_part}:to:{to_part}:sort:{sort_by}:{sort_order}"
         )
 
-    @staticmethod
-    def build_movie_logs_key(movie_id: str, user_id: PydanticObjectId | None = None) -> str:
+    def build_movie_logs_key(self, movie_id: str, user_id: PydanticObjectId | None = None) -> str:
         user_part = str(user_id) if user_id is not None else "all"
         return f"cinelog:logs:movie:{movie_id}:user:{user_part}"
 
-    @staticmethod
-    def build_user_logs_pattern(user_id: PydanticObjectId) -> str:
+    def build_user_logs_pattern(self, user_id: PydanticObjectId) -> str:
         return f"cinelog:logs:user:{user_id}:*"
 
-    @staticmethod
-    def build_movie_logs_pattern(movie_id: PydanticObjectId | str) -> str:
+    def build_movie_logs_pattern(self, movie_id: PydanticObjectId | str) -> str:
         return f"cinelog:logs:movie:{movie_id}:*"
 
-    @staticmethod
-    def _serialize_log(log: Log) -> dict[str, Any]:
+    def _serialize_log(self, log: Log) -> dict[str, Any]:
         return cast(dict[str, Any], log.model_dump(mode="json", by_alias=True))
 
-    @classmethod
-    def _serialize_logs(cls, logs: list[Log]) -> list[dict[str, Any]]:
-        return [cls._serialize_log(log) for log in logs]
+    def _serialize_logs(self, logs: list[Log]) -> list[dict[str, Any]]:
+        return [self._serialize_log(log) for log in logs]
 
-    @staticmethod
-    def _deserialize_log(data: dict[str, Any]) -> Log:
+    def _deserialize_log(self, data: dict[str, Any]) -> Log:
         return cast(Log, Log.model_validate(data))
 
-    @classmethod
-    def _deserialize_logs(cls, data: list[Any]) -> list[Log]:
-        return [cls._deserialize_log(item) for item in data]
+    def _deserialize_logs(self, data: list[Any]) -> list[Log]:
+        return [self._deserialize_log(item) for item in data]
 
     async def _get_log(self, key: str) -> Log | None:
         try:
@@ -142,7 +138,7 @@ class LogCacheRepository(LogRepository):
         await self._invalidate_movie_logs(log.movie_id)
 
     async def create_log(self, user_id: PydanticObjectId, create_log_request: LogCreateRequest) -> Log:
-        log = await super().create_log(user_id, create_log_request)
+        log = await self.repository.create_log(user_id, create_log_request)
         await self._invalidate_user_logs(log.user_id)
         await self._invalidate_movie_logs(log.movie_id)
         return log
@@ -153,13 +149,13 @@ class LogCacheRepository(LogRepository):
         if cached is not None:
             return cached
 
-        log = await super().find_log_by_id(log_id, user_id)
+        log = await self.repository.find_log_by_id(log_id, user_id)
         if log is not None:
             await self._set_log(key, log)
         return log
 
     async def update_log(self, log_id: str, user_id: PydanticObjectId, update_request: LogUpdateRequest) -> Log | None:
-        log = await super().update_log(log_id, user_id, update_request)
+        log = await self.repository.update_log(log_id, user_id, update_request)
         if log is not None:
             await self._invalidate_log(log)
         return log
@@ -185,16 +181,13 @@ class LogCacheRepository(LogRepository):
         if cached is not None:
             return cached
 
-        logs = cast(
-            list[Log],
-            await super().find_logs_by_user_id(
-                user_id=user_id,
-                watched_where=watched_where,
-                date_watched_from=date_watched_from,
-                date_watched_to=date_watched_to,
-                sort_by=sort_by,
-                sort_order=sort_order,
-            ),
+        logs = await self.repository.find_logs_by_user_id(
+            user_id=user_id,
+            watched_where=watched_where,
+            date_watched_from=date_watched_from,
+            date_watched_to=date_watched_to,
+            sort_by=sort_by,
+            sort_order=sort_order,
         )
         await self._set_logs(key, logs)
         return logs
@@ -205,16 +198,22 @@ class LogCacheRepository(LogRepository):
         if cached is not None:
             return cached
 
-        logs = await super().find_logs_by_movie_id(movie_id, user_id)
+        logs = await self.repository.find_logs_by_movie_id(movie_id, user_id)
         await self._set_logs(key, logs)
         return logs
 
-    async def delete_log(self, log_id: str, user_id: PydanticObjectId) -> bool:
-        existing_log = await super().find_log_by_id(log_id, user_id)
-        if existing_log is None:
-            return False
+    async def delete_log(self, log_id: str, user_id: PydanticObjectId) -> Log | None:
+        deleted_log = await self.repository.delete_log(log_id, user_id)
+        if deleted_log is None:
+            return None
 
-        deleted = await super()._delete_log(existing_log)
-        if deleted:
-            await self._invalidate_log(existing_log)
-        return deleted
+        await self._invalidate_log(deleted_log)
+        return deleted_log
+
+    async def get_log_stats(
+        self,
+        user_id: PydanticObjectId,
+        date_from: date | None = None,
+        date_to: date | None = None,
+    ) -> LogStats:
+        return await self.repository.get_log_stats(user_id, date_from=date_from, date_to=date_to)

--- a/app/repository/log_repository.py
+++ b/app/repository/log_repository.py
@@ -65,7 +65,7 @@ class LogRepository:
         date_watched_to: date | None = None,
         sort_by: str = "dateWatched",
         sort_order: str = "desc",
-    ):
+    ) -> list[Log]:
         """
         Find all log entries for a specific user with optional filtering and sorting.
         Returns a list of dictionaries containing log data with joined movie data.
@@ -114,19 +114,16 @@ class LogRepository:
 
         return await Log.find(query_params).to_list()
 
-    async def delete_log(self, log_id: str, user_id: PydanticObjectId) -> bool:
+    async def delete_log(self, log_id: str, user_id: PydanticObjectId) -> Log | None:
         """
-        Delete a log entry (hard delete).
+        Delete a log entry (hard delete). Returns the deleted log, or None if not found.
         """
         log = await self._find_log_by_id(log_id, user_id)
         if not log:
-            return False
+            return None
 
-        return await self._delete_log(log)
-
-    async def _delete_log(self, log: Log) -> bool:
         await log.delete()
-        return True
+        return log
 
     async def get_log_stats(
         self,

--- a/app/repository/movie_rating_repository.py
+++ b/app/repository/movie_rating_repository.py
@@ -6,9 +6,8 @@ from app.utils.object_id_utils import to_object_id
 
 
 class MovieRatingRepository:
-    @staticmethod
     async def find_movie_rating_by_user_and_movie(
-        user_id: PydanticObjectId, movie_id: PydanticObjectId
+        self, user_id: PydanticObjectId, movie_id: PydanticObjectId
     ) -> MovieRating | None:
         """
         Find a movie rating by user ID and movie ID.
@@ -21,8 +20,7 @@ class MovieRatingRepository:
             MovieRating.active_filter({"userId": user_object_id, "movieId": movie_object_id})
         )
 
-    @staticmethod
-    async def find_movie_rating_by_user_and_tmdb(user_id: PydanticObjectId, tmdb_id: int) -> MovieRating | None:
+    async def find_movie_rating_by_user_and_tmdb(self, user_id: PydanticObjectId, tmdb_id: int) -> MovieRating | None:
         """
         Find a movie rating by user ID and TMDB ID.
         """
@@ -31,8 +29,8 @@ class MovieRatingRepository:
             return None
         return await MovieRating.find_one(MovieRating.active_filter({"userId": user_object_id, "tmdbId": tmdb_id}))
 
-    @staticmethod
     async def create_update_movie_rating(
+        self,
         user_id: PydanticObjectId,
         movie_id: PydanticObjectId,
         rating: int,
@@ -43,7 +41,7 @@ class MovieRatingRepository:
         Create or update a movie rating for a specific user and movie.
         If a rating already exists for the user and movie, it will be updated.
         """
-        existing_rating = await MovieRatingRepository.find_movie_rating_by_user_and_movie(user_id, movie_id)
+        existing_rating = await self.find_movie_rating_by_user_and_movie(user_id, movie_id)
 
         if existing_rating:
             existing_rating.rating = rating

--- a/app/repository/movie_repository.py
+++ b/app/repository/movie_repository.py
@@ -11,8 +11,7 @@ from app.schemas.tmdb_schemas import TMDBMovieDetails
 class MovieRepository:
     """Repository class for movie-related operations."""
 
-    @staticmethod
-    async def create_movie(request: MovieCreateRequest) -> Movie:
+    async def create_movie(self, request: MovieCreateRequest) -> Movie:
         """Create a new movie in the database."""
 
         movie_data = request.model_dump()
@@ -20,11 +19,10 @@ class MovieRepository:
         await movie.insert()
         return movie
 
-    @staticmethod
-    async def update_movie(movie_id: PydanticObjectId, request: MovieUpdateRequest) -> None:
+    async def update_movie(self, movie_id: PydanticObjectId, request: MovieUpdateRequest) -> None:
         """Update a movie in the database."""
 
-        movie = await MovieRepository.find_movie_by_id(movie_id)
+        movie = await self.find_movie_by_id(movie_id)
 
         if not movie:
             return None
@@ -33,18 +31,15 @@ class MovieRepository:
         movie.updated_at = datetime.now(UTC)
         await movie.save()
 
-    @staticmethod
-    async def find_movie_by_id(movie_id: PydanticObjectId) -> Movie | None:
+    async def find_movie_by_id(self, movie_id: PydanticObjectId) -> Movie | None:
         """Find a movie by ID."""
         return await Movie.find_one(Movie.active_filter({"_id": movie_id}))
 
-    @staticmethod
-    async def find_movie_by_tmdb_id(tmdb_id: int) -> Movie | None:
+    async def find_movie_by_tmdb_id(self, tmdb_id: int) -> Movie | None:
         """Find a movie by TMDB ID."""
         return await Movie.find_one(Movie.active_filter({"tmdbId": tmdb_id}))
 
-    @staticmethod
-    async def create_from_tmdb_data(tmdb_data: TMDBMovieDetails) -> Movie:
+    async def create_from_tmdb_data(self, tmdb_data: TMDBMovieDetails) -> Movie:
         """
         Create a movie from TMDB API response data.
 
@@ -83,7 +78,7 @@ class MovieRepository:
             await movie.insert()
             return movie
         except DuplicateKeyError:
-            existing_movie = await MovieRepository.find_movie_by_tmdb_id(tmdb_data.id)
+            existing_movie = await self.find_movie_by_tmdb_id(tmdb_data.id)
             if existing_movie is None:
                 raise
             return existing_movie

--- a/app/repository/user_repository.py
+++ b/app/repository/user_repository.py
@@ -12,8 +12,7 @@ from app.utils.object_id_utils import to_object_id
 class UserRepository:
     """Repository class for User-related operations."""
 
-    @staticmethod
-    async def create_user(request: UserCreateRequest) -> User:
+    async def create_user(self, request: UserCreateRequest) -> User:
         """Create a new user in the database."""
 
         # Convert Pydantic model to dict and unpack into User model
@@ -23,35 +22,28 @@ class UserRepository:
         await user.insert()
         return user
 
-    @staticmethod
-    async def find_user_by_email(email: str) -> User | None:
+    async def find_user_by_email(self, email: str) -> User | None:
         """Find a user by email (case-insensitive)."""
         return await User.find_one(User.active_filter({"email": {"$regex": f"^{re.escape(email)}$", "$options": "i"}}))
 
-    @staticmethod
-    async def find_user_by_handle(handle: str) -> User | None:
+    async def find_user_by_handle(self, handle: str) -> User | None:
         """Find a user by handle."""
         return await User.find_one(User.active_filter({"handle": handle}))
 
-    @staticmethod
-    async def find_user_by_email_or_handle(email_or_handle: str) -> User | None:
+    async def find_user_by_email_or_handle(self, email_or_handle: str) -> User | None:
         """Find a user by email or handle."""
-        return await UserRepository.find_user_by_email(email_or_handle) or await UserRepository.find_user_by_handle(
-            email_or_handle
-        )
+        return await self.find_user_by_email(email_or_handle) or await self.find_user_by_handle(email_or_handle)
 
-    @staticmethod
-    async def find_user_by_id(user_id: PydanticObjectId) -> User | None:
+    async def find_user_by_id(self, user_id: PydanticObjectId) -> User | None:
         """Find a user by ID."""
         parsed_user_id = to_object_id(user_id)
         if parsed_user_id is None:
             return None
         return await User.find_one(User.active_filter({"_id": parsed_user_id}))
 
-    @staticmethod
-    async def delete_user(user_id: PydanticObjectId) -> bool:
+    async def delete_user(self, user_id: PydanticObjectId) -> bool:
         """Delete a user logically by ID."""
-        user = await UserRepository.find_user_by_id(user_id)
+        user = await self.find_user_by_id(user_id)
         if not user:
             return False
 
@@ -61,10 +53,9 @@ class UserRepository:
         await user.save()
         return True
 
-    @staticmethod
-    async def delete_user_oblivion(user_id: PydanticObjectId) -> bool:
+    async def delete_user_oblivion(self, user_id: PydanticObjectId) -> bool:
         """Obscure all the user information and delete the user logically."""
-        user = await UserRepository.find_user_by_id(user_id)
+        user = await self.find_user_by_id(user_id)
         if not user:
             return False
 
@@ -82,33 +73,29 @@ class UserRepository:
 
         return True
 
-    @staticmethod
-    async def update_password(user: User, password_hash: str) -> User:
+    async def update_password(self, user: User, password_hash: str) -> User:
         """Update user password."""
         user.password_hash = password_hash
         await user.save()
         return user
 
-    @staticmethod
-    async def set_reset_password_code(user: User, code: str, expires_at: datetime) -> User:
+    async def set_reset_password_code(self, user: User, code: str, expires_at: datetime) -> User:
         """Set reset password code and expiration."""
         user.reset_password_code = code
         user.reset_password_expires = expires_at
         await user.save()
         return user
 
-    @staticmethod
-    async def clear_reset_password_code(user: User) -> User:
+    async def clear_reset_password_code(self, user: User) -> User:
         """Clear reset password code."""
         user.reset_password_code = None
         user.reset_password_expires = None
         await user.save()
         return user
 
-    @staticmethod
-    async def update_user_profile(user_id: PydanticObjectId, update_data: dict[str, Any]) -> User | None:
+    async def update_user_profile(self, user_id: PydanticObjectId, update_data: dict[str, Any]) -> User | None:
         """Update user profile fields."""
-        user = await UserRepository.find_user_by_id(user_id)
+        user = await self.find_user_by_id(user_id)
         if not user:
             return None
         for field, value in update_data.items():

--- a/app/services/log_service.py
+++ b/app/services/log_service.py
@@ -1,7 +1,7 @@
 from beanie import PydanticObjectId
 
 from app.models.movie import Movie
-from app.repository.log_repository import LogRepository
+from app.repository.log_cache_repository import LogCacheRepository
 from app.repository.movie_rating_repository import MovieRatingRepository
 from app.repository.movie_repository import MovieRepository
 from app.repository.user_repository import UserRepository
@@ -25,22 +25,21 @@ class LogService:
 
     def __init__(
         self,
-        log_repository: LogRepository,
+        log_repository: LogCacheRepository | None = None,
         movie_service: MovieService | None = None,
         movie_repository: MovieRepository | None = None,
         movie_rating_repository: MovieRatingRepository | None = None,
         stats_cache_service: StatsCacheService | None = None,
         user_repository: UserRepository | None = None,
     ):
-        self.log_repository = log_repository
-        # Initialize movie service if not provided
+        self.log_repository = log_repository or LogCacheRepository()
+        resolved_movie_repository = movie_repository or MovieRepository()
         if movie_service is None:
-            movie_repository = MovieRepository()
-            movie_service = MovieService(movie_repository)
+            movie_service = MovieService(resolved_movie_repository)
 
         self.movie_service = movie_service
         self.movie_rating_repository = movie_rating_repository or MovieRatingRepository()
-        self.movie_repository = movie_repository or MovieRepository()
+        self.movie_repository = resolved_movie_repository
         self.stats_cache_service = stats_cache_service or StatsCacheService()
         self.user_repository = user_repository or UserRepository()
 
@@ -122,8 +121,8 @@ class LogService:
         """
         Delete a viewing log entry owned by the given user.
         """
-        deleted = await self.log_repository.delete_log(log_id=log_id, user_id=user_id)
-        if not deleted:
+        deleted_log = await self.log_repository.delete_log(log_id=log_id, user_id=user_id)
+        if deleted_log is None:
             raise AppException(ErrorCodes.LOG_NOT_FOUND)
 
         await self.stats_cache_service.invalidate_user_stats(user_id)

--- a/app/services/stats_service.py
+++ b/app/services/stats_service.py
@@ -3,7 +3,7 @@ from datetime import date
 
 from beanie import PydanticObjectId
 
-from app.repository.log_repository import LogRepository
+from app.repository.log_cache_repository import LogCacheRepository
 from app.repository.movie_rating_repository import MovieRatingRepository
 from app.repository.movie_repository import MovieRepository
 from app.schemas.stats_schemas import (
@@ -20,12 +20,12 @@ from app.services.stats_cache_service import StatsCacheService
 class StatsService:
     def __init__(
         self,
-        log_repository: LogRepository | None = None,
+        log_repository: LogCacheRepository | None = None,
         movie_rating_repository: MovieRatingRepository | None = None,
         movie_repository: MovieRepository | None = None,
         stats_cache_service: StatsCacheService | None = None,
     ):
-        self.log_repository = log_repository or LogRepository()
+        self.log_repository = log_repository or LogCacheRepository()
         self.movie_rating_repository = movie_rating_repository or MovieRatingRepository()
         self.movie_repository = movie_repository or MovieRepository()
         self.stats_cache_service = stats_cache_service or StatsCacheService()

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,7 @@ Developer-facing documentation covering infrastructure, implementation details, 
 | [Pydantic Types and Validators](technical/pydantic_types_and_validators.md) | Reusable Annotated validation types by domain |
 | [Rate Limiting](technical/rate-limiting.md) | slowapi setup, Redis backend, endpoint decoration, test strategy |
 | [Redis Caching](technical/redis-caching.md) | Cache layer configuration, design, and usage |
+| [Service Dependencies](technical/service-dependencies.md) | Service providers, FastAPI `Depends` wiring, test overrides |
 | [Stats Caching](technical/stats-caching.md) | Stats caching strategy, TTL, and invalidation triggers |
 | [TMDB Service](technical/tmdb-service.md) | Singleton lifecycle, HTTP client, cache keys, MovieService integration |
 

--- a/docs/technical/redis-caching.md
+++ b/docs/technical/redis-caching.md
@@ -62,13 +62,13 @@ Key construction is the caller's responsibility — `CacheService` is key-agnost
 Cinelog uses cache layers at the same boundary as the data being cached:
 
 - `*_cache_service.py` is for service-level, composed, or external API responses. Examples: `StatsCacheService` caches a `StatsResponse`, and `TMDBCacheService` caches TMDB API responses.
-- `*_cache_repository.py` is for raw persistence lookups. `LogCacheRepository` wraps `LogRepository` and caches raw `Log` documents before `LogService` enriches them with movie and rating data.
+- `*_cache_repository.py` is for raw persistence lookups. `LogCacheRepository` wraps a `LogRepository` instance and caches raw `Log` documents before `LogService` enriches them with movie and rating data.
 
 Use the narrowest boundary that owns the data dependencies. If a response combines multiple repositories or services, caching it at that level also makes invalidation responsible for all of those dependencies.
 
-### Inheritance vs Composition
+### Composition over Inheritance
 
-Use inheritance only when the cache layer is a drop-in replacement for the uncached layer and exposes the same contract. `LogCacheRepository` extends `LogRepository` because callers can use it anywhere a log repository is expected.
+Repository cache decorators use composition. `LogCacheRepository` wraps a `LogRepository` instance via constructor injection, exposes the same method surface, and can be used anywhere a log repository dependency is expected.
 
 Use composition when the cache layer is only a helper for storing, reading, or invalidating cached payloads. `StatsService` composes `StatsCacheService`, and `TMDBService` composes `TMDBCacheService`; those cache services are not substitutes for the full service APIs.
 
@@ -76,7 +76,7 @@ Use composition when the cache layer is only a helper for storing, reading, or i
 
 ## Log Repository Cache
 
-`LogCacheRepository` (`app/repository/log_cache_repository.py`) decorates `LogRepository` and caches:
+`LogCacheRepository` (`app/repository/log_cache_repository.py`) decorates a `LogRepository` instance and caches:
 
 - `find_log_by_id(log_id, user_id)`
 - `find_logs_by_user_id(...)`

--- a/docs/technical/service-dependencies.md
+++ b/docs/technical/service-dependencies.md
@@ -1,0 +1,140 @@
+# Service Dependencies
+
+Controllers receive services through FastAPI `Depends(...)`. Each service owns and instantiates its repositories directly — there is no separate repository dependency layer or protocol indirection.
+
+## Conventions
+
+- Service providers live in `app/dependencies/service_dependency.py`.
+- Each provider is `@lru_cache`-d, so it returns the same process-wide service instance.
+- Each service constructs its own repositories. Tests can pass a mock via the service's optional repository constructor parameters; production code does not.
+- Cache decorators (currently only `LogCacheRepository`) are wired at the dependency layer — the service stays cache-agnostic.
+- Controllers do not hold module-level service singletons. Endpoints use `Depends(get_*_service)` exclusively.
+
+## Service Providers
+
+| Provider | Service |
+|---|---|
+| `get_auth_service()` | `AuthService` |
+| `get_auth_rate_limit_service()` | `AuthRateLimitService` |
+| `get_user_service()` | `UserService` |
+| `get_movie_service()` | `MovieService` |
+| `get_movie_rating_service()` | `MovieRatingService` |
+| `get_log_service()` | `LogService` (wraps `LogRepository` with `LogCacheRepository`) |
+| `get_stats_service()` | `StatsService` (wraps `LogRepository` with `LogCacheRepository`) |
+
+## Endpoint Usage
+
+```python
+from app.dependencies.service_dependency import get_log_service
+from app.services.log_service import LogService
+
+
+@router.post("/")
+async def create_log(
+    body: LogCreateRequest,
+    user_id: PydanticObjectId = Depends(auth_dependency),
+    log_service: LogService = Depends(get_log_service),
+) -> LogCreateResponse:
+    return await log_service.create_log(user_id=user_id, request=body)
+```
+
+## Test Overrides
+
+Because every `get_*_service` provider is `@lru_cache`-d, the same instance is returned to the controller (via `Depends`) and to the test code (via direct call). This gives two equally valid override patterns. Pick the one that matches how much of the service you want to replace.
+
+### Pattern 1 — Patch a single method
+
+Use this when the test only cares about one method on the service. The cached instance keeps its identity; only the named method is swapped for the duration of the test, then restored automatically.
+
+```python
+from unittest.mock import AsyncMock, patch
+
+from app.dependencies.service_dependency import get_log_service
+
+
+class TestCreateLog:
+    @patch.object(get_log_service(), "create_log", new_callable=AsyncMock)
+    def test_create_log_success(self, mock_create_log, client, sample_log_response):
+        mock_create_log.return_value = sample_log_response
+
+        response = client.post("/v1/logs/", json={...}, cookies={...})
+
+        assert response.status_code == 201
+        mock_create_log.assert_awaited_once()
+```
+
+This is the dominant pattern in `tests/units/controllers/` because most controller tests exercise one endpoint at a time.
+
+> ⚠️ Do not call `get_log_service.cache_clear()` (or any `get_*_service.cache_clear()`) during a test that uses `patch.object(get_*_service(), ...)`. The decorator evaluates `get_*_service()` once at import and patches that instance; clearing the cache makes the controller resolve a fresh, unpatched instance on the next request, and the test would silently pass for the wrong reason — or fail in a confusing way.
+
+### Pattern 2 — Replace the whole service via `dependency_overrides`
+
+Use this when the test needs to swap out many methods on the service, or when the test fixture needs full control over how the service behaves (e.g. a fully-faked service with shared state across calls).
+
+```python
+from unittest.mock import AsyncMock, MagicMock
+
+from app import app
+from app.dependencies.service_dependency import get_log_service
+
+
+def test_create_then_list(client):
+    fake_log_service = MagicMock()
+    fake_log_service.create_log = AsyncMock(return_value=...)
+    fake_log_service.get_user_logs_by_handle = AsyncMock(return_value=...)
+
+    app.dependency_overrides[get_log_service] = lambda: fake_log_service
+    try:
+        client.post("/v1/logs/", json={...})
+        client.get("/v1/logs/myhandle")
+    finally:
+        app.dependency_overrides.pop(get_log_service, None)
+```
+
+`dependency_overrides` is keyed by the provider function itself, **not** the service instance — that's what makes the override active for the duration of the request.
+
+### Combining with auth overrides
+
+Most controller tests also need to bypass `auth_dependency`. The two override styles compose cleanly:
+
+```python
+from app.dependencies.auth_dependency import auth_dependency
+from app.dependencies.service_dependency import get_log_service
+
+
+@pytest.fixture
+def override_auth():
+    return lambda: PydanticObjectId()
+
+
+@patch.object(get_log_service(), "create_log", new_callable=AsyncMock)
+def test_create_log_authenticated(mock_create_log, client, override_auth):
+    app.dependency_overrides[auth_dependency] = override_auth
+    mock_create_log.return_value = ...
+    try:
+        response = client.post("/v1/logs/", ...)
+        assert response.status_code == 201
+    finally:
+        app.dependency_overrides.pop(auth_dependency, None)
+```
+
+Always remove your override at the end of the test — `dependency_overrides` is module-level state and leaks across tests if not cleaned up. Prefer `pop(specific_key, None)` over `app.dependency_overrides = {}`: the latter silently wipes overrides set by other fixtures (e.g. an autouse session fixture) and is a footgun. Reserve `app.dependency_overrides = {}` for top-level pytest teardown fixtures that intentionally own all override state.
+
+### When to prefer which pattern
+
+| Use Pattern 1 (`patch.object`) when | Use Pattern 2 (`dependency_overrides`) when |
+|---|---|
+| Mocking one or two methods on the service | Replacing the entire service with a fake |
+| Test only exercises a single endpoint | Test exercises multiple endpoints with cross-call state |
+| You want minimal setup and automatic cleanup | You need to control method behavior in a fixture |
+
+## Why no protocol layer?
+
+A repository `Protocol` would only be useful if a second backend implementation existed. Today the repositories return Beanie `Document` subclasses (`Log`, `Movie`, `User`, `MovieRating`), which carry MongoDB-specific machinery (`PydanticObjectId`, `find_one`, `save`, `Settings`/indexes). A non-Mongo repository couldn't satisfy that contract without dragging Mongo concepts into a different store, so the abstraction wouldn't deliver real flexibility.
+
+If a second backend is added later, the prerequisite is splitting persistence-neutral domain types from the Beanie `Document` models — at that point repository protocols become genuinely load-bearing and can be reintroduced.
+
+## Related Docs
+
+- [Redis Caching](redis-caching.md)
+- [TMDB Service](tmdb-service.md)

--- a/tests/units/controllers/test_auth_controller.py
+++ b/tests/units/controllers/test_auth_controller.py
@@ -10,6 +10,7 @@ from fastapi.testclient import TestClient
 
 from app import app
 from app.dependencies.auth_dependency import auth_dependency
+from app.dependencies.service_dependency import get_auth_service
 from app.schemas.auth_schemas import RegisterResponse
 
 
@@ -21,7 +22,7 @@ def client():
 class TestAuthController:
     """Tests for auth controller endpoints."""
 
-    @patch("app.controllers.auth_controller.auth_service.register", new_callable=AsyncMock)
+    @patch.object(get_auth_service(), "register", new_callable=AsyncMock)
     def test_register_success(self, mock_register, client):
         """Test successful user registration."""
         mock_register.return_value = RegisterResponse(
@@ -54,7 +55,7 @@ class TestAuthController:
         assert data["handle"] == "johndoe"
         mock_register.assert_called_once()
 
-    @patch("app.controllers.auth_controller.auth_service.register", new_callable=AsyncMock)
+    @patch.object(get_auth_service(), "register", new_callable=AsyncMock)
     def test_register_with_exception(self, mock_register, client):
         """Test registration that raises AppException."""
         from app.utils.error_codes_utils import ErrorCodes
@@ -88,10 +89,7 @@ class TestAuthController:
 
         assert response.status_code == 422  # Validation error
 
-    @patch(
-        "app.controllers.auth_controller.auth_service.forgot_password",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_auth_service(), "forgot_password", new_callable=AsyncMock)
     def test_forgot_password_success(self, mock_forgot_password, client):
         """Test successful forgot-password request."""
         response = client.post(
@@ -103,10 +101,7 @@ class TestAuthController:
         assert response.json() == {"message": "If the email exists, a reset code has been sent."}
         mock_forgot_password.assert_awaited_once_with("test@example.com")
 
-    @patch(
-        "app.controllers.auth_controller.auth_service.reset_password",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_auth_service(), "reset_password", new_callable=AsyncMock)
     def test_reset_password_success(self, mock_reset_password, client):
         """Test successful reset-password request."""
         response = client.post(

--- a/tests/units/controllers/test_log_controller.py
+++ b/tests/units/controllers/test_log_controller.py
@@ -7,6 +7,7 @@ from fastapi.testclient import TestClient
 
 from app import app
 from app.dependencies.auth_dependency import auth_dependency
+from app.dependencies.service_dependency import get_log_service
 from app.schemas.log_schemas import (
     LogCreateResponse,
     LogListItem,
@@ -98,7 +99,7 @@ def override_auth():
 class TestCreateLog:
     """Tests for POST /v1/logs endpoint."""
 
-    @patch("app.controllers.log_controller.log_service.create_log", new_callable=AsyncMock)
+    @patch.object(get_log_service(), "create_log", new_callable=AsyncMock)
     def test_create_log_success(
         self,
         mock_create_log,
@@ -164,7 +165,7 @@ class TestCreateLog:
 class TestUpdateLog:
     """Tests for PUT /v1/logs/{log_id} endpoint."""
 
-    @patch("app.controllers.log_controller.log_service.update_log", new_callable=AsyncMock)
+    @patch.object(get_log_service(), "update_log", new_callable=AsyncMock)
     def test_update_log_success(self, mock_update_log, client, sample_log_response, override_auth):
         """Test successful log update."""
         app.dependency_overrides[auth_dependency] = override_auth
@@ -204,7 +205,7 @@ class TestUpdateLog:
 class TestDeleteLog:
     """Tests for DELETE /v1/logs/{log_id} endpoint."""
 
-    @patch("app.controllers.log_controller.log_service.delete_log", new_callable=AsyncMock)
+    @patch.object(get_log_service(), "delete_log", new_callable=AsyncMock)
     def test_delete_log_success_returns_204(self, mock_delete_log, client, override_auth):
         """Successful deletion returns 204 No Content with empty body."""
         app.dependency_overrides[auth_dependency] = override_auth
@@ -222,7 +223,7 @@ class TestDeleteLog:
         assert response.content == b""
         mock_delete_log.assert_called_once()
 
-    @patch("app.controllers.log_controller.log_service.delete_log", new_callable=AsyncMock)
+    @patch.object(get_log_service(), "delete_log", new_callable=AsyncMock)
     def test_delete_log_not_found_returns_404(self, mock_delete_log, client, override_auth):
         """Deleting a missing or non-owned log returns 404."""
         app.dependency_overrides[auth_dependency] = override_auth
@@ -254,10 +255,7 @@ class TestDeleteLog:
 class TestGetLogsByHandle:
     """Tests for GET /v1/logs/{handle} endpoint."""
 
-    @patch(
-        "app.controllers.log_controller.log_service.get_user_logs_by_handle",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_log_service(), "get_user_logs_by_handle", new_callable=AsyncMock)
     def test_get_logs_by_handle_success(self, mock_get_logs_by_handle, client, sample_log_list_response, override_auth):
         """Test successful log list retrieval by handle."""
         app.dependency_overrides[auth_dependency] = override_auth
@@ -279,10 +277,7 @@ class TestGetLogsByHandle:
 
         assert response.status_code == 401
 
-    @patch(
-        "app.controllers.log_controller.log_service.get_user_logs_by_handle",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_log_service(), "get_user_logs_by_handle", new_callable=AsyncMock)
     def test_get_logs_by_handle_profile_not_public(self, mock_get_logs_by_handle, client, override_auth):
         """Test log list retrieval for private profile."""
         from app.utils.error_codes_utils import ErrorCodes
@@ -297,10 +292,7 @@ class TestGetLogsByHandle:
 
         assert response.status_code == 403
 
-    @patch(
-        "app.controllers.log_controller.log_service.get_user_logs_by_handle",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_log_service(), "get_user_logs_by_handle", new_callable=AsyncMock)
     def test_get_logs_by_handle_user_not_found(self, mock_get_logs_by_handle, client, override_auth):
         """Test log list retrieval for nonexistent user."""
         from app.utils.error_codes_utils import ErrorCodes

--- a/tests/units/controllers/test_movie_rating_controller.py
+++ b/tests/units/controllers/test_movie_rating_controller.py
@@ -6,6 +6,7 @@ from fastapi.testclient import TestClient
 
 from app import app
 from app.dependencies.auth_dependency import auth_dependency
+from app.dependencies.service_dependency import get_movie_rating_service
 from app.schemas.movie_rating_schemas import MovieRatingResponse
 
 
@@ -23,10 +24,7 @@ def override_auth():
 class TestMovieRatingController:
     """Tests for movie rating controller endpoints."""
 
-    @patch(
-        "app.controllers.movie_rating_controller.movie_rating_service.create_update_movie_rating",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_movie_rating_service(), "create_update_movie_rating", new_callable=AsyncMock)
     def test_create_movie_rating_success(self, mock_create_rating, client, override_auth):
         """Test creating a movie rating."""
         app.dependency_overrides[auth_dependency] = override_auth
@@ -66,10 +64,7 @@ class TestMovieRatingController:
         )
         assert response.status_code == 401
 
-    @patch(
-        "app.controllers.movie_rating_controller.movie_rating_service.get_movie_ratings_by_tmdb_id",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_movie_rating_service(), "get_movie_ratings_by_tmdb_id", new_callable=AsyncMock)
     def test_get_movie_rating_success(self, mock_get_rating, client, override_auth):
         """Test getting a movie rating."""
         app.dependency_overrides[auth_dependency] = override_auth
@@ -93,10 +88,7 @@ class TestMovieRatingController:
         data = response.json()
         assert data["rating"] == 8
 
-    @patch(
-        "app.controllers.movie_rating_controller.movie_rating_service.get_movie_ratings_by_tmdb_id",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_movie_rating_service(), "get_movie_ratings_by_tmdb_id", new_callable=AsyncMock)
     def test_get_movie_rating_not_found(self, mock_get_rating, client, override_auth):
         """Test getting a movie rating that doesn't exist returns 204."""
         app.dependency_overrides[auth_dependency] = override_auth

--- a/tests/units/controllers/test_rate_limiting.py
+++ b/tests/units/controllers/test_rate_limiting.py
@@ -21,6 +21,7 @@ from fastapi.testclient import TestClient
 import app.config.rate_limiter as rate_limiter_module
 from app import app
 from app.dependencies.auth_dependency import auth_dependency
+from app.dependencies.service_dependency import get_auth_service, get_log_service
 from app.schemas.auth_schemas import RegisterResponse
 from app.schemas.log_schemas import LogCreateResponse
 from app.schemas.movie_schemas import MovieResponse
@@ -179,10 +180,7 @@ class TestRegisterRateLimit:
         profile_visibility="private",
     )
 
-    @patch(
-        "app.controllers.auth_controller.auth_service.register",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_auth_service(), "register", new_callable=AsyncMock)
     def test_register_allows_requests_within_limit(self, mock_register, client):
         """First 5 requests should succeed (201) with rate limit headers."""
         mock_register.return_value = self.REGISTER_RESPONSE
@@ -192,10 +190,7 @@ class TestRegisterRateLimit:
             assert response.status_code == 201
             assert_rate_limit_headers(response)
 
-    @patch(
-        "app.controllers.auth_controller.auth_service.register",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_auth_service(), "register", new_callable=AsyncMock)
     def test_register_blocks_request_over_limit(self, mock_register, client):
         """6th request should hit the session-scoped limit."""
         mock_register.return_value = self.REGISTER_RESPONSE
@@ -206,10 +201,7 @@ class TestRegisterRateLimit:
         response = client.post("/v1/auth/register", json=self.REGISTER_PAYLOAD)
         assert_429_response(response)
 
-    @patch(
-        "app.controllers.auth_controller.auth_service.register",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_auth_service(), "register", new_callable=AsyncMock)
     def test_register_session_limit_allows_another_client_on_same_ip(self, mock_register):
         """A second client on the same IP should still be allowed before the IP cap."""
         mock_register.return_value = self.REGISTER_RESPONSE
@@ -239,10 +231,7 @@ class TestRegisterRateLimit:
             first_client.close()
             second_client.close()
 
-    @patch(
-        "app.controllers.auth_controller.auth_service.register",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_auth_service(), "register", new_callable=AsyncMock)
     def test_register_ip_limit_blocks_after_ten_requests_across_clients(self, mock_register):
         """The outer IP gate should block the 11th request across sessions."""
         mock_register.return_value = self.REGISTER_RESPONSE
@@ -299,10 +288,7 @@ class TestLoginRateLimit:
             },
         )()
 
-    @patch(
-        "app.controllers.auth_controller.auth_service.login",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_auth_service(), "login", new_callable=AsyncMock)
     def test_login_allows_requests_within_limit(self, mock_login, client):
         """First 10 requests should succeed (200) with rate limit headers."""
         mock_login.return_value = self._mock_user()
@@ -315,10 +301,7 @@ class TestLoginRateLimit:
             client.cookies.pop("refresh_token", None)
             client.cookies.pop("__Host-csrf_token", None)
 
-    @patch(
-        "app.controllers.auth_controller.auth_service.login",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_auth_service(), "login", new_callable=AsyncMock)
     def test_login_blocks_request_over_limit(self, mock_login, client):
         """11th request should hit the session-scoped login limiter."""
         mock_login.return_value = self._mock_user()
@@ -332,10 +315,7 @@ class TestLoginRateLimit:
         response = client.post("/v1/auth/login", json=self.LOGIN_PAYLOAD)
         assert_custom_429_response(response)
 
-    @patch(
-        "app.controllers.auth_controller.auth_service.login",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_auth_service(), "login", new_callable=AsyncMock)
     def test_login_session_limit_allows_another_client_on_same_ip(self, mock_login):
         """Another anonymous client should still be allowed before the outer IP cap."""
         mock_login.return_value = self._mock_user()
@@ -368,10 +348,7 @@ class TestLoginRateLimit:
             first_client.close()
             second_client.close()
 
-    @patch(
-        "app.controllers.auth_controller.auth_service.login",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_auth_service(), "login", new_callable=AsyncMock)
     def test_login_ip_limit_blocks_after_thirty_requests_across_clients(self, mock_login):
         """The outer IP gate should block the 31st request across sessions."""
         mock_login.return_value = self._mock_user()
@@ -413,10 +390,7 @@ class TestLoginRateLimit:
             second_client.close()
             third_client.close()
 
-    @patch(
-        "app.controllers.auth_controller.auth_service.login",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_auth_service(), "login", new_callable=AsyncMock)
     def test_login_failed_account_limit_blocks_after_five_invalid_attempts(self, mock_login, client):
         """The email-based account bucket should block the 6th login attempt."""
         from app.utils.error_codes_utils import ErrorCodes
@@ -431,10 +405,7 @@ class TestLoginRateLimit:
         response = client.post("/v1/auth/login", json=self.LOGIN_PAYLOAD)
         assert_custom_429_response(response)
 
-    @patch(
-        "app.controllers.auth_controller.auth_service.login",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_auth_service(), "login", new_callable=AsyncMock)
     def test_login_failed_account_limit_short_circuits_before_auth_service(self, mock_login, client):
         """Once exhausted, the account limiter should block before auth_service.login runs."""
         from app.utils.error_codes_utils import ErrorCodes
@@ -452,10 +423,7 @@ class TestLoginRateLimit:
         assert_custom_429_response(response)
         assert mock_login.await_count == call_count_before_block
 
-    @patch(
-        "app.controllers.auth_controller.auth_service.login",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_auth_service(), "login", new_callable=AsyncMock)
     def test_login_success_clears_the_failure_bucket(self, mock_login, client):
         """Successful login should clear the email-hash failure bucket."""
 
@@ -467,10 +435,7 @@ class TestLoginRateLimit:
         assert response.status_code == 200
         clear_limit.assert_called_once()
 
-    @patch(
-        "app.controllers.auth_controller.auth_service.login",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_auth_service(), "login", new_callable=AsyncMock)
     def test_login_ignores_failure_bucket_cleanup_errors(self, mock_login, client):
         """Successful login should not fail if failure-bucket cleanup raises."""
 
@@ -489,10 +454,7 @@ class TestLoginRateLimit:
         assert response.status_code == 200
         mock_warning.assert_called_once()
 
-    @patch(
-        "app.controllers.auth_controller.auth_service.login",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_auth_service(), "login", new_callable=AsyncMock)
     def test_login_does_not_require_rate_limit_cache_dependency(self, mock_login, client):
         """Login account limiting should not depend on a request-state cache helper."""
         mock_login.return_value = self._mock_user()
@@ -501,10 +463,7 @@ class TestLoginRateLimit:
 
         assert response.status_code == 200
 
-    @patch(
-        "app.controllers.auth_controller.auth_service.login",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_auth_service(), "login", new_callable=AsyncMock)
     def test_login_failure_bucket_hashes_unknown_email(self, mock_login, client):
         """Failed login attempts should use the same hashed email identifier."""
         from app.utils.error_codes_utils import ErrorCodes
@@ -538,10 +497,7 @@ class TestForgotPasswordRateLimit:
 
     FORGOT_PASSWORD_PAYLOAD = {"email": "test@example.com"}
 
-    @patch(
-        "app.controllers.auth_controller.auth_service.forgot_password",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_auth_service(), "forgot_password", new_callable=AsyncMock)
     def test_forgot_password_allows_requests_within_limit(self, mock_forgot_password, client):
         """First 3 requests should succeed (200) with rate limit headers."""
         mock_forgot_password.return_value = None
@@ -554,10 +510,7 @@ class TestForgotPasswordRateLimit:
             assert response.status_code == 200
             assert_rate_limit_headers(response)
 
-    @patch(
-        "app.controllers.auth_controller.auth_service.forgot_password",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_auth_service(), "forgot_password", new_callable=AsyncMock)
     def test_forgot_password_blocks_request_over_limit(self, mock_forgot_password, client):
         """4th request should hit the session/account forgot-password limit."""
         mock_forgot_password.return_value = None
@@ -574,10 +527,7 @@ class TestForgotPasswordRateLimit:
         )
         assert_429_response(response)
 
-    @patch(
-        "app.controllers.auth_controller.auth_service.forgot_password",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_auth_service(), "forgot_password", new_callable=AsyncMock)
     def test_forgot_password_account_limit_blocks_across_clients(self, mock_forgot_password):
         """The hashed-email account bucket should block the 6th cross-client attempt."""
         mock_forgot_password.return_value = None
@@ -600,10 +550,7 @@ class TestForgotPasswordRateLimit:
             for client in clients:
                 client.close()
 
-    @patch(
-        "app.controllers.auth_controller.auth_service.forgot_password",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_auth_service(), "forgot_password", new_callable=AsyncMock)
     def test_forgot_password_ip_limit_blocks_after_six_requests_across_clients(self, mock_forgot_password):
         """The outer IP gate should block after the broader IP window is exhausted."""
         mock_forgot_password.return_value = None
@@ -675,10 +622,7 @@ class TestResetPasswordRateLimit:
         "newPassword": "newsecurepassword123",
     }
 
-    @patch(
-        "app.controllers.auth_controller.auth_service.reset_password",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_auth_service(), "reset_password", new_callable=AsyncMock)
     def test_reset_password_allows_requests_within_limit(self, mock_reset_password, client):
         """First 5 requests should succeed (200) with rate limit headers."""
         mock_reset_password.return_value = True
@@ -691,10 +635,7 @@ class TestResetPasswordRateLimit:
             assert response.status_code == 200
             assert_rate_limit_headers(response)
 
-    @patch(
-        "app.controllers.auth_controller.auth_service.reset_password",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_auth_service(), "reset_password", new_callable=AsyncMock)
     def test_reset_password_blocks_request_over_limit(self, mock_reset_password, client):
         """11th request should hit the session/account reset-password limit."""
         mock_reset_password.return_value = True
@@ -711,10 +652,7 @@ class TestResetPasswordRateLimit:
         )
         assert_429_response(response)
 
-    @patch(
-        "app.controllers.auth_controller.auth_service.reset_password",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_auth_service(), "reset_password", new_callable=AsyncMock)
     def test_reset_password_invalid_code_limit_blocks_on_eleventh_failure(self, mock_reset_password, client):
         """The 11th invalid reset attempt should hit the reset account bucket."""
         from app.utils.error_codes_utils import ErrorCodes
@@ -735,10 +673,7 @@ class TestResetPasswordRateLimit:
         )
         assert_custom_429_response(response)
 
-    @patch(
-        "app.controllers.auth_controller.auth_service.reset_password",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_auth_service(), "reset_password", new_callable=AsyncMock)
     def test_reset_password_account_limit_blocks_on_eleventh_failure_across_clients(self, mock_reset_password):
         """The reset-password account bucket should block the 11th invalid attempt across clients."""
         from app.utils.error_codes_utils import ErrorCodes
@@ -765,10 +700,7 @@ class TestResetPasswordRateLimit:
             for client in clients:
                 client.close()
 
-    @patch(
-        "app.controllers.auth_controller.auth_service.reset_password",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_auth_service(), "reset_password", new_callable=AsyncMock)
     def test_reset_password_account_limit_short_circuits_before_reset_logic(self, mock_reset_password):
         """Once the reset-password account bucket is exhausted, reset logic should not run."""
         from app.utils.error_codes_utils import ErrorCodes
@@ -798,10 +730,7 @@ class TestResetPasswordRateLimit:
             for client in clients:
                 client.close()
 
-    @patch(
-        "app.controllers.auth_controller.auth_service.reset_password",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_auth_service(), "reset_password", new_callable=AsyncMock)
     def test_reset_password_session_limit_blocks_before_account_limit(self, mock_reset_password, client):
         """A single client should hit the session limit before the account bucket is exhausted."""
         mock_reset_password.return_value = True
@@ -819,10 +748,7 @@ class TestResetPasswordRateLimit:
         )
         assert_429_response(response)
 
-    @patch(
-        "app.controllers.auth_controller.auth_service.reset_password",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_auth_service(), "reset_password", new_callable=AsyncMock)
     def test_reset_password_invalid_code_limit_short_circuits_on_eleventh_failure(self, mock_reset_password, client):
         """Once exhausted, the reset account bucket should block before reset logic runs."""
         from app.utils.error_codes_utils import ErrorCodes
@@ -1003,10 +929,7 @@ class TestCreateLogRateLimit:
         "watchedWhere": "cinema",
     }
 
-    @patch(
-        "app.controllers.log_controller.log_service.create_log",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_log_service(), "create_log", new_callable=AsyncMock)
     def test_create_log_allows_requests_within_limit(self, mock_create_log, client, override_auth, sample_log_response):
         """First 20 requests should succeed (201) with rate limit headers."""
         app.dependency_overrides[auth_dependency] = override_auth
@@ -1027,10 +950,7 @@ class TestCreateLogRateLimit:
             client.cookies.clear()
             app.dependency_overrides = {}
 
-    @patch(
-        "app.controllers.log_controller.log_service.create_log",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_log_service(), "create_log", new_callable=AsyncMock)
     def test_create_log_blocks_request_over_limit(self, mock_create_log, client, override_auth, sample_log_response):
         """21st request should be rate-limited (429) with proper headers and body."""
         app.dependency_overrides[auth_dependency] = override_auth
@@ -1065,10 +985,7 @@ class TestUpdateLogRateLimit:
         "watchedWhere": "streaming",
     }
 
-    @patch(
-        "app.controllers.log_controller.log_service.update_log",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_log_service(), "update_log", new_callable=AsyncMock)
     def test_update_log_allows_requests_within_limit(self, mock_update_log, client, override_auth, sample_log_response):
         """First 10 requests should succeed (200) with rate limit headers."""
         app.dependency_overrides[auth_dependency] = override_auth
@@ -1089,10 +1006,7 @@ class TestUpdateLogRateLimit:
             client.cookies.clear()
             app.dependency_overrides = {}
 
-    @patch(
-        "app.controllers.log_controller.log_service.update_log",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_log_service(), "update_log", new_callable=AsyncMock)
     def test_update_log_blocks_request_over_limit(self, mock_update_log, client, override_auth, sample_log_response):
         """11th request should be rate-limited (429) with proper headers and body."""
         app.dependency_overrides[auth_dependency] = override_auth
@@ -1211,10 +1125,7 @@ class TestRateLimitSessionMiddleware:
         self, client, fake_cache_client, rate_limit_cache_service
     ):
         """Should issue and register a new session on a session-tracked auth route."""
-        with patch(
-            "app.controllers.auth_controller.auth_service.forgot_password",
-            new_callable=AsyncMock,
-        ) as mock_forgot_password:
+        with patch.object(get_auth_service(), "forgot_password", new_callable=AsyncMock) as mock_forgot_password:
             mock_forgot_password.return_value = None
             response = client.post(
                 "/v1/auth/forgot-password",
@@ -1233,10 +1144,7 @@ class TestRateLimitSessionMiddleware:
     def test_access_token_cookie_does_not_skip_tracking_on_public_auth_route(self, client, fake_cache_client):
         """A raw access-token cookie must not bypass tracking on public auth routes."""
         client.cookies.set(ACCESS_TOKEN_COOKIE, "some-token")
-        with patch(
-            "app.controllers.auth_controller.auth_service.forgot_password",
-            new_callable=AsyncMock,
-        ) as mock_forgot_password:
+        with patch.object(get_auth_service(), "forgot_password", new_callable=AsyncMock) as mock_forgot_password:
             mock_forgot_password.return_value = None
             response = client.post(
                 "/v1/auth/forgot-password",
@@ -1254,10 +1162,7 @@ class TestRateLimitSessionMiddleware:
         fake_cache_client.values[session_key] = '{"active": true}'
         client.cookies.set(RATE_LIMIT_SESSION_COOKIE, session_id)
 
-        with patch(
-            "app.controllers.auth_controller.auth_service.forgot_password",
-            new_callable=AsyncMock,
-        ) as mock_forgot_password:
+        with patch.object(get_auth_service(), "forgot_password", new_callable=AsyncMock) as mock_forgot_password:
             mock_forgot_password.return_value = None
             response = client.post(
                 "/v1/auth/forgot-password",
@@ -1277,10 +1182,7 @@ class TestRateLimitSessionMiddleware:
     def test_reissues_cookie_when_session_cookie_is_unknown(self, client, fake_cache_client, rate_limit_cache_service):
         """Should replace a client-provided session that is not registered in Redis."""
         client.cookies.set(RATE_LIMIT_SESSION_COOKIE, "unknown-session")
-        with patch(
-            "app.controllers.auth_controller.auth_service.forgot_password",
-            new_callable=AsyncMock,
-        ) as mock_forgot_password:
+        with patch.object(get_auth_service(), "forgot_password", new_callable=AsyncMock) as mock_forgot_password:
             mock_forgot_password.return_value = None
             response = client.post(
                 "/v1/auth/forgot-password",

--- a/tests/units/controllers/test_stats_controller.py
+++ b/tests/units/controllers/test_stats_controller.py
@@ -5,6 +5,7 @@ from fastapi.testclient import TestClient
 
 from app import app
 from app.dependencies.auth_dependency import auth_dependency
+from app.dependencies.service_dependency import get_stats_service
 
 
 @pytest.fixture
@@ -21,10 +22,7 @@ def override_auth():
 class TestStatsController:
     """Tests for stats controller endpoints."""
 
-    @patch(
-        "app.controllers.stats_controller.stats_service.get_user_stats",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_stats_service(), "get_user_stats", new_callable=AsyncMock)
     def test_get_my_stats_success(self, mock_get_stats, client, override_auth):
         """Test successful stats retrieval."""
         app.dependency_overrides[auth_dependency] = override_auth
@@ -62,10 +60,7 @@ class TestStatsController:
         assert data["summary"]["totalWatches"] == 10
         assert data["summary"]["uniqueTitles"] == 8
 
-    @patch(
-        "app.controllers.stats_controller.stats_service.get_user_stats",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_stats_service(), "get_user_stats", new_callable=AsyncMock)
     def test_get_my_stats_with_year_filter(self, mock_get_stats, client, override_auth):
         """Test stats retrieval with year filters."""
         app.dependency_overrides[auth_dependency] = override_auth
@@ -124,10 +119,7 @@ class TestStatsController:
         response = client.get("/v1/stats/me")
         assert response.status_code == 401
 
-    @patch(
-        "app.controllers.stats_controller.stats_service.get_user_stats",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_stats_service(), "get_user_stats", new_callable=AsyncMock)
     def test_get_my_stats_not_implemented(self, mock_get_stats, client, override_auth):
         """Test stats returns 501 when NotImplementedError is raised."""
         app.dependency_overrides[auth_dependency] = override_auth
@@ -140,10 +132,7 @@ class TestStatsController:
         assert response.status_code == 501
         assert "Stats endpoint not implemented yet" in response.json()["detail"]
 
-    @patch(
-        "app.controllers.stats_controller.stats_service.get_user_stats",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_stats_service(), "get_user_stats", new_callable=AsyncMock)
     def test_get_my_stats_app_exception(self, mock_get_stats, client, override_auth):
         """Test stats re-raises AppException."""
         from app.utils.error_codes_utils import ErrorCodes

--- a/tests/units/controllers/test_user_controller.py
+++ b/tests/units/controllers/test_user_controller.py
@@ -6,6 +6,7 @@ from fastapi.testclient import TestClient
 
 from app import app
 from app.dependencies.auth_dependency import auth_dependency
+from app.dependencies.service_dependency import get_user_service
 from app.schemas.user_schemas import (
     ChangePasswordResponse,
     UserProfileResponse,
@@ -26,10 +27,7 @@ def override_auth():
 
 
 class TestUserController:
-    @patch(
-        "app.controllers.user_controller.user_service.get_user_info",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_user_service(), "get_user_info", new_callable=AsyncMock)
     def test_get_user_info_success(self, mock_get_user_info, client, override_auth):
         app.dependency_overrides[auth_dependency] = override_auth
 
@@ -59,10 +57,7 @@ class TestUserController:
         response = client.get("/v1/users/info")
         assert response.status_code == 401
 
-    @patch(
-        "app.controllers.user_controller.user_service.get_user_info",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_user_service(), "get_user_info", new_callable=AsyncMock)
     def test_get_user_info_not_found(self, mock_get_user_info, client, override_auth):
         app.dependency_overrides[auth_dependency] = override_auth
         mock_get_user_info.side_effect = AppException(ErrorCodes.USER_NOT_FOUND)
@@ -75,10 +70,7 @@ class TestUserController:
 
 
 class TestGetVisibleProfile:
-    @patch(
-        "app.controllers.user_controller.user_service.get_visible_profile",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_user_service(), "get_visible_profile", new_callable=AsyncMock)
     def test_get_visible_profile_success(self, mock_get_visible_profile, client, override_auth):
         app.dependency_overrides[auth_dependency] = override_auth
 
@@ -110,10 +102,7 @@ class TestGetVisibleProfile:
         response = client.get("/v1/users/johndoe/profile")
         assert response.status_code == 401
 
-    @patch(
-        "app.controllers.user_controller.user_service.get_visible_profile",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_user_service(), "get_visible_profile", new_callable=AsyncMock)
     def test_get_visible_profile_not_found(self, mock_get_visible_profile, client, override_auth):
         app.dependency_overrides[auth_dependency] = override_auth
         mock_get_visible_profile.side_effect = AppException(ErrorCodes.USER_NOT_FOUND)
@@ -129,10 +118,7 @@ class TestGetVisibleProfile:
 
 
 class TestUpdateProfileController:
-    @patch(
-        "app.controllers.user_controller.user_service.update_profile",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_user_service(), "update_profile", new_callable=AsyncMock)
     def test_update_profile_success(self, mock_update_profile, client, override_auth):
         app.dependency_overrides[auth_dependency] = override_auth
 
@@ -165,10 +151,7 @@ class TestUpdateProfileController:
         assert data["bio"] == "New bio"
         mock_update_profile.assert_awaited_once()
 
-    @patch(
-        "app.controllers.user_controller.user_service.update_profile",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_user_service(), "update_profile", new_callable=AsyncMock)
     def test_update_profile_with_visibility(self, mock_update_profile, client, override_auth):
         app.dependency_overrides[auth_dependency] = override_auth
 
@@ -209,10 +192,7 @@ class TestUpdateProfileController:
         )
         assert response.status_code == 401
 
-    @patch(
-        "app.controllers.user_controller.user_service.update_profile",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_user_service(), "update_profile", new_callable=AsyncMock)
     def test_update_profile_user_not_found(self, mock_update_profile, client, override_auth):
         app.dependency_overrides[auth_dependency] = override_auth
         mock_update_profile.side_effect = AppException(ErrorCodes.USER_NOT_FOUND)
@@ -231,10 +211,7 @@ class TestUpdateProfileController:
 
         assert response.status_code == 404
 
-    @patch(
-        "app.controllers.user_controller.user_service.update_profile",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_user_service(), "update_profile", new_callable=AsyncMock)
     def test_update_profile_invalid_name(self, mock_update_profile, client, override_auth):
         app.dependency_overrides[auth_dependency] = override_auth
 
@@ -252,10 +229,7 @@ class TestUpdateProfileController:
 
         assert response.status_code == 422
 
-    @patch(
-        "app.controllers.user_controller.user_service.update_profile",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_user_service(), "update_profile", new_callable=AsyncMock)
     def test_update_profile_invalid_visibility(self, mock_update_profile, client, override_auth):
         app.dependency_overrides[auth_dependency] = override_auth
 
@@ -275,10 +249,7 @@ class TestUpdateProfileController:
 
 
 class TestChangePasswordController:
-    @patch(
-        "app.controllers.user_controller.user_service.change_password",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_user_service(), "change_password", new_callable=AsyncMock)
     def test_change_password_success(self, mock_change_password, client, override_auth):
         app.dependency_overrides[auth_dependency] = override_auth
 
@@ -314,10 +285,7 @@ class TestChangePasswordController:
         )
         assert response.status_code == 401
 
-    @patch(
-        "app.controllers.user_controller.user_service.change_password",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_user_service(), "change_password", new_callable=AsyncMock)
     def test_change_password_invalid_current(self, mock_change_password, client, override_auth):
         app.dependency_overrides[auth_dependency] = override_auth
         mock_change_password.side_effect = AppException(ErrorCodes.INVALID_CURRENT_PASSWORD)
@@ -336,10 +304,7 @@ class TestChangePasswordController:
 
         assert response.status_code == 401
 
-    @patch(
-        "app.controllers.user_controller.user_service.change_password",
-        new_callable=AsyncMock,
-    )
+    @patch.object(get_user_service(), "change_password", new_callable=AsyncMock)
     def test_change_password_same_password(self, mock_change_password, client, override_auth):
         app.dependency_overrides[auth_dependency] = override_auth
         mock_change_password.side_effect = AppException(ErrorCodes.SAME_PASSWORD)

--- a/tests/units/repository/test_log_cache_repository.py
+++ b/tests/units/repository/test_log_cache_repository.py
@@ -6,8 +6,8 @@ from beanie import PydanticObjectId
 
 from app.models.log import Log
 from app.repository.log_cache_repository import LOG_CACHE_TTL, LogCacheRepository
-from app.repository.log_repository import LogRepository
 from app.schemas.log_schemas import LogCreateRequest, LogUpdateRequest
+from app.schemas.stats_schemas import LogStats
 
 
 def _sample_log(
@@ -34,10 +34,23 @@ def _mock_cache() -> MagicMock:
     return cache
 
 
+def _mock_log_repository() -> MagicMock:
+    repository = MagicMock()
+    repository.create_log = AsyncMock()
+    repository.find_log_by_id = AsyncMock()
+    repository.update_log = AsyncMock()
+    repository.find_logs_by_user_id = AsyncMock()
+    repository.find_logs_by_movie_id = AsyncMock()
+    repository.delete_log = AsyncMock()
+    repository.get_log_stats = AsyncMock()
+    return repository
+
+
 def test_build_user_logs_key_includes_filters():
     user_id = PydanticObjectId()
+    repository = LogCacheRepository(_mock_log_repository())
 
-    key = LogCacheRepository.build_user_logs_key(
+    key = repository.build_user_logs_key(
         user_id=user_id,
         watched_where="cinema",
         date_watched_from=date(2024, 1, 1),
@@ -53,37 +66,34 @@ def test_build_user_logs_key_includes_filters():
 async def test_find_log_by_id_cache_hit_skips_repository(beanie_test_db):
     log = _sample_log()
     cache = _mock_cache()
-    cache.get.return_value = LogCacheRepository._serialize_log(log)
+    inner_repository = _mock_log_repository()
+    repository = LogCacheRepository(inner_repository)
+    cache.get.return_value = repository._serialize_log(log)
 
-    with (
-        patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache),
-        patch.object(LogRepository, "find_log_by_id", AsyncMock()) as find_log_by_id,
-    ):
-        repository = LogCacheRepository()
+    with patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache):
         result = await repository.find_log_by_id(str(log.id), log.user_id)
 
     assert result is not None
     assert result.id == log.id
-    find_log_by_id.assert_not_awaited()
-    cache.get.assert_awaited_once_with(LogCacheRepository.build_log_key(str(log.id), log.user_id))
+    inner_repository.find_log_by_id.assert_not_awaited()
+    cache.get.assert_awaited_once_with(repository.build_log_key(str(log.id), log.user_id))
 
 
 @pytest.mark.asyncio
 async def test_find_log_by_id_cache_miss_queries_repository_and_sets_cache(beanie_test_db):
     log = _sample_log()
     cache = _mock_cache()
+    inner_repository = _mock_log_repository()
+    inner_repository.find_log_by_id.return_value = log
+    repository = LogCacheRepository(inner_repository)
 
-    with (
-        patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache),
-        patch.object(LogRepository, "find_log_by_id", AsyncMock(return_value=log)) as find_log_by_id,
-    ):
-        repository = LogCacheRepository()
+    with patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache):
         result = await repository.find_log_by_id(str(log.id), log.user_id)
 
-    expected_key = LogCacheRepository.build_log_key(str(log.id), log.user_id)
+    expected_key = repository.build_log_key(str(log.id), log.user_id)
     assert result == log
-    find_log_by_id.assert_awaited_once_with(str(log.id), log.user_id)
-    cache.set.assert_awaited_once_with(expected_key, LogCacheRepository._serialize_log(log), ttl=LOG_CACHE_TTL)
+    inner_repository.find_log_by_id.assert_awaited_once_with(str(log.id), log.user_id)
+    cache.set.assert_awaited_once_with(expected_key, repository._serialize_log(log), ttl=LOG_CACHE_TTL)
 
 
 @pytest.mark.asyncio
@@ -91,12 +101,11 @@ async def test_find_logs_by_user_id_cache_miss_uses_filter_specific_key(beanie_t
     user_id = PydanticObjectId()
     log = _sample_log(user_id=user_id)
     cache = _mock_cache()
+    inner_repository = _mock_log_repository()
+    inner_repository.find_logs_by_user_id.return_value = [log]
+    repository = LogCacheRepository(inner_repository)
 
-    with (
-        patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache),
-        patch.object(LogRepository, "find_logs_by_user_id", AsyncMock(return_value=[log])) as find_logs_by_user_id,
-    ):
-        repository = LogCacheRepository()
+    with patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache):
         result = await repository.find_logs_by_user_id(
             user_id=user_id,
             watched_where="streaming",
@@ -106,7 +115,7 @@ async def test_find_logs_by_user_id_cache_miss_uses_filter_specific_key(beanie_t
             sort_order="desc",
         )
 
-    expected_key = LogCacheRepository.build_user_logs_key(
+    expected_key = repository.build_user_logs_key(
         user_id=user_id,
         watched_where="streaming",
         date_watched_from=date(2024, 1, 1),
@@ -115,7 +124,7 @@ async def test_find_logs_by_user_id_cache_miss_uses_filter_specific_key(beanie_t
         sort_order="desc",
     )
     assert result == [log]
-    find_logs_by_user_id.assert_awaited_once_with(
+    inner_repository.find_logs_by_user_id.assert_awaited_once_with(
         user_id=user_id,
         watched_where="streaming",
         date_watched_from=date(2024, 1, 1),
@@ -123,7 +132,7 @@ async def test_find_logs_by_user_id_cache_miss_uses_filter_specific_key(beanie_t
         sort_by="dateWatched",
         sort_order="desc",
     )
-    cache.set.assert_awaited_once_with(expected_key, LogCacheRepository._serialize_logs([log]), ttl=LOG_CACHE_TTL)
+    cache.set.assert_awaited_once_with(expected_key, repository._serialize_logs([log]), ttl=LOG_CACHE_TTL)
 
 
 @pytest.mark.asyncio
@@ -131,56 +140,51 @@ async def test_find_logs_by_user_id_cache_hit_skips_repository(beanie_test_db):
     user_id = PydanticObjectId()
     log = _sample_log(user_id=user_id)
     cache = _mock_cache()
-    cache.get.return_value = LogCacheRepository._serialize_logs([log])
+    inner_repository = _mock_log_repository()
+    repository = LogCacheRepository(inner_repository)
+    cache.get.return_value = repository._serialize_logs([log])
 
-    with (
-        patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache),
-        patch.object(LogRepository, "find_logs_by_user_id", AsyncMock()) as find_logs_by_user_id,
-    ):
-        repository = LogCacheRepository()
+    with patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache):
         result = await repository.find_logs_by_user_id(user_id=user_id)
 
     assert len(result) == 1
     assert result[0].id == log.id
-    find_logs_by_user_id.assert_not_awaited()
-    cache.get.assert_awaited_once_with(LogCacheRepository.build_user_logs_key(user_id=user_id))
+    inner_repository.find_logs_by_user_id.assert_not_awaited()
+    cache.get.assert_awaited_once_with(repository.build_user_logs_key(user_id=user_id))
 
 
 @pytest.mark.asyncio
 async def test_find_logs_by_movie_id_cache_hit_skips_repository(beanie_test_db):
     log = _sample_log()
     cache = _mock_cache()
-    cache.get.return_value = LogCacheRepository._serialize_logs([log])
+    inner_repository = _mock_log_repository()
+    repository = LogCacheRepository(inner_repository)
+    cache.get.return_value = repository._serialize_logs([log])
 
-    with (
-        patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache),
-        patch.object(LogRepository, "find_logs_by_movie_id", AsyncMock()) as find_logs_by_movie_id,
-    ):
-        repository = LogCacheRepository()
+    with patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache):
         result = await repository.find_logs_by_movie_id(str(log.movie_id), log.user_id)
 
     assert len(result) == 1
     assert result[0].id == log.id
-    find_logs_by_movie_id.assert_not_awaited()
-    cache.get.assert_awaited_once_with(LogCacheRepository.build_movie_logs_key(str(log.movie_id), log.user_id))
+    inner_repository.find_logs_by_movie_id.assert_not_awaited()
+    cache.get.assert_awaited_once_with(repository.build_movie_logs_key(str(log.movie_id), log.user_id))
 
 
 @pytest.mark.asyncio
 async def test_find_logs_by_movie_id_cache_miss_queries_repository_and_sets_cache(beanie_test_db):
     log = _sample_log()
     cache = _mock_cache()
+    inner_repository = _mock_log_repository()
+    inner_repository.find_logs_by_movie_id.return_value = [log]
+    repository = LogCacheRepository(inner_repository)
 
-    with (
-        patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache),
-        patch.object(LogRepository, "find_logs_by_movie_id", AsyncMock(return_value=[log])) as find_logs_by_movie_id,
-    ):
-        repository = LogCacheRepository()
+    with patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache):
         result = await repository.find_logs_by_movie_id(str(log.movie_id), log.user_id)
 
-    expected_key = LogCacheRepository.build_movie_logs_key(str(log.movie_id), log.user_id)
+    expected_key = repository.build_movie_logs_key(str(log.movie_id), log.user_id)
     assert result == [log]
-    find_logs_by_movie_id.assert_awaited_once_with(str(log.movie_id), log.user_id)
-    cache.set.assert_awaited_once_with(expected_key, LogCacheRepository._serialize_logs([log]), ttl=LOG_CACHE_TTL)
+    inner_repository.find_logs_by_movie_id.assert_awaited_once_with(str(log.movie_id), log.user_id)
+    cache.set.assert_awaited_once_with(expected_key, repository._serialize_logs([log]), ttl=LOG_CACHE_TTL)
 
 
 @pytest.mark.asyncio
@@ -189,28 +193,27 @@ async def test_cache_get_and_set_failures_fall_back_to_repository(beanie_test_db
     cache = _mock_cache()
     cache.get.side_effect = RuntimeError("redis down")
     cache.set.side_effect = RuntimeError("redis down")
+    inner_repository = _mock_log_repository()
+    inner_repository.find_log_by_id.return_value = log
+    repository = LogCacheRepository(inner_repository)
 
-    with (
-        patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache),
-        patch.object(LogRepository, "find_log_by_id", AsyncMock(return_value=log)) as find_log_by_id,
-    ):
-        repository = LogCacheRepository()
+    with patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache):
         result = await repository.find_log_by_id(str(log.id), log.user_id)
 
+    expected_key = repository.build_log_key(str(log.id), log.user_id)
     assert result == log
-    cache.get.assert_awaited_once_with(LogCacheRepository.build_log_key(str(log.id), log.user_id))
-    cache.set.assert_awaited_once_with(
-        LogCacheRepository.build_log_key(str(log.id), log.user_id),
-        LogCacheRepository._serialize_log(log),
-        ttl=LOG_CACHE_TTL,
-    )
-    find_log_by_id.assert_awaited_once_with(str(log.id), log.user_id)
+    cache.get.assert_awaited_once_with(expected_key)
+    cache.set.assert_awaited_once_with(expected_key, repository._serialize_log(log), ttl=LOG_CACHE_TTL)
+    inner_repository.find_log_by_id.assert_awaited_once_with(str(log.id), log.user_id)
 
 
 @pytest.mark.asyncio
 async def test_create_log_invalidates_user_and_movie_lists(beanie_test_db):
     log = _sample_log()
     cache = _mock_cache()
+    inner_repository = _mock_log_repository()
+    inner_repository.create_log.return_value = log
+    repository = LogCacheRepository(inner_repository)
     request = LogCreateRequest(
         movie_id=str(log.movie_id),
         tmdb_id=log.tmdb_id,
@@ -218,18 +221,14 @@ async def test_create_log_invalidates_user_and_movie_lists(beanie_test_db):
         watched_where=log.watched_where,
     )
 
-    with (
-        patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache),
-        patch.object(LogRepository, "create_log", AsyncMock(return_value=log)),
-    ):
-        repository = LogCacheRepository()
+    with patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache):
         result = await repository.create_log(log.user_id, request)
 
     assert result == log
     cache.invalidate_pattern.assert_has_awaits(
         [
-            call(LogCacheRepository.build_user_logs_pattern(log.user_id)),
-            call(LogCacheRepository.build_movie_logs_pattern(log.movie_id)),
+            call(repository.build_user_logs_pattern(log.user_id)),
+            call(repository.build_movie_logs_pattern(log.movie_id)),
         ]
     )
     assert cache.invalidate_pattern.await_count == 2
@@ -239,21 +238,20 @@ async def test_create_log_invalidates_user_and_movie_lists(beanie_test_db):
 async def test_update_log_invalidates_id_user_and_movie_cache(beanie_test_db):
     log = _sample_log()
     cache = _mock_cache()
+    inner_repository = _mock_log_repository()
+    inner_repository.update_log.return_value = log
+    repository = LogCacheRepository(inner_repository)
     request = LogUpdateRequest(viewing_notes="Updated")
 
-    with (
-        patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache),
-        patch.object(LogRepository, "update_log", AsyncMock(return_value=log)),
-    ):
-        repository = LogCacheRepository()
+    with patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache):
         result = await repository.update_log(str(log.id), log.user_id, request)
 
     assert result == log
-    cache.delete.assert_awaited_once_with(LogCacheRepository.build_log_key(str(log.id), log.user_id))
+    cache.delete.assert_awaited_once_with(repository.build_log_key(str(log.id), log.user_id))
     cache.invalidate_pattern.assert_has_awaits(
         [
-            call(LogCacheRepository.build_user_logs_pattern(log.user_id)),
-            call(LogCacheRepository.build_movie_logs_pattern(log.movie_id)),
+            call(repository.build_user_logs_pattern(log.user_id)),
+            call(repository.build_movie_logs_pattern(log.movie_id)),
         ]
     )
     assert cache.invalidate_pattern.await_count == 2
@@ -264,39 +262,38 @@ async def test_update_log_uses_database_lookup_without_reading_cache(beanie_test
     log = _sample_log()
     await log.insert()
     cache = _mock_cache()
-    cache.get.return_value = LogCacheRepository._serialize_log(log)
+    repository = LogCacheRepository()
+    cache.get.return_value = repository._serialize_log(log)
     request = LogUpdateRequest(viewing_notes="Updated from DB")
 
     with patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache):
-        repository = LogCacheRepository()
         result = await repository.update_log(str(log.id), log.user_id, request)
 
     assert result is not None
     assert result.viewing_notes == "Updated from DB"
     cache.get.assert_not_awaited()
-    cache.delete.assert_awaited_once_with(LogCacheRepository.build_log_key(str(log.id), log.user_id))
+    cache.delete.assert_awaited_once_with(repository.build_log_key(str(log.id), log.user_id))
 
 
 @pytest.mark.asyncio
 async def test_delete_log_invalidates_only_after_successful_delete(beanie_test_db):
     log = _sample_log()
     cache = _mock_cache()
+    inner_repository = _mock_log_repository()
+    inner_repository.delete_log.return_value = log
+    repository = LogCacheRepository(inner_repository)
 
-    with (
-        patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache),
-        patch.object(LogRepository, "find_log_by_id", AsyncMock(return_value=log)),
-        patch.object(LogRepository, "_delete_log", AsyncMock(return_value=True)) as delete_log,
-    ):
-        repository = LogCacheRepository()
+    with patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache):
         result = await repository.delete_log(str(log.id), log.user_id)
 
-    assert result is True
-    delete_log.assert_awaited_once_with(log)
-    cache.delete.assert_awaited_once_with(LogCacheRepository.build_log_key(str(log.id), log.user_id))
+    assert result == log
+    inner_repository.find_log_by_id.assert_not_awaited()
+    inner_repository.delete_log.assert_awaited_once_with(str(log.id), log.user_id)
+    cache.delete.assert_awaited_once_with(repository.build_log_key(str(log.id), log.user_id))
     cache.invalidate_pattern.assert_has_awaits(
         [
-            call(LogCacheRepository.build_user_logs_pattern(log.user_id)),
-            call(LogCacheRepository.build_movie_logs_pattern(log.movie_id)),
+            call(repository.build_user_logs_pattern(log.user_id)),
+            call(repository.build_movie_logs_pattern(log.movie_id)),
         ]
     )
     assert cache.invalidate_pattern.await_count == 2
@@ -307,54 +304,52 @@ async def test_delete_log_uses_database_lookup_without_reading_cache(beanie_test
     log = _sample_log()
     await log.insert()
     cache = _mock_cache()
-    cache.get.return_value = LogCacheRepository._serialize_log(log)
+    repository = LogCacheRepository()
+    cache.get.return_value = repository._serialize_log(log)
 
     with patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache):
-        repository = LogCacheRepository()
         result = await repository.delete_log(str(log.id), log.user_id)
 
-    assert result is True
+    assert result is not None
     assert await Log.get(log.id) is None
     cache.get.assert_not_awaited()
-    cache.delete.assert_awaited_once_with(LogCacheRepository.build_log_key(str(log.id), log.user_id))
+    cache.delete.assert_awaited_once_with(repository.build_log_key(str(log.id), log.user_id))
 
 
 @pytest.mark.asyncio
-async def test_delete_log_not_found_skips_delete_and_invalidation(beanie_test_db):
+async def test_delete_log_not_found_skips_invalidation(beanie_test_db):
     user_id = PydanticObjectId()
+    log_id = str(PydanticObjectId())
     cache = _mock_cache()
+    inner_repository = _mock_log_repository()
+    inner_repository.delete_log.return_value = None
+    repository = LogCacheRepository(inner_repository)
 
-    with (
-        patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache),
-        patch.object(LogRepository, "find_log_by_id", AsyncMock(return_value=None)),
-        patch.object(LogRepository, "_delete_log", AsyncMock()) as delete_log,
-    ):
-        repository = LogCacheRepository()
-        result = await repository.delete_log(str(PydanticObjectId()), user_id)
+    with patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache):
+        result = await repository.delete_log(log_id, user_id)
 
-    assert result is False
-    delete_log.assert_not_awaited()
+    assert result is None
+    inner_repository.delete_log.assert_awaited_once_with(log_id, user_id)
     cache.delete.assert_not_awaited()
     cache.invalidate_pattern.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_delete_log_does_not_invalidate_when_delete_fails(beanie_test_db):
-    log = _sample_log()
-    cache = _mock_cache()
+async def test_get_log_stats_delegates_to_inner_repository(beanie_test_db):
+    user_id = PydanticObjectId()
+    stats = LogStats()
+    inner_repository = _mock_log_repository()
+    inner_repository.get_log_stats.return_value = stats
+    repository = LogCacheRepository(inner_repository)
 
-    with (
-        patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache),
-        patch.object(LogRepository, "find_log_by_id", AsyncMock(return_value=log)),
-        patch.object(LogRepository, "_delete_log", AsyncMock(return_value=False)) as delete_log,
-    ):
-        repository = LogCacheRepository()
-        result = await repository.delete_log(str(log.id), log.user_id)
+    result = await repository.get_log_stats(user_id, date_from=date(2024, 1, 1), date_to=date(2024, 12, 31))
 
-    assert result is False
-    delete_log.assert_awaited_once_with(log)
-    cache.delete.assert_not_awaited()
-    cache.invalidate_pattern.assert_not_awaited()
+    assert result == stats
+    inner_repository.get_log_stats.assert_awaited_once_with(
+        user_id,
+        date_from=date(2024, 1, 1),
+        date_to=date(2024, 12, 31),
+    )
 
 
 @pytest.mark.asyncio
@@ -362,6 +357,9 @@ async def test_invalidation_failure_does_not_raise(beanie_test_db):
     log = _sample_log()
     cache = _mock_cache()
     cache.invalidate_pattern.side_effect = RuntimeError("redis down")
+    inner_repository = _mock_log_repository()
+    inner_repository.create_log.return_value = log
+    repository = LogCacheRepository(inner_repository)
     request = LogCreateRequest(
         movie_id=str(log.movie_id),
         tmdb_id=log.tmdb_id,
@@ -369,18 +367,14 @@ async def test_invalidation_failure_does_not_raise(beanie_test_db):
         watched_where=log.watched_where,
     )
 
-    with (
-        patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache),
-        patch.object(LogRepository, "create_log", AsyncMock(return_value=log)),
-    ):
-        repository = LogCacheRepository()
+    with patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache):
         result = await repository.create_log(log.user_id, request)
 
     assert result == log
     cache.invalidate_pattern.assert_has_awaits(
         [
-            call(LogCacheRepository.build_user_logs_pattern(log.user_id)),
-            call(LogCacheRepository.build_movie_logs_pattern(log.movie_id)),
+            call(repository.build_user_logs_pattern(log.user_id)),
+            call(repository.build_movie_logs_pattern(log.movie_id)),
         ]
     )
     assert cache.invalidate_pattern.await_count == 2

--- a/tests/units/repository/test_log_repository.py
+++ b/tests/units/repository/test_log_repository.py
@@ -325,13 +325,13 @@ async def test_update_log_success(
 async def test_delete_log_not_found(beanie_test_db, log_repository: LogRepository, user_id: PydanticObjectId):
     non_existent_id = str(ObjectId())
     result = await log_repository.delete_log(non_existent_id, user_id)
-    assert result is False
+    assert result is None
 
 
 @pytest.mark.asyncio
 async def test_delete_log_invalid_object_id(beanie_test_db, log_repository: LogRepository, user_id: PydanticObjectId):
     result = await log_repository.delete_log("invalid-log-id", user_id)
-    assert result is False
+    assert result is None
 
 
 @pytest.mark.asyncio
@@ -344,7 +344,8 @@ async def test_delete_log_success(
 ):
     log = await log_repository.create_log(user_id, movie_create_request)
     result = await log_repository.delete_log(str(log.id), user_id)
-    assert result is True
+    assert result is not None
+    assert result.id == log.id
     deleted_log = await Log.get(log.id)
     assert deleted_log is None
 

--- a/tests/units/services/test_log_service.py
+++ b/tests/units/services/test_log_service.py
@@ -1,5 +1,5 @@
 from datetime import date
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
 from beanie import PydanticObjectId
@@ -261,7 +261,7 @@ class TestLogService:
     async def test_delete_log_success(self, log_service, mock_log_repository, mock_stats_cache_service):
         """Test successful log deletion invalidates the stats cache."""
         user_id = PydanticObjectId()
-        mock_log_repository.delete_log.return_value = True
+        mock_log_repository.delete_log.return_value = MagicMock()
 
         await log_service.delete_log(user_id=user_id, log_id="log123")
 
@@ -272,7 +272,7 @@ class TestLogService:
     async def test_delete_log_not_found_raises(self, log_service, mock_log_repository, mock_stats_cache_service):
         """Test deleting a missing log raises LOG_NOT_FOUND and does not invalidate cache."""
         user_id = PydanticObjectId()
-        mock_log_repository.delete_log.return_value = False
+        mock_log_repository.delete_log.return_value = None
 
         with pytest.raises(AppException) as exc_info:
             await log_service.delete_log(user_id=user_id, log_id="nonexistent")


### PR DESCRIPTION
## Summary

Service-level dependency injection for the API layer — controllers depend on services through FastAPI `Depends(...)`; services own/instantiate their repositories directly. No protocol layer, no `MongoDB` prefix.

This PR walks back the protocol/repo-DI ceremony from earlier commits after concluding it was premature: the protocols returned Beanie `Document` subclasses, so they didn't actually abstract storage. A future second backend will require splitting domain models from Beanie documents first; protocols can be reintroduced at that point.

## Changes

- **Repositories** (`app/repository/`): reverted `MongoDB{X}Repository` → `{X}Repository` renames; deleted the four `*_repository_protocol.py` files.
- **`LogCacheRepository`**: kept as a composition-based decorator over `LogRepository` (the genuine win salvaged from the earlier design).
- **Service providers** (`app/dependencies/service_dependency.py`): each `@lru_cache`-d `get_*_service()` provider now constructs its repositories directly. Cache decorator wired at the dependency layer, not inside `LogService`.
- **Controllers**: removed module-level service singletons (`log_service = get_log_service()` etc.); endpoints depend on services purely via `Depends(get_*_service)`. Unlocks `app.dependency_overrides[get_*_service]` test pattern.
- **Removed**: `app/dependencies/repository_dependency.py` (the `build_*_repository()` indirection) and its test file.
- **Tests**: migrated 60+ controller-test patches from string-path style (`patch("app.controllers.X.X_service.method")`) to instance style (`patch.object(get_X_service(), "method")`). Same target instance because `@lru_cache` returns the same singleton.
- **Docs**: replaced `repository-dependencies.md` with `service-dependencies.md`; updated `ARCHITECTURE.md`, `redis-caching.md`, `tmdb-service.md`, and the docs index.

Closes #149. Supersedes #150.

## Verification

- `make lint` ✓
- `make typecheck` ✓
- `make test-unit` — 416 passing
- `make test-e2e` — 73 passing