### PR TITLE
Normalize log repository ID typing to PydanticObjectId

### DIFF
--- a/app/controllers/log_controller.py
+++ b/app/controllers/log_controller.py
@@ -38,7 +38,7 @@ async def create_log(
 async def update_log(
     request: Request,
     response: Response,
-    log_id: str,
+    log_id: PydanticObjectId,
     request_body: LogUpdateRequest,
     user_id: PydanticObjectId = Depends(auth_dependency),
     log_service: LogService = Depends(get_log_service),
@@ -61,7 +61,7 @@ async def update_log(
 async def delete_log(
     request: Request,
     response: Response,
-    log_id: str,
+    log_id: PydanticObjectId,
     user_id: PydanticObjectId = Depends(auth_dependency),
     log_service: LogService = Depends(get_log_service),
 ) -> None:

--- a/app/repository/log_cache_repository.py
+++ b/app/repository/log_cache_repository.py
@@ -26,7 +26,7 @@ class LogCacheRepository:
     def _cache(self) -> CacheService:
         return CacheService.get_instance()
 
-    def build_log_key(self, log_id: str, user_id: PydanticObjectId) -> str:
+    def build_log_key(self, log_id: PydanticObjectId, user_id: PydanticObjectId) -> str:
         return f"cinelog:logs:id:{user_id}:{log_id}"
 
     def build_user_logs_key(
@@ -46,14 +46,18 @@ class LogCacheRepository:
             f"from:{from_part}:to:{to_part}:sort:{sort_by}:{sort_order}"
         )
 
-    def build_movie_logs_key(self, movie_id: str, user_id: PydanticObjectId | None = None) -> str:
+    def build_movie_logs_key(
+        self,
+        movie_id: PydanticObjectId,
+        user_id: PydanticObjectId | None = None,
+    ) -> str:
         user_part = str(user_id) if user_id is not None else "all"
         return f"cinelog:logs:movie:{movie_id}:user:{user_part}"
 
     def build_user_logs_pattern(self, user_id: PydanticObjectId) -> str:
         return f"cinelog:logs:user:{user_id}:*"
 
-    def build_movie_logs_pattern(self, movie_id: PydanticObjectId | str) -> str:
+    def build_movie_logs_pattern(self, movie_id: PydanticObjectId) -> str:
         return f"cinelog:logs:movie:{movie_id}:*"
 
     def _serialize_log(self, log: Log) -> dict[str, Any]:
@@ -129,11 +133,11 @@ class LogCacheRepository:
     async def _invalidate_user_logs(self, user_id: PydanticObjectId) -> None:
         await self._invalidate_pattern(self.build_user_logs_pattern(user_id))
 
-    async def _invalidate_movie_logs(self, movie_id: PydanticObjectId | str) -> None:
+    async def _invalidate_movie_logs(self, movie_id: PydanticObjectId) -> None:
         await self._invalidate_pattern(self.build_movie_logs_pattern(movie_id))
 
     async def _invalidate_log(self, log: Log) -> None:
-        await self._delete_key(self.build_log_key(str(log.id), log.user_id))
+        await self._delete_key(self.build_log_key(log.id, log.user_id))
         await self._invalidate_user_logs(log.user_id)
         await self._invalidate_movie_logs(log.movie_id)
 
@@ -143,7 +147,7 @@ class LogCacheRepository:
         await self._invalidate_movie_logs(log.movie_id)
         return log
 
-    async def find_log_by_id(self, log_id: str, user_id: PydanticObjectId) -> Log | None:
+    async def find_log_by_id(self, log_id: PydanticObjectId, user_id: PydanticObjectId) -> Log | None:
         key = self.build_log_key(log_id, user_id)
         cached = await self._get_log(key)
         if cached is not None:
@@ -154,7 +158,12 @@ class LogCacheRepository:
             await self._set_log(key, log)
         return log
 
-    async def update_log(self, log_id: str, user_id: PydanticObjectId, update_request: LogUpdateRequest) -> Log | None:
+    async def update_log(
+        self,
+        log_id: PydanticObjectId,
+        user_id: PydanticObjectId,
+        update_request: LogUpdateRequest,
+    ) -> Log | None:
         log = await self.repository.update_log(log_id, user_id, update_request)
         if log is not None:
             await self._invalidate_log(log)
@@ -192,7 +201,11 @@ class LogCacheRepository:
         await self._set_logs(key, logs)
         return logs
 
-    async def find_logs_by_movie_id(self, movie_id: str, user_id: PydanticObjectId | None = None) -> list[Log]:
+    async def find_logs_by_movie_id(
+        self,
+        movie_id: PydanticObjectId,
+        user_id: PydanticObjectId | None = None,
+    ) -> list[Log]:
         key = self.build_movie_logs_key(movie_id, user_id)
         cached = await self._get_logs(key)
         if cached is not None:
@@ -202,7 +215,7 @@ class LogCacheRepository:
         await self._set_logs(key, logs)
         return logs
 
-    async def delete_log(self, log_id: str, user_id: PydanticObjectId) -> Log | None:
+    async def delete_log(self, log_id: PydanticObjectId, user_id: PydanticObjectId) -> Log | None:
         deleted_log = await self.repository.delete_log(log_id, user_id)
         if deleted_log is None:
             return None

--- a/app/repository/log_repository.py
+++ b/app/repository/log_repository.py
@@ -28,19 +28,21 @@ class LogRepository:
         await log.insert()
         return log
 
-    async def find_log_by_id(self, log_id: str, user_id: PydanticObjectId) -> Log | None:
+    async def find_log_by_id(self, log_id: PydanticObjectId, user_id: PydanticObjectId) -> Log | None:
         """
         Find a log entry by its ID, ensuring it belongs to the user.
         """
         return await self._find_log_by_id(log_id, user_id)
 
-    async def _find_log_by_id(self, log_id: str, user_id: PydanticObjectId) -> Log | None:
-        log_object_id = to_object_id(log_id)
-        if log_object_id is None or user_id is None:
-            return None
-        return await Log.find_one(Log.active_filter({"_id": log_object_id, "userId": user_id}))
+    async def _find_log_by_id(self, log_id: PydanticObjectId, user_id: PydanticObjectId) -> Log | None:
+        return await Log.find_one(Log.active_filter({"_id": log_id, "userId": user_id}))
 
-    async def update_log(self, log_id: str, user_id: PydanticObjectId, update_request: LogUpdateRequest) -> Log | None:
+    async def update_log(
+        self,
+        log_id: PydanticObjectId,
+        user_id: PydanticObjectId,
+        update_request: LogUpdateRequest,
+    ) -> Log | None:
         """
         Update an existing log entry.
         """
@@ -99,22 +101,22 @@ class LogRepository:
 
         return await Log.find(filters).sort(sort_spec).to_list()
 
-    async def find_logs_by_movie_id(self, movie_id: str, user_id: PydanticObjectId | None = None) -> list[Log]:
+    async def find_logs_by_movie_id(
+        self,
+        movie_id: PydanticObjectId,
+        user_id: PydanticObjectId | None = None,
+    ) -> list[Log]:
         """
         Find all log entries for a specific movie by its ID.
         Optionally filter by user_id.
         """
-        movie_object_id = to_object_id(movie_id)
-        if movie_object_id is None:
-            return []
-
-        query_params: dict = Log.active_filter({"movieId": movie_object_id})
+        query_params: dict = Log.active_filter({"movieId": movie_id})
         if user_id:
             query_params["userId"] = user_id
 
         return await Log.find(query_params).to_list()
 
-    async def delete_log(self, log_id: str, user_id: PydanticObjectId) -> Log | None:
+    async def delete_log(self, log_id: PydanticObjectId, user_id: PydanticObjectId) -> Log | None:
         """
         Delete a log entry (hard delete). Returns the deleted log, or None if not found.
         """

--- a/app/services/log_service.py
+++ b/app/services/log_service.py
@@ -18,6 +18,7 @@ from app.services.movie_service import MovieService
 from app.services.stats_cache_service import StatsCacheService
 from app.utils.error_codes_utils import ErrorCodes
 from app.utils.exceptions_utils import AppException
+from app.utils.object_id_utils import to_object_id
 
 
 class LogService:
@@ -94,7 +95,11 @@ class LogService:
         """
         Update an existing log entry.
         """
-        log = await self.log_repository.update_log(log_id=log_id, user_id=user_id, update_request=request)
+        log_object_id = to_object_id(log_id)
+        if log_object_id is None:
+            raise AppException(ErrorCodes.LOG_NOT_FOUND)
+
+        log = await self.log_repository.update_log(log_id=log_object_id, user_id=user_id, update_request=request)
 
         if not log:
             # Log not found or doesn't belong to user
@@ -121,7 +126,11 @@ class LogService:
         """
         Delete a viewing log entry owned by the given user.
         """
-        deleted_log = await self.log_repository.delete_log(log_id=log_id, user_id=user_id)
+        log_object_id = to_object_id(log_id)
+        if log_object_id is None:
+            raise AppException(ErrorCodes.LOG_NOT_FOUND)
+
+        deleted_log = await self.log_repository.delete_log(log_id=log_object_id, user_id=user_id)
         if deleted_log is None:
             raise AppException(ErrorCodes.LOG_NOT_FOUND)
 

--- a/app/services/log_service.py
+++ b/app/services/log_service.py
@@ -18,7 +18,6 @@ from app.services.movie_service import MovieService
 from app.services.stats_cache_service import StatsCacheService
 from app.utils.error_codes_utils import ErrorCodes
 from app.utils.exceptions_utils import AppException
-from app.utils.object_id_utils import to_object_id
 
 
 class LogService:
@@ -91,15 +90,16 @@ class LogService:
             watched_where=log.watched_where,
         )
 
-    async def update_log(self, user_id: PydanticObjectId, log_id: str, request: LogUpdateRequest) -> LogCreateResponse:
+    async def update_log(
+        self,
+        user_id: PydanticObjectId,
+        log_id: PydanticObjectId,
+        request: LogUpdateRequest,
+    ) -> LogCreateResponse:
         """
         Update an existing log entry.
         """
-        log_object_id = to_object_id(log_id)
-        if log_object_id is None:
-            raise AppException(ErrorCodes.LOG_NOT_FOUND)
-
-        log = await self.log_repository.update_log(log_id=log_object_id, user_id=user_id, update_request=request)
+        log = await self.log_repository.update_log(log_id=log_id, user_id=user_id, update_request=request)
 
         if not log:
             # Log not found or doesn't belong to user
@@ -122,15 +122,11 @@ class LogService:
             watched_where=log.watched_where,
         )
 
-    async def delete_log(self, user_id: PydanticObjectId, log_id: str) -> None:
+    async def delete_log(self, user_id: PydanticObjectId, log_id: PydanticObjectId) -> None:
         """
         Delete a viewing log entry owned by the given user.
         """
-        log_object_id = to_object_id(log_id)
-        if log_object_id is None:
-            raise AppException(ErrorCodes.LOG_NOT_FOUND)
-
-        deleted_log = await self.log_repository.delete_log(log_id=log_object_id, user_id=user_id)
+        deleted_log = await self.log_repository.delete_log(log_id=log_id, user_id=user_id)
         if deleted_log is None:
             raise AppException(ErrorCodes.LOG_NOT_FOUND)
 

--- a/tests/units/controllers/test_log_controller.py
+++ b/tests/units/controllers/test_log_controller.py
@@ -174,7 +174,7 @@ class TestUpdateLog:
         update_request = {"viewingNotes": "Updated notes", "watchedWhere": "streaming"}
 
         response = client.put(
-            "/v1/logs/log123",
+            "/v1/logs/507f1f77bcf86cd799439011",
             json=update_request,
             cookies={"__Host-access_token": "token", "__Host-csrf_token": "test-token"},
             headers={"X-CSRF-Token": "test-token"},
@@ -193,13 +193,28 @@ class TestUpdateLog:
         update_request = {"viewingNotes": "Updated notes"}
 
         response = client.put(
-            "/v1/logs/log123",
+            "/v1/logs/507f1f77bcf86cd799439011",
             json=update_request,
             cookies={"__Host-csrf_token": "test-token"},
             headers={"X-CSRF-Token": "test-token"},
         )
 
         assert response.status_code == 401
+
+    def test_update_log_invalid_object_id_returns_422(self, client, override_auth):
+        """Malformed log_id path param fails FastAPI validation with 422."""
+        app.dependency_overrides[auth_dependency] = override_auth
+
+        response = client.put(
+            "/v1/logs/not-an-object-id",
+            json={"viewingNotes": "x"},
+            cookies={"__Host-access_token": "token", "__Host-csrf_token": "test-token"},
+            headers={"X-CSRF-Token": "test-token"},
+        )
+
+        app.dependency_overrides = {}
+
+        assert response.status_code == 422
 
 
 class TestDeleteLog:
@@ -212,7 +227,7 @@ class TestDeleteLog:
         mock_delete_log.return_value = None
 
         response = client.delete(
-            "/v1/logs/log123",
+            "/v1/logs/507f1f77bcf86cd799439011",
             cookies={"__Host-access_token": "token", "__Host-csrf_token": "test-token"},
             headers={"X-CSRF-Token": "test-token"},
         )
@@ -230,7 +245,7 @@ class TestDeleteLog:
         mock_delete_log.side_effect = AppException(ErrorCodes.LOG_NOT_FOUND)
 
         response = client.delete(
-            "/v1/logs/log123",
+            "/v1/logs/507f1f77bcf86cd799439011",
             cookies={"__Host-access_token": "token", "__Host-csrf_token": "test-token"},
             headers={"X-CSRF-Token": "test-token"},
         )
@@ -244,12 +259,26 @@ class TestDeleteLog:
         """Delete without access token returns 401."""
         app.dependency_overrides = {}
         response = client.delete(
-            "/v1/logs/log123",
+            "/v1/logs/507f1f77bcf86cd799439011",
             cookies={"__Host-csrf_token": "test-token"},
             headers={"X-CSRF-Token": "test-token"},
         )
 
         assert response.status_code == 401
+
+    def test_delete_log_invalid_object_id_returns_422(self, client, override_auth):
+        """Malformed log_id path param fails FastAPI validation with 422."""
+        app.dependency_overrides[auth_dependency] = override_auth
+
+        response = client.delete(
+            "/v1/logs/not-an-object-id",
+            cookies={"__Host-access_token": "token", "__Host-csrf_token": "test-token"},
+            headers={"X-CSRF-Token": "test-token"},
+        )
+
+        app.dependency_overrides = {}
+
+        assert response.status_code == 422
 
 
 class TestGetLogsByHandle:

--- a/tests/units/controllers/test_rate_limiting.py
+++ b/tests/units/controllers/test_rate_limiting.py
@@ -996,7 +996,7 @@ class TestUpdateLogRateLimit:
         try:
             for _ in range(10):
                 response = client.put(
-                    "/v1/logs/log123",
+                    "/v1/logs/507f1f77bcf86cd799439011",
                     json=self.LOG_UPDATE_PAYLOAD,
                     headers={"X-CSRF-Token": "test-token"},
                 )
@@ -1017,13 +1017,13 @@ class TestUpdateLogRateLimit:
         try:
             for _ in range(10):
                 client.put(
-                    "/v1/logs/log123",
+                    "/v1/logs/507f1f77bcf86cd799439011",
                     json=self.LOG_UPDATE_PAYLOAD,
                     headers={"X-CSRF-Token": "test-token"},
                 )
 
             response = client.put(
-                "/v1/logs/log123",
+                "/v1/logs/507f1f77bcf86cd799439011",
                 json=self.LOG_UPDATE_PAYLOAD,
                 headers={"X-CSRF-Token": "test-token"},
             )

--- a/tests/units/repository/test_log_cache_repository.py
+++ b/tests/units/repository/test_log_cache_repository.py
@@ -71,12 +71,12 @@ async def test_find_log_by_id_cache_hit_skips_repository(beanie_test_db):
     cache.get.return_value = repository._serialize_log(log)
 
     with patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache):
-        result = await repository.find_log_by_id(str(log.id), log.user_id)
+        result = await repository.find_log_by_id(log.id, log.user_id)
 
     assert result is not None
     assert result.id == log.id
     inner_repository.find_log_by_id.assert_not_awaited()
-    cache.get.assert_awaited_once_with(repository.build_log_key(str(log.id), log.user_id))
+    cache.get.assert_awaited_once_with(repository.build_log_key(log.id, log.user_id))
 
 
 @pytest.mark.asyncio
@@ -88,11 +88,11 @@ async def test_find_log_by_id_cache_miss_queries_repository_and_sets_cache(beani
     repository = LogCacheRepository(inner_repository)
 
     with patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache):
-        result = await repository.find_log_by_id(str(log.id), log.user_id)
+        result = await repository.find_log_by_id(log.id, log.user_id)
 
-    expected_key = repository.build_log_key(str(log.id), log.user_id)
+    expected_key = repository.build_log_key(log.id, log.user_id)
     assert result == log
-    inner_repository.find_log_by_id.assert_awaited_once_with(str(log.id), log.user_id)
+    inner_repository.find_log_by_id.assert_awaited_once_with(log.id, log.user_id)
     cache.set.assert_awaited_once_with(expected_key, repository._serialize_log(log), ttl=LOG_CACHE_TTL)
 
 
@@ -162,12 +162,12 @@ async def test_find_logs_by_movie_id_cache_hit_skips_repository(beanie_test_db):
     cache.get.return_value = repository._serialize_logs([log])
 
     with patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache):
-        result = await repository.find_logs_by_movie_id(str(log.movie_id), log.user_id)
+        result = await repository.find_logs_by_movie_id(log.movie_id, log.user_id)
 
     assert len(result) == 1
     assert result[0].id == log.id
     inner_repository.find_logs_by_movie_id.assert_not_awaited()
-    cache.get.assert_awaited_once_with(repository.build_movie_logs_key(str(log.movie_id), log.user_id))
+    cache.get.assert_awaited_once_with(repository.build_movie_logs_key(log.movie_id, log.user_id))
 
 
 @pytest.mark.asyncio
@@ -179,11 +179,11 @@ async def test_find_logs_by_movie_id_cache_miss_queries_repository_and_sets_cach
     repository = LogCacheRepository(inner_repository)
 
     with patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache):
-        result = await repository.find_logs_by_movie_id(str(log.movie_id), log.user_id)
+        result = await repository.find_logs_by_movie_id(log.movie_id, log.user_id)
 
-    expected_key = repository.build_movie_logs_key(str(log.movie_id), log.user_id)
+    expected_key = repository.build_movie_logs_key(log.movie_id, log.user_id)
     assert result == [log]
-    inner_repository.find_logs_by_movie_id.assert_awaited_once_with(str(log.movie_id), log.user_id)
+    inner_repository.find_logs_by_movie_id.assert_awaited_once_with(log.movie_id, log.user_id)
     cache.set.assert_awaited_once_with(expected_key, repository._serialize_logs([log]), ttl=LOG_CACHE_TTL)
 
 
@@ -198,13 +198,13 @@ async def test_cache_get_and_set_failures_fall_back_to_repository(beanie_test_db
     repository = LogCacheRepository(inner_repository)
 
     with patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache):
-        result = await repository.find_log_by_id(str(log.id), log.user_id)
+        result = await repository.find_log_by_id(log.id, log.user_id)
 
-    expected_key = repository.build_log_key(str(log.id), log.user_id)
+    expected_key = repository.build_log_key(log.id, log.user_id)
     assert result == log
     cache.get.assert_awaited_once_with(expected_key)
     cache.set.assert_awaited_once_with(expected_key, repository._serialize_log(log), ttl=LOG_CACHE_TTL)
-    inner_repository.find_log_by_id.assert_awaited_once_with(str(log.id), log.user_id)
+    inner_repository.find_log_by_id.assert_awaited_once_with(log.id, log.user_id)
 
 
 @pytest.mark.asyncio
@@ -244,10 +244,10 @@ async def test_update_log_invalidates_id_user_and_movie_cache(beanie_test_db):
     request = LogUpdateRequest(viewing_notes="Updated")
 
     with patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache):
-        result = await repository.update_log(str(log.id), log.user_id, request)
+        result = await repository.update_log(log.id, log.user_id, request)
 
     assert result == log
-    cache.delete.assert_awaited_once_with(repository.build_log_key(str(log.id), log.user_id))
+    cache.delete.assert_awaited_once_with(repository.build_log_key(log.id, log.user_id))
     cache.invalidate_pattern.assert_has_awaits(
         [
             call(repository.build_user_logs_pattern(log.user_id)),
@@ -267,12 +267,12 @@ async def test_update_log_uses_database_lookup_without_reading_cache(beanie_test
     request = LogUpdateRequest(viewing_notes="Updated from DB")
 
     with patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache):
-        result = await repository.update_log(str(log.id), log.user_id, request)
+        result = await repository.update_log(log.id, log.user_id, request)
 
     assert result is not None
     assert result.viewing_notes == "Updated from DB"
     cache.get.assert_not_awaited()
-    cache.delete.assert_awaited_once_with(repository.build_log_key(str(log.id), log.user_id))
+    cache.delete.assert_awaited_once_with(repository.build_log_key(log.id, log.user_id))
 
 
 @pytest.mark.asyncio
@@ -284,12 +284,12 @@ async def test_delete_log_invalidates_only_after_successful_delete(beanie_test_d
     repository = LogCacheRepository(inner_repository)
 
     with patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache):
-        result = await repository.delete_log(str(log.id), log.user_id)
+        result = await repository.delete_log(log.id, log.user_id)
 
     assert result == log
     inner_repository.find_log_by_id.assert_not_awaited()
-    inner_repository.delete_log.assert_awaited_once_with(str(log.id), log.user_id)
-    cache.delete.assert_awaited_once_with(repository.build_log_key(str(log.id), log.user_id))
+    inner_repository.delete_log.assert_awaited_once_with(log.id, log.user_id)
+    cache.delete.assert_awaited_once_with(repository.build_log_key(log.id, log.user_id))
     cache.invalidate_pattern.assert_has_awaits(
         [
             call(repository.build_user_logs_pattern(log.user_id)),
@@ -308,18 +308,18 @@ async def test_delete_log_uses_database_lookup_without_reading_cache(beanie_test
     cache.get.return_value = repository._serialize_log(log)
 
     with patch("app.repository.log_cache_repository.CacheService.get_instance", return_value=cache):
-        result = await repository.delete_log(str(log.id), log.user_id)
+        result = await repository.delete_log(log.id, log.user_id)
 
     assert result is not None
     assert await Log.get(log.id) is None
     cache.get.assert_not_awaited()
-    cache.delete.assert_awaited_once_with(repository.build_log_key(str(log.id), log.user_id))
+    cache.delete.assert_awaited_once_with(repository.build_log_key(log.id, log.user_id))
 
 
 @pytest.mark.asyncio
 async def test_delete_log_not_found_skips_invalidation(beanie_test_db):
     user_id = PydanticObjectId()
-    log_id = str(PydanticObjectId())
+    log_id = PydanticObjectId()
     cache = _mock_cache()
     inner_repository = _mock_log_repository()
     inner_repository.delete_log.return_value = None

--- a/tests/units/repository/test_log_repository.py
+++ b/tests/units/repository/test_log_repository.py
@@ -2,7 +2,6 @@ from datetime import UTC, datetime
 
 import pytest
 from beanie import PydanticObjectId
-from bson import ObjectId
 
 from app.models.log import Log
 from app.models.movie import Movie
@@ -101,12 +100,13 @@ async def test_find_logs_by_movie_id(
 ):
     log = await log_repository.create_log(user_id, movie_create_request)
     assert movie_create_request.movie_id is not None
-    logs = await log_repository.find_logs_by_movie_id(movie_create_request.movie_id)
+    movie_object_id = PydanticObjectId(movie_create_request.movie_id)
+    logs = await log_repository.find_logs_by_movie_id(movie_object_id)
     assert len(logs) == 1
     assert logs[0].id == log.id
 
     second_log = await log_repository.create_log(user_id, movie_create_request)
-    logs = await log_repository.find_logs_by_movie_id(movie_create_request.movie_id)
+    logs = await log_repository.find_logs_by_movie_id(movie_object_id)
     assert len(logs) == 2
     assert logs[0].id == log.id
     assert logs[1].id == second_log.id
@@ -263,16 +263,8 @@ async def test_log_list_with_watched_where_filter(
 
 @pytest.mark.asyncio
 async def test_find_log_by_id_not_found(beanie_test_db, log_repository: LogRepository, user_id: PydanticObjectId):
-    non_existent_id = str(ObjectId())
+    non_existent_id = PydanticObjectId()
     result = await log_repository.find_log_by_id(non_existent_id, user_id)
-    assert result is None
-
-
-@pytest.mark.asyncio
-async def test_find_log_by_id_invalid_object_id(
-    beanie_test_db, log_repository: LogRepository, user_id: PydanticObjectId
-):
-    result = await log_repository.find_log_by_id("invalid-log-id", user_id)
     assert result is None
 
 
@@ -285,23 +277,16 @@ async def test_find_log_by_id_success(
     user_id: PydanticObjectId,
 ):
     log = await log_repository.create_log(user_id, movie_create_request)
-    result = await log_repository.find_log_by_id(str(log.id), user_id)
+    result = await log_repository.find_log_by_id(log.id, user_id)
     assert result is not None
     assert result.id == log.id
 
 
 @pytest.mark.asyncio
 async def test_update_log_not_found(beanie_test_db, log_repository: LogRepository, user_id: PydanticObjectId):
-    non_existent_id = str(ObjectId())
+    non_existent_id = PydanticObjectId()
     update_request = LogUpdateRequest(viewing_notes="Updated notes")
     result = await log_repository.update_log(non_existent_id, user_id, update_request)
-    assert result is None
-
-
-@pytest.mark.asyncio
-async def test_update_log_invalid_object_id(beanie_test_db, log_repository: LogRepository, user_id: PydanticObjectId):
-    update_request = LogUpdateRequest(viewing_notes="Updated notes")
-    result = await log_repository.update_log("invalid-log-id", user_id, update_request)
     assert result is None
 
 
@@ -315,7 +300,7 @@ async def test_update_log_success(
 ):
     log = await log_repository.create_log(user_id, movie_create_request)
     update_request = LogUpdateRequest(viewing_notes="Updated notes", watched_where="streaming")
-    result = await log_repository.update_log(str(log.id), user_id, update_request)
+    result = await log_repository.update_log(log.id, user_id, update_request)
     assert result is not None
     assert result.viewing_notes == "Updated notes"
     assert result.watched_where == "streaming"
@@ -323,14 +308,8 @@ async def test_update_log_success(
 
 @pytest.mark.asyncio
 async def test_delete_log_not_found(beanie_test_db, log_repository: LogRepository, user_id: PydanticObjectId):
-    non_existent_id = str(ObjectId())
+    non_existent_id = PydanticObjectId()
     result = await log_repository.delete_log(non_existent_id, user_id)
-    assert result is None
-
-
-@pytest.mark.asyncio
-async def test_delete_log_invalid_object_id(beanie_test_db, log_repository: LogRepository, user_id: PydanticObjectId):
-    result = await log_repository.delete_log("invalid-log-id", user_id)
     assert result is None
 
 
@@ -343,7 +322,7 @@ async def test_delete_log_success(
     user_id: PydanticObjectId,
 ):
     log = await log_repository.create_log(user_id, movie_create_request)
-    result = await log_repository.delete_log(str(log.id), user_id)
+    result = await log_repository.delete_log(log.id, user_id)
     assert result is not None
     assert result.id == log.id
     deleted_log = await Log.get(log.id)
@@ -362,7 +341,7 @@ async def test_find_log_by_id_filters_soft_deleted(
     log.deleted = True
     await log.save()
 
-    found = await log_repository.find_log_by_id(str(log.id), user_id)
+    found = await log_repository.find_log_by_id(log.id, user_id)
     assert found is None
 
 
@@ -438,31 +417,12 @@ async def test_find_logs_by_movie_id_with_user_filter(
     other_user_id = PydanticObjectId()
 
     assert movie_create_request.movie_id is not None
-    logs = await log_repository.find_logs_by_movie_id(movie_create_request.movie_id, user_id)
+    movie_object_id = PydanticObjectId(movie_create_request.movie_id)
+    logs = await log_repository.find_logs_by_movie_id(movie_object_id, user_id)
     assert len(logs) == 1
 
-    logs = await log_repository.find_logs_by_movie_id(movie_create_request.movie_id, other_user_id)
+    logs = await log_repository.find_logs_by_movie_id(movie_object_id, other_user_id)
     assert len(logs) == 0
-
-
-@pytest.mark.asyncio
-async def test_find_logs_by_movie_id_invalid_ids(beanie_test_db, log_repository: LogRepository):
-    logs_invalid_movie = await log_repository.find_logs_by_movie_id("invalid-movie-id")
-    assert logs_invalid_movie == []
-
-    from bson import ObjectId as BSONObjectId
-    from bson.errors import InvalidId
-
-    try:
-        # Test with a valid ObjectId string for the movie_id (which will be converted)
-        # and an invalid ObjectId for user_id
-        movie_id = str(ObjectId())
-        invalid_user_id = PydanticObjectId(BSONObjectId("000000000000000000000000"))
-        logs_invalid_user = await log_repository.find_logs_by_movie_id(movie_id, user_id=invalid_user_id)
-        assert logs_invalid_user == []
-    except InvalidId:
-        # If the ID is completely invalid, we expect the query to return empty results
-        assert True
 
 
 @pytest.mark.asyncio
@@ -478,5 +438,5 @@ async def test_find_logs_by_movie_id_excludes_soft_deleted(
     await log.save()
 
     assert movie_create_request.movie_id is not None
-    logs = await log_repository.find_logs_by_movie_id(movie_create_request.movie_id)
+    logs = await log_repository.find_logs_by_movie_id(PydanticObjectId(movie_create_request.movie_id))
     assert logs == []

--- a/tests/units/services/test_log_service.py
+++ b/tests/units/services/test_log_service.py
@@ -203,8 +203,8 @@ class TestLogService:
         mock_movie_service.get_movie_by_id.return_value = mock_movie
 
         request = LogUpdateRequest(viewing_notes="Updated notes")
-        log_id_str = str(PydanticObjectId())
-        result = await log_service.update_log("user123", log_id_str, request)
+        log_id = PydanticObjectId()
+        result = await log_service.update_log("user123", log_id, request)
 
         assert result.viewing_notes == "Updated notes"
         mock_log_repository.update_log.assert_awaited_once()
@@ -244,8 +244,8 @@ class TestLogService:
         mock_movie_service.get_movie_by_id.return_value = mock_movie
 
         request = LogUpdateRequest(viewing_notes="Updated notes")
-        log_id_str = str(PydanticObjectId())
-        await log_service.update_log(user_id, log_id_str, request)
+        log_id = PydanticObjectId()
+        await log_service.update_log(user_id, log_id, request)
 
         mock_stats_cache_service.invalidate_user_stats.assert_awaited_once_with(user_id)
 
@@ -257,33 +257,18 @@ class TestLogService:
         request = LogUpdateRequest(viewing_notes="Updated notes")
 
         with pytest.raises(AppException):
-            await log_service.update_log("user123", str(PydanticObjectId()), request)
-
-    @pytest.mark.asyncio
-    async def test_update_log_invalid_id_raises_log_not_found(
-        self, log_service, mock_log_repository, mock_stats_cache_service
-    ):
-        """Test that an unparseable log_id short-circuits to LOG_NOT_FOUND without hitting the repo."""
-        request = LogUpdateRequest(viewing_notes="Updated notes")
-
-        with pytest.raises(AppException) as exc_info:
-            await log_service.update_log("user123", "not-an-object-id", request)
-
-        assert exc_info.value.error.error_code == ErrorCodes.LOG_NOT_FOUND.error_code
-        mock_log_repository.update_log.assert_not_awaited()
-        mock_stats_cache_service.invalidate_user_stats.assert_not_called()
+            await log_service.update_log("user123", PydanticObjectId(), request)
 
     @pytest.mark.asyncio
     async def test_delete_log_success(self, log_service, mock_log_repository, mock_stats_cache_service):
         """Test successful log deletion invalidates the stats cache."""
         user_id = PydanticObjectId()
-        log_id_str = str(PydanticObjectId())
-        expected_log_id = PydanticObjectId(log_id_str)
+        log_id = PydanticObjectId()
         mock_log_repository.delete_log.return_value = MagicMock()
 
-        await log_service.delete_log(user_id=user_id, log_id=log_id_str)
+        await log_service.delete_log(user_id=user_id, log_id=log_id)
 
-        mock_log_repository.delete_log.assert_awaited_once_with(log_id=expected_log_id, user_id=user_id)
+        mock_log_repository.delete_log.assert_awaited_once_with(log_id=log_id, user_id=user_id)
         mock_stats_cache_service.invalidate_user_stats.assert_awaited_once_with(user_id)
 
     @pytest.mark.asyncio
@@ -293,23 +278,9 @@ class TestLogService:
         mock_log_repository.delete_log.return_value = None
 
         with pytest.raises(AppException) as exc_info:
-            await log_service.delete_log(user_id=user_id, log_id=str(PydanticObjectId()))
+            await log_service.delete_log(user_id=user_id, log_id=PydanticObjectId())
 
         assert exc_info.value.error.error_code == ErrorCodes.LOG_NOT_FOUND.error_code
-        mock_stats_cache_service.invalidate_user_stats.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_delete_log_invalid_id_raises_log_not_found(
-        self, log_service, mock_log_repository, mock_stats_cache_service
-    ):
-        """Test that an unparseable log_id short-circuits to LOG_NOT_FOUND without hitting the repo."""
-        user_id = PydanticObjectId()
-
-        with pytest.raises(AppException) as exc_info:
-            await log_service.delete_log(user_id=user_id, log_id="not-an-object-id")
-
-        assert exc_info.value.error.error_code == ErrorCodes.LOG_NOT_FOUND.error_code
-        mock_log_repository.delete_log.assert_not_awaited()
         mock_stats_cache_service.invalidate_user_stats.assert_not_called()
 
     @pytest.mark.asyncio

--- a/tests/units/services/test_log_service.py
+++ b/tests/units/services/test_log_service.py
@@ -203,7 +203,8 @@ class TestLogService:
         mock_movie_service.get_movie_by_id.return_value = mock_movie
 
         request = LogUpdateRequest(viewing_notes="Updated notes")
-        result = await log_service.update_log("user123", "log123", request)
+        log_id_str = str(PydanticObjectId())
+        result = await log_service.update_log("user123", log_id_str, request)
 
         assert result.viewing_notes == "Updated notes"
         mock_log_repository.update_log.assert_awaited_once()
@@ -243,7 +244,8 @@ class TestLogService:
         mock_movie_service.get_movie_by_id.return_value = mock_movie
 
         request = LogUpdateRequest(viewing_notes="Updated notes")
-        await log_service.update_log(user_id, "log123", request)
+        log_id_str = str(PydanticObjectId())
+        await log_service.update_log(user_id, log_id_str, request)
 
         mock_stats_cache_service.invalidate_user_stats.assert_awaited_once_with(user_id)
 
@@ -255,17 +257,33 @@ class TestLogService:
         request = LogUpdateRequest(viewing_notes="Updated notes")
 
         with pytest.raises(AppException):
-            await log_service.update_log("user123", "nonexistent_log", request)
+            await log_service.update_log("user123", str(PydanticObjectId()), request)
+
+    @pytest.mark.asyncio
+    async def test_update_log_invalid_id_raises_log_not_found(
+        self, log_service, mock_log_repository, mock_stats_cache_service
+    ):
+        """Test that an unparseable log_id short-circuits to LOG_NOT_FOUND without hitting the repo."""
+        request = LogUpdateRequest(viewing_notes="Updated notes")
+
+        with pytest.raises(AppException) as exc_info:
+            await log_service.update_log("user123", "not-an-object-id", request)
+
+        assert exc_info.value.error.error_code == ErrorCodes.LOG_NOT_FOUND.error_code
+        mock_log_repository.update_log.assert_not_awaited()
+        mock_stats_cache_service.invalidate_user_stats.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_delete_log_success(self, log_service, mock_log_repository, mock_stats_cache_service):
         """Test successful log deletion invalidates the stats cache."""
         user_id = PydanticObjectId()
+        log_id_str = str(PydanticObjectId())
+        expected_log_id = PydanticObjectId(log_id_str)
         mock_log_repository.delete_log.return_value = MagicMock()
 
-        await log_service.delete_log(user_id=user_id, log_id="log123")
+        await log_service.delete_log(user_id=user_id, log_id=log_id_str)
 
-        mock_log_repository.delete_log.assert_awaited_once_with(log_id="log123", user_id=user_id)
+        mock_log_repository.delete_log.assert_awaited_once_with(log_id=expected_log_id, user_id=user_id)
         mock_stats_cache_service.invalidate_user_stats.assert_awaited_once_with(user_id)
 
     @pytest.mark.asyncio
@@ -275,9 +293,23 @@ class TestLogService:
         mock_log_repository.delete_log.return_value = None
 
         with pytest.raises(AppException) as exc_info:
-            await log_service.delete_log(user_id=user_id, log_id="nonexistent")
+            await log_service.delete_log(user_id=user_id, log_id=str(PydanticObjectId()))
 
         assert exc_info.value.error.error_code == ErrorCodes.LOG_NOT_FOUND.error_code
+        mock_stats_cache_service.invalidate_user_stats.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_delete_log_invalid_id_raises_log_not_found(
+        self, log_service, mock_log_repository, mock_stats_cache_service
+    ):
+        """Test that an unparseable log_id short-circuits to LOG_NOT_FOUND without hitting the repo."""
+        user_id = PydanticObjectId()
+
+        with pytest.raises(AppException) as exc_info:
+            await log_service.delete_log(user_id=user_id, log_id="not-an-object-id")
+
+        assert exc_info.value.error.error_code == ErrorCodes.LOG_NOT_FOUND.error_code
+        mock_log_repository.delete_log.assert_not_awaited()
         mock_stats_cache_service.invalidate_user_stats.assert_not_called()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`LogRepository` and `LogCacheRepository` methods now accept `PydanticObjectId` for `log_id` and `movie_id` parameters instead of raw strings. Path-param parsing is pushed all the way to FastAPI: controllers declare `log_id: PydanticObjectId` and the service receives the typed value with no conversion in between. The repo, service, and controller all share one ID contract.

Closes #151.

## Changes

- **`app/repository/log_repository.py`**: `find_log_by_id`, `_find_log_by_id`, `update_log`, `delete_log`, `find_logs_by_movie_id` now take `PydanticObjectId`. Internal `to_object_id` calls and `is None` early returns dropped from these methods (`create_log` is unchanged — it takes a `LogCreateRequest`, not a raw ID).
- **`app/repository/log_cache_repository.py`**: matches the new contract. `build_log_key`, `build_movie_logs_key`, `build_movie_logs_pattern` updated; `_invalidate_log` no longer wraps `log.id` in `str(...)` (the f-string handles it). Existing Redis keys are byte-for-byte identical because `PydanticObjectId.__str__` produces the same hex.
- **`app/services/log_service.py`**: `update_log` and `delete_log` take `PydanticObjectId`. No more `to_object_id` conversion at the service boundary.
- **`app/controllers/log_controller.py`**: `PUT /v1/logs/{log_id}` and `DELETE /v1/logs/{log_id}` declare `log_id: PydanticObjectId`. FastAPI parses and validates the path segment.

## Behavior change

A malformed `log_id` in the path (e.g. `PUT /v1/logs/not-an-object-id`) now returns **422** (FastAPI validation error) instead of the previous **404 `LOG_NOT_FOUND`**. Acceptable trade-off: a real client never sends a malformed ObjectId, and skipping the redundant string-to-ObjectId boundary in the service is the cleaner outcome.

## Tests

- Added `test_update_log_invalid_object_id_returns_422` and `test_delete_log_invalid_object_id_returns_422` in `tests/units/controllers/test_log_controller.py` to pin the 422 contract.
- Removed `test_*_invalid_object_id` repository tests (the typed contract makes them unreachable).
- Repository and cache-repository tests updated to pass `PydanticObjectId` directly instead of `str(log.id)`.
- Service tests updated to use `PydanticObjectId()` rather than placeholder strings.
- Controller and rate-limit tests that hit `/v1/logs/log123` updated to use a valid ObjectId hex (`/v1/logs/507f1f77bcf86cd799439011`).

## Verification

- `make lint` ✓
- `make typecheck` ✓
- `make test-unit` — 414 passing
- `make test-e2e` — 73 passing