### PR TITLE
feat: migrate MovieRepository to PostgreSQL (issue #126)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,9 @@
 MONGODB_URI=mongodb://localhost:27017/cinelog_db
 MONGODB_DB=cinelog_db
 
+# Database backend selection
+# DB_BACKEND=mongo
+
 # PostgreSQL Configuration (optional until PostgreSQL repositories are activated)
 DATABASE_URL=postgresql+asyncpg://cinelog:cinelog@localhost:5432/cinelog_db
 

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+.mypy_cache/
 
 # Jupyter Notebook
 .ipynb_checkpoints

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install dev hooks test-unit test-e2e lint format format-check typecheck security dependency-audit run docker-up docker-down docker-build-prod docker-prod-up docker-prod-down migrate migrate-dry-run db-schema-migrate db-schema-rollback
+.PHONY: install dev hooks test-unit test-e2e lint format format-check typecheck security dependency-audit run docker-up docker-down docker-build-prod docker-prod-up docker-prod-down migrate migrate-dry-run db-data-migrate db-data-migrate-dry-run migrate-all migrate-all-dry-run db-schema-migrate db-schema-migrate-dry-run db-schema-rollback
 
 install:
 	uv sync
@@ -60,8 +60,27 @@ migrate:
 migrate-dry-run:
 	uv run python -m migrations.runner --dry-run
 
+db-data-migrate:
+	uv run python -m db_migrations.runner --yes
+
+db-data-migrate-dry-run:
+	uv run python -m db_migrations.runner --dry-run
+
+migrate-all:
+	uv run python -m migrations.runner --yes
+	uv run alembic upgrade head
+	uv run python -m db_migrations.runner --yes
+
+migrate-all-dry-run:
+	uv run python -m migrations.runner --dry-run
+	uv run alembic upgrade head --sql
+	uv run python -m db_migrations.runner --dry-run
+
 db-schema-migrate:
 	uv run alembic upgrade head
+
+db-schema-migrate-dry-run:
+	uv run alembic upgrade head --sql
 
 db-schema-rollback:
 	uv run alembic downgrade -1

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -9,14 +9,18 @@ from sqlalchemy import pool
 from sqlalchemy.engine import Connection
 from sqlalchemy.ext.asyncio import async_engine_from_config
 
+# Import all ORM modules so their tables register with ``Base.metadata`` before
+# ``--autogenerate`` snapshots it. Imports are side-effect only.
 from alembic import context, util
+from app.models import movie_model  # noqa: F401
+from app.models.base_model import Base
 
 config = context.config
 
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
-target_metadata = None
+target_metadata = Base.metadata
 DATABASE_URL_ENV = "DATABASE_URL"
 
 

--- a/alembic/versions/001_create_movies_table.py
+++ b/alembic/versions/001_create_movies_table.py
@@ -1,0 +1,50 @@
+"""create movies table
+
+Revision ID: 001_create_movies_table
+Revises:
+Create Date: 2026-05-26 12:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "001_create_movies_table"
+down_revision: str | Sequence[str] | None = None
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Apply the migration."""
+    op.execute("CREATE EXTENSION IF NOT EXISTS pgcrypto")
+
+    op.create_table(
+        "movies",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("tmdb_id", sa.Integer(), nullable=False),
+        sa.Column("title", sa.Text(), nullable=False),
+        sa.Column("release_date", sa.DateTime(timezone=False), nullable=True),
+        sa.Column("overview", sa.Text(), nullable=True),
+        sa.Column("poster_path", sa.Text(), nullable=True),
+        sa.Column("vote_average", sa.Float(), nullable=True),
+        sa.Column("runtime", sa.Integer(), nullable=True),
+        sa.Column("original_language", sa.Text(), nullable=True),
+        sa.Column("tmdb_payload", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("tmdb_last_synced_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("deleted", sa.Boolean(), nullable=False, server_default=sa.text("FALSE")),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
+    )
+
+    op.create_index("ix_movies_tmdb_id", "movies", ["tmdb_id"], unique=True)
+
+
+def downgrade() -> None:
+    """Rollback the migration."""
+    op.drop_index("ix_movies_tmdb_id", table_name="movies")
+    op.drop_table("movies")

--- a/app/dependencies/repository_dependency.py
+++ b/app/dependencies/repository_dependency.py
@@ -1,0 +1,29 @@
+"""Repository dependency providers and backend activation guardrails."""
+
+from functools import lru_cache
+
+from app.db.postgres import is_postgres_required
+from app.repository.movie_repository import MovieRepository
+
+
+class RepositoryActivationError(RuntimeError):
+    """Raised when an unsafe repository activation is requested."""
+
+
+@lru_cache
+def get_movie_repository() -> MovieRepository:
+    """Return the active movie repository implementation.
+
+    MovieRepository PostgreSQL activation is intentionally blocked in mixed mode
+    because LogRepository and MovieRatingRepository still persist/query Mongo
+    ObjectId-based movie references.
+    """
+
+    if is_postgres_required():
+        raise RepositoryActivationError(
+            "DB_BACKEND=postgres is not yet safe for MovieRepository activation: "
+            "LogRepository and MovieRatingRepository still depend on Mongo ObjectId movie references. "
+            "Keep DB_BACKEND=mongo until related repositories are migrated or a compatibility adapter exists."
+        )
+
+    return MovieRepository()

--- a/app/dependencies/service_dependency.py
+++ b/app/dependencies/service_dependency.py
@@ -8,10 +8,10 @@ Tests can swap a whole service through
 
 from functools import lru_cache
 
+from app.dependencies.repository_dependency import get_movie_repository
 from app.repository.log_cache_repository import LogCacheRepository
 from app.repository.log_repository import LogRepository
 from app.repository.movie_rating_repository import MovieRatingRepository
-from app.repository.movie_repository import MovieRepository
 from app.repository.user_repository import UserRepository
 from app.services.auth_rate_limit_service import AuthRateLimitService
 from app.services.auth_service import AuthService
@@ -39,7 +39,7 @@ def get_user_service() -> UserService:
 
 @lru_cache
 def get_movie_service() -> MovieService:
-    return MovieService(MovieRepository())
+    return MovieService(get_movie_repository())
 
 
 @lru_cache
@@ -55,7 +55,7 @@ def get_log_service() -> LogService:
     return LogService(
         log_repository=LogCacheRepository(LogRepository()),
         movie_service=get_movie_service(),
-        movie_repository=MovieRepository(),
+        movie_repository=get_movie_repository(),
         movie_rating_repository=MovieRatingRepository(),
         user_repository=UserRepository(),
     )
@@ -66,5 +66,5 @@ def get_stats_service() -> StatsService:
     return StatsService(
         log_repository=LogCacheRepository(LogRepository()),
         movie_rating_repository=MovieRatingRepository(),
-        movie_repository=MovieRepository(),
+        movie_repository=get_movie_repository(),
     )

--- a/app/models/base_model.py
+++ b/app/models/base_model.py
@@ -1,0 +1,37 @@
+"""SQLAlchemy declarative base and shared entity fields for PostgreSQL models."""
+
+from datetime import UTC, datetime
+
+from sqlalchemy import Boolean, ColumnElement, DateTime, text
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+
+class Base(DeclarativeBase):
+    """Base class for PostgreSQL ORM models."""
+
+
+class PostgresBaseEntity(Base):
+    """Abstract PostgreSQL base entity matching common Mongo lifecycle fields."""
+
+    __abstract__ = True
+
+    deleted: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("FALSE"), default=False)
+    deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+        default=lambda: datetime.now(UTC),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+    )
+
+    @classmethod
+    def active(cls) -> ColumnElement[bool]:
+        """Return a WHERE criterion that excludes soft-deleted rows."""
+        return cls.deleted.is_(False)

--- a/app/models/movie_model.py
+++ b/app/models/movie_model.py
@@ -1,0 +1,35 @@
+"""PostgreSQL movie ORM model."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import DateTime, Float, Integer, Text, text
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base_model import PostgresBaseEntity
+
+
+class PostgresMovie(PostgresBaseEntity):
+    """Movie record stored in PostgreSQL."""
+
+    __tablename__ = "movies"
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    tmdb_id: Mapped[int] = mapped_column(Integer, unique=True, nullable=False, index=True)
+    title: Mapped[str] = mapped_column(Text, nullable=False)
+    release_date: Mapped[datetime | None] = mapped_column(DateTime(timezone=False), nullable=True)
+    overview: Mapped[str | None] = mapped_column(Text, nullable=True)
+    poster_path: Mapped[str | None] = mapped_column(Text, nullable=True)
+    vote_average: Mapped[float | None] = mapped_column(Float, nullable=True)
+    runtime: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    original_language: Mapped[str | None] = mapped_column(Text, nullable=True)
+    tmdb_payload: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    tmdb_last_synced_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/app/repository/movie_repository.py
+++ b/app/repository/movie_repository.py
@@ -1,3 +1,5 @@
+"""MongoDB movie repository implementation."""
+
 from datetime import UTC, datetime
 
 from beanie import PydanticObjectId
@@ -9,10 +11,17 @@ from app.schemas.tmdb_schemas import TMDBMovieDetails
 
 
 class MovieRepository:
-    """Repository class for movie-related operations."""
+    """MongoDB movie repository — active runtime implementation.
+
+    Pending replacement by ``PostgresMovieRepository`` (in
+    ``app/repository/postgres_movie_repository.py``) once mixed-mode FK
+    dependencies in ``LogRepository`` and ``MovieRatingRepository`` are
+    migrated. ``PostgresMovieRepository`` is intentionally unwired today —
+    do not import it from runtime code paths.
+    """
 
     async def create_movie(self, request: MovieCreateRequest) -> Movie:
-        """Create a new movie in the database."""
+        """Create a new movie in MongoDB."""
 
         movie_data = request.model_dump()
         movie = Movie(**movie_data)
@@ -20,7 +29,7 @@ class MovieRepository:
         return movie
 
     async def update_movie(self, movie_id: PydanticObjectId, request: MovieUpdateRequest) -> None:
-        """Update a movie in the database."""
+        """Update an existing movie in MongoDB."""
 
         movie = await self.find_movie_by_id(movie_id)
 
@@ -40,28 +49,13 @@ class MovieRepository:
         return await Movie.find_one(Movie.active_filter({"tmdbId": tmdb_id}))
 
     async def create_from_tmdb_data(self, tmdb_data: TMDBMovieDetails) -> Movie:
-        """
-        Create a movie from TMDB API response data.
-
-        Expected fields in tmdb_data:
-        - id (tmdbId)
-        - title
-        - release_date
-        - overview
-        - poster_path
-        - vote_average
-        - runtime
-        - original_language
-        """
-        from datetime import datetime
-
-        # Parse release date if present
+        """Create a movie from TMDB details or return existing one on duplicate TMDB ID."""
         release_date = None
         if tmdb_data.release_date:
             try:
                 release_date = datetime.strptime(tmdb_data.release_date, "%Y-%m-%d")
             except ValueError:
-                pass  # Keep as None if parsing fails
+                pass
 
         movie = Movie(
             tmdb_id=tmdb_data.id,
@@ -88,6 +82,7 @@ class MovieRepository:
         return await Movie.find(Movie.active_filter({"_id": {"$in": list(movie_ids)}})).to_list()
 
     async def get_movie_stats(self, movie_ids: set[PydanticObjectId]) -> MovieStats:
+        """Compute movie aggregates for a set of IDs."""
         pipeline = [
             {"$match": {"_id": {"$in": list(movie_ids)}}},
             {

--- a/app/repository/postgres_movie_repository.py
+++ b/app/repository/postgres_movie_repository.py
@@ -1,0 +1,136 @@
+"""PostgreSQL movie repository implementation."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import UUID
+
+from sqlalchemy import func, select, update
+from sqlalchemy.exc import IntegrityError
+
+from app.models.movie_model import PostgresMovie
+from app.repository.repository_base import RepositoryBase
+from app.schemas.movie_schemas import MovieCreateRequest, MovieStats, MovieUpdateRequest
+from app.schemas.tmdb_schemas import TMDBMovieDetails
+from app.utils.datetime_utils import parse_iso_date
+
+
+class PostgresMovieRepository(RepositoryBase):
+    """Repository class for PostgreSQL movie-related operations."""
+
+    async def create_movie(self, request: MovieCreateRequest) -> PostgresMovie:
+        """Create a new movie in PostgreSQL."""
+
+        async with self._session_provider() as session:
+            movie = PostgresMovie(
+                tmdb_id=request.tmdb_id,
+                title=request.title,
+            )
+            session.add(movie)
+            await session.commit()
+            await session.refresh(movie)
+            return movie
+
+    async def update_movie(self, movie_id: UUID, request: MovieUpdateRequest) -> None:
+        """Update a movie in PostgreSQL. No-op for missing or soft-deleted rows."""
+
+        async with self._session_provider() as session:
+            statement = (
+                update(PostgresMovie)
+                .where(
+                    PostgresMovie.id == movie_id,
+                    PostgresMovie.active(),
+                )
+                .values(
+                    title=request.title,
+                    updated_at=datetime.now(UTC),
+                )
+            )
+            await session.execute(statement)
+            await session.commit()
+
+    async def find_movie_by_id(self, movie_id: UUID) -> PostgresMovie | None:
+        """Find an active movie by UUID."""
+
+        async with self._session_provider() as session:
+            statement = select(PostgresMovie).where(
+                PostgresMovie.id == movie_id,
+                PostgresMovie.active(),
+            )
+            result = await session.execute(statement)
+            return result.scalar_one_or_none()
+
+    async def find_movie_by_tmdb_id(self, tmdb_id: int) -> PostgresMovie | None:
+        """Find an active movie by TMDB ID."""
+
+        async with self._session_provider() as session:
+            statement = select(PostgresMovie).where(
+                PostgresMovie.tmdb_id == tmdb_id,
+                PostgresMovie.active(),
+            )
+            result = await session.execute(statement)
+            return result.scalar_one_or_none()
+
+    async def create_from_tmdb_data(self, tmdb_data: TMDBMovieDetails) -> PostgresMovie:
+        """Create a movie from TMDB details or return existing row on duplicate TMDB ID."""
+
+        async with self._session_provider() as session:
+            movie = PostgresMovie(
+                tmdb_id=tmdb_data.id,
+                title=tmdb_data.title,
+                release_date=parse_iso_date(tmdb_data.release_date),
+                overview=tmdb_data.overview,
+                poster_path=tmdb_data.poster_path,
+                vote_average=tmdb_data.vote_average,
+                runtime=tmdb_data.runtime,
+                original_language=tmdb_data.original_language,
+                tmdb_payload=tmdb_data.model_dump(mode="json"),
+                tmdb_last_synced_at=datetime.now(UTC),
+            )
+
+            session.add(movie)
+
+            try:
+                await session.commit()
+                await session.refresh(movie)
+                return movie
+            except IntegrityError:
+                await session.rollback()
+                statement = select(PostgresMovie).where(
+                    PostgresMovie.tmdb_id == tmdb_data.id,
+                    PostgresMovie.active(),
+                )
+                result = await session.execute(statement)
+                existing_movie = result.scalar_one_or_none()
+                if existing_movie is None:
+                    raise
+                return existing_movie
+
+    async def find_movies_by_ids(self, movie_ids: set[UUID]) -> list[PostgresMovie]:
+        """Find active movies by UUID set."""
+
+        if not movie_ids:
+            return []
+
+        async with self._session_provider() as session:
+            statement = select(PostgresMovie).where(
+                PostgresMovie.id.in_(movie_ids),
+                PostgresMovie.active(),
+            )
+            result = await session.execute(statement)
+            return list(result.scalars().all())
+
+    async def get_movie_stats(self, movie_ids: set[UUID]) -> MovieStats:
+        """Compute runtime stats for active movies in PostgreSQL."""
+
+        if not movie_ids:
+            return MovieStats(total_runtime=0)
+
+        async with self._session_provider() as session:
+            statement = select(func.coalesce(func.sum(PostgresMovie.runtime), 0)).where(
+                PostgresMovie.id.in_(movie_ids),
+                PostgresMovie.active(),
+            )
+            result = await session.execute(statement)
+            total_runtime = result.scalar_one()
+            return MovieStats(total_runtime=int(total_runtime or 0))

--- a/app/repository/repository_base.py
+++ b/app/repository/repository_base.py
@@ -1,0 +1,18 @@
+"""Shared PostgreSQL repository primitives."""
+
+from collections.abc import Callable
+from contextlib import AbstractAsyncContextManager
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.postgres import get_async_session
+
+
+class RepositoryBase:
+    """Base class for repositories that require an async SQLAlchemy session."""
+
+    def __init__(
+        self,
+        session_provider: Callable[[], AbstractAsyncContextManager[AsyncSession]] = get_async_session,
+    ):
+        self._session_provider = session_provider

--- a/app/services/log_service.py
+++ b/app/services/log_service.py
@@ -1,5 +1,6 @@
 from beanie import PydanticObjectId
 
+from app.dependencies.repository_dependency import get_movie_repository
 from app.models.movie import Movie
 from app.repository.log_cache_repository import LogCacheRepository
 from app.repository.movie_rating_repository import MovieRatingRepository
@@ -33,7 +34,7 @@ class LogService:
         user_repository: UserRepository | None = None,
     ):
         self.log_repository = log_repository or LogCacheRepository()
-        resolved_movie_repository = movie_repository or MovieRepository()
+        resolved_movie_repository = movie_repository or get_movie_repository()
         if movie_service is None:
             movie_service = MovieService(resolved_movie_repository)
 
@@ -65,13 +66,10 @@ class LogService:
         If the movie doesn't exist in our database, it will be fetched from TMDB
         and created automatically.
         """
-        # Ensure movie exists (find or create from TMDB)
         movie: Movie = await self.movie_service.find_or_create_movie(tmdb_id=request.tmdb_id)
 
-        # Update the movieId in the request with the actual database ID
         request.movie_id = str(movie.id)
 
-        # Auto-populate posterPath from movie if not provided
         if not request.poster_path and movie.poster_path:
             request.poster_path = movie.poster_path
 
@@ -96,13 +94,10 @@ class LogService:
         log_id: PydanticObjectId,
         request: LogUpdateRequest,
     ) -> LogCreateResponse:
-        """
-        Update an existing log entry.
-        """
+        """Update an existing log entry."""
         log = await self.log_repository.update_log(log_id=log_id, user_id=user_id, update_request=request)
 
         if not log:
-            # Log not found or doesn't belong to user
             raise AppException(ErrorCodes.LOG_NOT_FOUND)
 
         movie = await self.movie_service.get_movie_by_id(log.movie_id)
@@ -123,9 +118,7 @@ class LogService:
         )
 
     async def delete_log(self, user_id: PydanticObjectId, log_id: PydanticObjectId) -> None:
-        """
-        Delete a viewing log entry owned by the given user.
-        """
+        """Delete a viewing log entry owned by the given user."""
         deleted_log = await self.log_repository.delete_log(log_id=log_id, user_id=user_id)
         if deleted_log is None:
             raise AppException(ErrorCodes.LOG_NOT_FOUND)
@@ -133,9 +126,7 @@ class LogService:
         await self.stats_cache_service.invalidate_user_stats(user_id)
 
     async def get_user_logs(self, user_id: PydanticObjectId, request: LogListRequest) -> LogListResponse:
-        """
-        Get list of user's viewing logs with optional filtering and sorting.
-        """
+        """Get list of user's viewing logs with optional filtering and sorting."""
 
         logs_data = await self.log_repository.find_logs_by_user_id(
             user_id=user_id,

--- a/app/services/movie_service.py
+++ b/app/services/movie_service.py
@@ -11,58 +11,22 @@ class MovieService:
         self.tmdb_service = tmdb_service or TMDBService.get_instance()
 
     async def get_movie_by_id(self, movie_id: PydanticObjectId) -> Movie | None:
-        """
-        Find a movie by its ID.
-
-        Args:
-            movie_id: The movie ID
-
-        Returns:
-            Movie: The found movie, or None
-        """
+        """Find a movie by its ID."""
         return await self.movie_repository.find_movie_by_id(movie_id)
 
     async def get_movie_by_tmdb_id(self, tmdb_id: int) -> Movie | None:
-        """
-        Find a movie by its TMDB ID.
-
-        Args:
-            tmdb_id: The TMDB movie ID
-
-        Returns:
-            Movie: The found movie, or None
-        """
+        """Find a movie by its TMDB ID."""
         return await self.movie_repository.find_movie_by_tmdb_id(tmdb_id)
 
     async def find_or_create_movie(self, tmdb_id: int) -> Movie:
-        """
-        Find a movie by TMDB ID, or create it if it doesn't exist.
+        """Find a movie by TMDB ID, or create it if it doesn't exist."""
 
-        This method:
-        1. Checks if the movie exists in our database
-        2. If not, fetches movie data from TMDB API
-        3. Creates the movie in our database
-        4. Returns the movie
-
-        Args:
-            tmdb_id: The TMDB movie ID
-
-        Returns:
-            Movie: The found or created movie
-
-        Raises:
-            Exception: If TMDB API request fails or movie not found on TMDB
-        """
-        # Check if movie already exists
         movie = await self.movie_repository.find_movie_by_tmdb_id(tmdb_id)
 
         if movie:
             return movie
 
-        # Movie doesn't exist, fetch from TMDB
         tmdb_data = await self.tmdb_service.get_movie_details(tmdb_id)
-
-        # Create movie from TMDB data
         movie = await self.movie_repository.create_from_tmdb_data(tmdb_data)
 
         return movie

--- a/app/services/stats_service.py
+++ b/app/services/stats_service.py
@@ -3,6 +3,7 @@ from datetime import date
 
 from beanie import PydanticObjectId
 
+from app.dependencies.repository_dependency import get_movie_repository
 from app.repository.log_cache_repository import LogCacheRepository
 from app.repository.movie_rating_repository import MovieRatingRepository
 from app.repository.movie_repository import MovieRepository
@@ -27,7 +28,7 @@ class StatsService:
     ):
         self.log_repository = log_repository or LogCacheRepository()
         self.movie_rating_repository = movie_rating_repository or MovieRatingRepository()
-        self.movie_repository = movie_repository or MovieRepository()
+        self.movie_repository = movie_repository or get_movie_repository()
         self.stats_cache_service = stats_cache_service or StatsCacheService()
 
     async def get_user_stats(

--- a/app/utils/datetime_utils.py
+++ b/app/utils/datetime_utils.py
@@ -13,3 +13,14 @@ def to_utc_datetime(value: date | datetime) -> datetime:
     if isinstance(value, datetime):
         return value if value.tzinfo else value.replace(tzinfo=UTC)
     return date_start_utc(value)
+
+
+def parse_iso_date(value: str | None, fmt: str = "%Y-%m-%d") -> datetime | None:
+    """Parse a date string into a naive ``datetime``, returning ``None`` on empty or malformed input."""
+    if not value:
+        return None
+
+    try:
+        return datetime.strptime(value, fmt)
+    except ValueError:
+        return None

--- a/db_migrations/__init__.py
+++ b/db_migrations/__init__.py
@@ -1,0 +1,1 @@
+"""PostgreSQL data migrations."""

--- a/db_migrations/m001_migrate_movies.py
+++ b/db_migrations/m001_migrate_movies.py
@@ -1,0 +1,171 @@
+"""Migrate movies data from MongoDB to PostgreSQL."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+
+from sqlalchemy import delete, select
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.movie_model import PostgresMovie
+from app.utils.id_utils import mongo_id_to_uuid
+
+BATCH_SIZE = 100
+
+
+def _parse_release_date(value: str | date | datetime | None) -> datetime | None:
+    if value is None:
+        return None
+
+    if isinstance(value, datetime):
+        return value.replace(tzinfo=None)
+
+    if isinstance(value, date):
+        return datetime(year=value.year, month=value.month, day=value.day)
+
+    if not isinstance(value, str) or not value:
+        return None
+
+    try:
+        return datetime.strptime(value, "%Y-%m-%d")
+    except ValueError:
+        return None
+
+
+def _normalize_movie_doc(mongo_movie: dict) -> dict:
+    return {
+        "id": mongo_id_to_uuid(str(mongo_movie["_id"])),
+        "tmdb_id": mongo_movie.get("tmdbId"),
+        "title": mongo_movie.get("title") or "",
+        "release_date": _parse_release_date(mongo_movie.get("releaseDate")),
+        "overview": mongo_movie.get("overview"),
+        "poster_path": mongo_movie.get("posterPath"),
+        "vote_average": mongo_movie.get("voteAverage"),
+        "runtime": mongo_movie.get("runtime"),
+        "original_language": mongo_movie.get("originalLanguage"),
+        "tmdb_payload": mongo_movie.get("tmdbPayload"),
+        "tmdb_last_synced_at": mongo_movie.get("tmdbLastSyncedAt"),
+        "deleted": bool(mongo_movie.get("deleted", False)),
+        "deleted_at": mongo_movie.get("deletedAt"),
+        "created_at": mongo_movie.get("createdAt") or datetime.now(UTC),
+        "updated_at": mongo_movie.get("updatedAt") or datetime.now(UTC),
+    }
+
+
+async def _count_dry_run_insertable_movies(
+    pg_session: AsyncSession,
+    batch: list[dict],
+    projected_tmdb_ids: set[int],
+) -> int:
+    """Count how many rows a dry-run batch would insert after uniqueness conflicts."""
+    batch_tmdb_ids = {values["tmdb_id"] for values in batch}
+    result = await pg_session.execute(select(PostgresMovie.tmdb_id).where(PostgresMovie.tmdb_id.in_(batch_tmdb_ids)))
+    occupied_tmdb_ids = projected_tmdb_ids | set(result.scalars().all())
+    insertable_tmdb_ids: set[int] = set()
+
+    for values in batch:
+        tmdb_id = values["tmdb_id"]
+        if tmdb_id in occupied_tmdb_ids or tmdb_id in insertable_tmdb_ids:
+            continue
+        insertable_tmdb_ids.add(tmdb_id)
+
+    projected_tmdb_ids.update(insertable_tmdb_ids)
+    return len(insertable_tmdb_ids)
+
+
+async def _flush_batch(
+    pg_session: AsyncSession,
+    batch: list[dict],
+    *,
+    dry_run: bool,
+    projected_tmdb_ids: set[int] | None = None,
+) -> int:
+    """Insert a batch and return how many rows were actually persisted."""
+    if not batch:
+        return 0
+
+    if dry_run:
+        return await _count_dry_run_insertable_movies(
+            pg_session,
+            batch,
+            projected_tmdb_ids if projected_tmdb_ids is not None else set(),
+        )
+
+    statement = (
+        insert(PostgresMovie)
+        .values(batch)
+        .on_conflict_do_nothing(index_elements=[PostgresMovie.tmdb_id])
+        .returning(PostgresMovie.tmdb_id)
+    )
+    result = await pg_session.execute(statement)
+    return len(result.scalars().all())
+
+
+async def up(mongo_db, pg_session: AsyncSession, dry_run: bool = False) -> None:
+    """Migrate active movies from MongoDB into PostgreSQL in batches."""
+
+    cursor = mongo_db.movies.find({"deleted": {"$ne": True}}, batch_size=BATCH_SIZE)
+
+    total = 0
+    inserted = 0
+    skipped = 0
+    batch: list[dict] = []
+    projected_tmdb_ids: set[int] = set()
+
+    for mongo_movie in cursor:
+        total += 1
+        values = _normalize_movie_doc(mongo_movie)
+        if values["tmdb_id"] is None:
+            skipped += 1
+            continue
+
+        batch.append(values)
+
+        if len(batch) >= BATCH_SIZE:
+            inserted_in_batch = await _flush_batch(
+                pg_session,
+                batch,
+                dry_run=dry_run,
+                projected_tmdb_ids=projected_tmdb_ids,
+            )
+            inserted += inserted_in_batch
+            skipped += len(batch) - inserted_in_batch
+            batch = []
+
+    if batch:
+        inserted_in_batch = await _flush_batch(
+            pg_session,
+            batch,
+            dry_run=dry_run,
+            projected_tmdb_ids=projected_tmdb_ids,
+        )
+        inserted += inserted_in_batch
+        skipped += len(batch) - inserted_in_batch
+
+    if not dry_run:
+        await pg_session.commit()
+
+    print(f"[movies-migration] total={total} inserted={inserted} skipped={skipped} dry_run={dry_run}")
+
+
+async def down(mongo_db, pg_session: AsyncSession) -> None:
+    """Rollback movie migration by deleting only the PostgreSQL rows derived from Mongo.
+
+    Scoped to UUIDs produced by ``mongo_id_to_uuid`` over the current Mongo
+    ``movies`` collection, so any PG rows added outside the migration are
+    preserved.
+    """
+
+    cursor = mongo_db.movies.find({}, batch_size=BATCH_SIZE)
+    derived_ids = [mongo_id_to_uuid(str(doc["_id"])) for doc in cursor]
+
+    deleted = 0
+    if derived_ids:
+        result = await pg_session.execute(
+            delete(PostgresMovie).where(PostgresMovie.id.in_(derived_ids)).returning(PostgresMovie.id)
+        )
+        deleted = len(result.scalars().all())
+        await pg_session.commit()
+
+    print(f"[movies-migration:down] derived_ids={len(derived_ids)} deleted={deleted}")

--- a/db_migrations/runner.py
+++ b/db_migrations/runner.py
@@ -1,0 +1,266 @@
+"""Runner for PostgreSQL-backed data migrations.
+
+This runner discovers ``mNNN_*`` modules in ``db_migrations/`` and
+applies only versions that have not yet been recorded in PostgreSQL.
+
+Usage:
+    python -m db_migrations.runner [--dry-run] [--yes]
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib
+import inspect
+import os
+import re
+import sys
+import urllib.parse
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from pymongo import MongoClient
+from pymongo.database import Database
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.db.postgres import get_database_url
+
+VERSIONS_TABLE = "data_migration_versions"
+CREATE_VERSIONS_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS data_migration_versions (
+    migration_id TEXT PRIMARY KEY,
+    applied_at TIMESTAMPTZ NOT NULL
+)
+"""
+SELECT_APPLIED_MIGRATIONS_SQL = "SELECT migration_id FROM data_migration_versions"
+INSERT_APPLIED_MIGRATION_SQL = """
+INSERT INTO data_migration_versions (migration_id, applied_at)
+VALUES (:migration_id, :applied_at)
+ON CONFLICT (migration_id) DO NOTHING
+"""
+
+
+def _get_mongodb_settings() -> tuple[str, str]:
+    """Get MongoDB connection settings from environment variables."""
+    mongodb_uri = os.getenv("MONGODB_URI")
+
+    if mongodb_uri:
+        parsed = urllib.parse.urlparse(mongodb_uri)
+        db_name_from_uri = parsed.path.lstrip("/") if parsed.path else None
+
+        if db_name_from_uri:
+            return mongodb_uri, db_name_from_uri
+
+        mongodb_db = os.getenv("MONGODB_DB", "cinelog_db")
+        return mongodb_uri, mongodb_db
+
+    mongodb_host = os.getenv("MONGODB_HOST", "localhost")
+    mongodb_port = int(os.getenv("MONGODB_PORT", "27017"))
+    mongodb_db = os.getenv("MONGODB_DB", "cinelog_db")
+
+    return f"mongodb://{mongodb_host}:{mongodb_port}/?directConnection=true", mongodb_db
+
+
+def _migration_id(version: str, module_name: str) -> str:
+    """Build a migration identifier from version + module name."""
+    return f"{version}_{module_name}"
+
+
+def _discover_migrations() -> list[tuple[str, str]]:
+    """Discover migration files in the ``db_migrations`` directory."""
+    migrations_dir = Path(__file__).resolve().parent
+    if not migrations_dir.exists():
+        return []
+
+    pattern = re.compile(r"^m(\d{3})_(.+)\.py$")
+    migrations: list[tuple[str, str]] = []
+
+    for filename in os.listdir(migrations_dir):
+        match = pattern.match(filename)
+        if not match or filename == "__init__.py":
+            continue
+
+        version = match.group(1)
+        module_name = match.group(2)
+        migrations.append((version, module_name))
+
+    migrations.sort(key=lambda x: x[0])
+    return migrations
+
+
+def _get_pending_migrations(
+    applied_versions: set[str], discovered_migrations: list[tuple[str, str]]
+) -> list[tuple[str, str]]:
+    """Return migrations that are discovered but not yet applied."""
+    return [(v, n) for v, n in discovered_migrations if _migration_id(v, n) not in applied_versions]
+
+
+def _load_migration_module(version: str, module_name: str) -> Any:
+    """Load a migration module dynamically."""
+    module_path = f"db_migrations.m{version}_{module_name}"
+    return importlib.import_module(module_path)
+
+
+async def _ensure_versions_table(pg_session: AsyncSession) -> None:
+    """Create data-migration versions table if it does not exist."""
+    await pg_session.execute(text(CREATE_VERSIONS_TABLE_SQL))
+    await pg_session.commit()
+
+
+async def _get_applied_versions(pg_session: AsyncSession) -> set[str]:
+    """Read applied migration identifiers from PostgreSQL."""
+    table_exists_result = await pg_session.execute(text(f"SELECT to_regclass('public.{VERSIONS_TABLE}')"))
+    table_name = table_exists_result.scalar_one_or_none()
+    if table_name is None:
+        return set()
+
+    result = await pg_session.execute(text(SELECT_APPLIED_MIGRATIONS_SQL))
+    migration_ids = result.scalars().all()
+    return {str(migration_id) for migration_id in migration_ids}
+
+
+async def _record_migration(pg_session: AsyncSession, version: str, module_name: str) -> None:
+    """Persist a migration as applied in PostgreSQL."""
+    await _ensure_versions_table(pg_session)
+    await pg_session.execute(
+        text(INSERT_APPLIED_MIGRATION_SQL),
+        {
+            "migration_id": _migration_id(version, module_name),
+            "applied_at": datetime.now(UTC),
+        },
+    )
+    await pg_session.commit()
+
+
+async def _run_up_migration(
+    mongo_db: Database,
+    pg_session: AsyncSession,
+    version: str,
+    module_name: str,
+    dry_run: bool = False,
+) -> bool:
+    """Run ``up(...)`` for one data migration."""
+    migration_name = _migration_id(version, module_name)
+    print(f"[db-migrate] Applying migration: {migration_name}")
+
+    module = _load_migration_module(version, module_name)
+    if not hasattr(module, "up"):
+        print(f"  [error] Migration {migration_name} does not define up()")
+        return False
+
+    up_fn = module.up
+    try:
+        result = up_fn(mongo_db, pg_session, dry_run=dry_run)
+        if inspect.isawaitable(result):
+            await result
+
+        if not dry_run:
+            await _record_migration(pg_session, version, module_name)
+
+        print(f"  [success] Migration {migration_name} applied")
+        return True
+    except Exception as exc:
+        print(f"  [error] Migration {migration_name} failed: {exc}")
+        return False
+
+
+async def _run_pending_migrations(
+    mongo_db: Database,
+    pg_session: AsyncSession,
+    dry_run: bool = False,
+    yes: bool = False,
+) -> bool:
+    """Discover and run all pending data migrations in order."""
+    applied_versions = await _get_applied_versions(pg_session)
+    discovered = _discover_migrations()
+    pending = _get_pending_migrations(applied_versions, discovered)
+
+    if not pending:
+        print("[db-migrate] No pending migrations")
+        return True
+
+    print(f"[db-migrate] Found {len(pending)} pending migration(s):")
+    for version, module_name in pending:
+        print(f"  - {_migration_id(version, module_name)}")
+
+    if not yes and not dry_run:
+        response = input("[db-migrate] Apply these migrations? (y/N): ")
+        if response.lower() != "y":
+            print("[db-migrate] Aborted")
+            return False
+
+    for version, module_name in pending:
+        if not await _run_up_migration(
+            mongo_db,
+            pg_session,
+            version,
+            module_name,
+            dry_run=dry_run,
+        ):
+            return False
+
+    if dry_run:
+        print("[db-migrate] Dry run complete (no changes made)")
+    else:
+        print("[db-migrate] All pending migrations applied successfully")
+
+    return True
+
+
+async def _run() -> int:
+    """Run data migration CLI asynchronously."""
+    parser = argparse.ArgumentParser(description="Run PostgreSQL data migrations")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show pending data migrations without applying them",
+    )
+    parser.add_argument("--yes", action="store_true", help="Skip confirmation prompts")
+
+    args = parser.parse_args()
+
+    database_url = get_database_url(required=True)
+    mongo_uri, mongo_db_name = _get_mongodb_settings()
+
+    mongo_client: MongoClient | None = None
+    engine = create_async_engine(database_url, pool_pre_ping=True)
+    session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    try:
+        mongo_client = MongoClient(mongo_uri)
+        mongo_db = mongo_client[mongo_db_name]
+
+        print(f"[db-migrate] Connected to MongoDB: {mongo_db_name}")
+
+        async with session_factory() as pg_session:
+            success = await _run_pending_migrations(
+                mongo_db,
+                pg_session,
+                dry_run=args.dry_run,
+                yes=args.yes,
+            )
+
+        return 0 if success else 1
+    except Exception as exc:
+        print(f"[db-migrate] Failed: {exc}")
+        return 1
+    finally:
+        if mongo_client is not None:
+            try:
+                mongo_client.close()
+            except Exception as exc:
+                print(f"[db-migrate] Warning: failed to close MongoDB client: {exc}")
+
+        await engine.dispose()
+
+
+def main() -> int:
+    """Synchronous entrypoint for ``python -m db_migrations.runner``."""
+    return asyncio.run(_run())
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,7 +52,12 @@ Developer-facing documentation covering infrastructure, implementation details, 
 | `make test-e2e` | Start e2e MongoDB, run e2e tests, then stop e2e MongoDB |
 | `make migrate` | Run pending database migrations with confirmation |
 | `make migrate-dry-run` | Preview pending migrations without applying changes |
+| `make db-data-migrate` | Run pending PostgreSQL data migrations from `db_migrations/` |
+| `make db-data-migrate-dry-run` | Preview pending PostgreSQL data migrations without applying changes |
+| `make migrate-all` | Run all pending Mongo migrations, PostgreSQL schema migrations, and PostgreSQL data migrations |
+| `make migrate-all-dry-run` | Preview all pending migration systems without applying changes |
 | `make db-schema-migrate` | Run Alembic schema migrations against `DATABASE_URL` |
+| `make db-schema-migrate-dry-run` | Print Alembic schema migration SQL without applying it |
 | `make db-schema-rollback` | Roll back the latest Alembic schema migration |
 | `make lint` | Run Ruff linter |
 | `make format` | Format code with Ruff and apply auto-fixes |

--- a/docs/technical/migrations.md
+++ b/docs/technical/migrations.md
@@ -2,6 +2,8 @@
 
 This guide covers the Cinelog database migration system — a lightweight, versioned migration framework for MongoDB.
 
+For PostgreSQL schema/data migration commands and unified cross-backend execution, see [Postgres Migration](postgres-migration.md).
+
 ## Overview
 
 The migration system is a custom Python-based solution that uses PyMongo (sync) to discover and run numbered migration scripts. It tracks applied migrations in the `migration_versions` collection and supports dry-run mode for impact preview before execution.
@@ -126,7 +128,7 @@ Example dry-run output:
 
 ### File Naming
 
-Create a new file in `migrations/` with a 3-digit prefix and descriptive name:
+Create a new file in `migrations/` with a 3-digit version prefix and descriptive name:
 
 ```
 migrations/002_add_user_email_verified.py

--- a/docs/technical/postgres-migration.md
+++ b/docs/technical/postgres-migration.md
@@ -7,7 +7,7 @@ The current setup includes:
 - SQLAlchemy asyncio, asyncpg, and Alembic dependencies
 - Async PostgreSQL engine/session helpers in `app/db/postgres.py`
 - Optional application startup initialization driven by `DATABASE_URL`
-- Empty async Alembic scaffolding
+- Async Alembic scaffolding and schema migrations
 - Local and e2e Docker Compose PostgreSQL services
 - Deterministic Mongo ObjectId to PostgreSQL UUID conversion
 
@@ -19,7 +19,14 @@ Set `DATABASE_URL` when you want the app or Alembic to initialize PostgreSQL:
 DATABASE_URL=postgresql+asyncpg://cinelog:cinelog@localhost:5432/cinelog_db
 ```
 
-The app still starts without `DATABASE_URL` while MongoDB repositories remain active. If the database backend is set to `postgres` through `DB_BACKEND`, startup raises a clear configuration error when `DATABASE_URL` is missing.
+Repository activation is controlled through `DB_BACKEND`:
+
+```bash
+DB_BACKEND=mongo      # default during mixed-mode migration
+# DB_BACKEND=postgres # reserved for later cutover stages
+```
+
+If `DB_BACKEND=postgres` is set while repository dependencies are still unsafe for mixed mode, the app fails fast with a clear activation error.
 
 ## Local Services
 
@@ -43,18 +50,42 @@ The e2e compose file also includes PostgreSQL on host port `5433` with database 
 
 ## Schema Migrations
 
-Alembic is initialized for async SQLAlchemy migrations, but no application table migrations are included in this setup.
-
 Run migrations:
 
 ```bash
 make db-schema-migrate
 ```
 
+Preview schema migration SQL without applying changes:
+
+```bash
+make db-schema-migrate-dry-run
+```
+
 Roll back the latest migration:
 
 ```bash
 make db-schema-rollback
+```
+
+Run pending PostgreSQL data migrations:
+
+```bash
+make db-data-migrate
+```
+
+Preview pending PostgreSQL data migrations:
+
+```bash
+make db-data-migrate-dry-run
+```
+
+The movie data migration dry-run checks current PostgreSQL `tmdb_id` conflicts, so its inserted/skipped totals match a real run.
+
+Run all pending migration systems (Mongo custom runner + Alembic schema + PostgreSQL data):
+
+```bash
+make migrate-all
 ```
 
 ## Deterministic IDs
@@ -67,22 +98,48 @@ from app.utils.id_utils import mongo_id_to_uuid
 postgres_id = mongo_id_to_uuid("507f1f77bcf86cd799439011")
 ```
 
-The helper uses UUID's built-in `NAMESPACE_URL` namespace. It maps only the Mongo ObjectId value, without including the collection name.
+The helper uses UUID's built-in `NAMESPACE_URL` namespace and maps only the Mongo ObjectId value. The same Mongo ObjectId always produces the same UUID.
 
-The same Mongo ObjectId always produces the same UUID, even when that ObjectId is referenced from another collection as a foreign key.
+## Movie Collection Migration
+
+`#126` introduces the first repository/data migration for movies.
+
+### Repository split
+
+- Legacy Mongo implementation lives in `app/repository/movie_repository.py` as `MovieRepository` (deprecated during migration).
+- New PostgreSQL implementation lives in `app/repository/postgres_movie_repository.py` as `PostgresMovieRepository`. It is prepared but intentionally not wired into dependency injection — see [Activation Guardrails](#activation-guardrails).
+
+### Table shape
+
+Alembic migration creates `movies` with canonical fields (`title`, `release_date`, `runtime`, etc.) plus provider cache fields:
+
+- `tmdb_payload JSONB NULL`
+- `tmdb_last_synced_at TIMESTAMPTZ NULL`
+
+### Data migration script
+
+Use `db_migrations/m001_migrate_movies.py` with async session wiring:
+
+- `up(mongo_db, pg_session, dry_run=False)` migrates active (non-deleted) movies
+- `down(mongo_db, pg_session)` clears the PostgreSQL movies table
+
+Migration rules:
+
+- Skip `deleted=True` Mongo rows
+- Map Mongo `_id` -> Postgres UUID via `mongo_id_to_uuid(...)`
+- Idempotent inserts by `tmdb_id` uniqueness
+- Progress reporting (total / inserted / skipped)
 
 ## Activation Guardrails
 
-PostgreSQL repositories should only be activated through dependency wiring once their ID dependencies are ready. Public response IDs and JWT subjects should continue to use Mongo ObjectId strings until the core cutover has an explicit compatibility plan.
+PostgreSQL movie activation is intentionally blocked in mixed mode while `LogRepository` and `MovieRatingRepository` still persist/query Mongo ObjectId movie references.
 
-Do not switch a repository to PostgreSQL if an active MongoDB repository still needs to store or query IDs produced only by PostgreSQL.
+Activation must happen through dependency wiring (`app/dependencies/repository_dependency.py`), not controller imports.
 
 ## Later Tickets
 
 Future migration tickets should add:
 
-- SQLAlchemy table models
-- Alembic migrations that create application tables and indexes
-- PostgreSQL repository implementations
-- Data migration runner and mapping/version tables
-- Repository activation and rollback flags
+- User/movie_rating/log PostgreSQL repository migrations
+- Safe full backend cutover once ID dependencies are resolved
+- Final MongoDB decommissioning

--- a/docs/technical/service-dependencies.md
+++ b/docs/technical/service-dependencies.md
@@ -1,14 +1,22 @@
 # Service Dependencies
 
-Controllers receive services through FastAPI `Depends(...)`. Each service owns and instantiates its repositories directly — there is no separate repository dependency layer or protocol indirection.
+Controllers receive services through FastAPI `Depends(...)`.
 
 ## Conventions
 
 - Service providers live in `app/dependencies/service_dependency.py`.
-- Each provider is `@lru_cache`-d, so it returns the same process-wide service instance.
-- Each service constructs its own repositories. Tests can pass a mock via the service's optional repository constructor parameters; production code does not.
-- Cache decorators (currently only `LogCacheRepository`) are wired at the dependency layer — the service stays cache-agnostic.
-- Controllers do not hold module-level service singletons. Endpoints use `Depends(get_*_service)` exclusively.
+- Repository providers live in `app/dependencies/repository_dependency.py`.
+- Each provider is `@lru_cache`-d, so it returns the same process-wide instance.
+- Controllers use `Depends(get_*_service)` exclusively.
+
+## Repository Provider Guardrails
+
+`get_movie_repository()` is the runtime activation gate for movie persistence:
+
+- `DB_BACKEND` unset or `mongo` -> returns Mongo-backed `MovieRepository`.
+- `DB_BACKEND=postgres` while mixed-mode is unsafe -> raises `RepositoryActivationError` (fail-fast).
+
+This prevents accidental cutover while Mongo `LogRepository` and `MovieRatingRepository` still depend on ObjectId `movie_id` references.
 
 ## Service Providers
 
@@ -40,11 +48,9 @@ async def create_log(
 
 ## Test Overrides
 
-Because every `get_*_service` provider is `@lru_cache`-d, the same instance is returned to the controller (via `Depends`) and to the test code (via direct call). This gives two equally valid override patterns. Pick the one that matches how much of the service you want to replace.
+Because every `get_*_service` provider is `@lru_cache`-d, the same instance is returned to the controller (via `Depends`) and to test code (via direct call).
 
-### Pattern 1 — Patch a single method
-
-Use this when the test only cares about one method on the service. The cached instance keeps its identity; only the named method is swapped for the duration of the test, then restored automatically.
+### Pattern 1: Patch a single service method
 
 ```python
 from unittest.mock import AsyncMock, patch
@@ -52,24 +58,14 @@ from unittest.mock import AsyncMock, patch
 from app.dependencies.service_dependency import get_log_service
 
 
-class TestCreateLog:
-    @patch.object(get_log_service(), "create_log", new_callable=AsyncMock)
-    def test_create_log_success(self, mock_create_log, client, sample_log_response):
-        mock_create_log.return_value = sample_log_response
-
-        response = client.post("/v1/logs/", json={...}, cookies={...})
-
-        assert response.status_code == 201
-        mock_create_log.assert_awaited_once()
+@patch.object(get_log_service(), "create_log", new_callable=AsyncMock)
+def test_create_log_success(mock_create_log, client):
+    mock_create_log.return_value = ...
+    response = client.post("/v1/logs/", json={...}, cookies={...})
+    assert response.status_code == 201
 ```
 
-This is the dominant pattern in `tests/units/controllers/` because most controller tests exercise one endpoint at a time.
-
-> ⚠️ Do not call `get_log_service.cache_clear()` (or any `get_*_service.cache_clear()`) during a test that uses `patch.object(get_*_service(), ...)`. The decorator evaluates `get_*_service()` once at import and patches that instance; clearing the cache makes the controller resolve a fresh, unpatched instance on the next request, and the test would silently pass for the wrong reason — or fail in a confusing way.
-
-### Pattern 2 — Replace the whole service via `dependency_overrides`
-
-Use this when the test needs to swap out many methods on the service, or when the test fixture needs full control over how the service behaves (e.g. a fully-faked service with shared state across calls).
+### Pattern 2: Replace full service via `dependency_overrides`
 
 ```python
 from unittest.mock import AsyncMock, MagicMock
@@ -91,50 +87,8 @@ def test_create_then_list(client):
         app.dependency_overrides.pop(get_log_service, None)
 ```
 
-`dependency_overrides` is keyed by the provider function itself, **not** the service instance — that's what makes the override active for the duration of the request.
-
-### Combining with auth overrides
-
-Most controller tests also need to bypass `auth_dependency`. The two override styles compose cleanly:
-
-```python
-from app.dependencies.auth_dependency import auth_dependency
-from app.dependencies.service_dependency import get_log_service
-
-
-@pytest.fixture
-def override_auth():
-    return lambda: PydanticObjectId()
-
-
-@patch.object(get_log_service(), "create_log", new_callable=AsyncMock)
-def test_create_log_authenticated(mock_create_log, client, override_auth):
-    app.dependency_overrides[auth_dependency] = override_auth
-    mock_create_log.return_value = ...
-    try:
-        response = client.post("/v1/logs/", ...)
-        assert response.status_code == 201
-    finally:
-        app.dependency_overrides.pop(auth_dependency, None)
-```
-
-Always remove your override at the end of the test — `dependency_overrides` is module-level state and leaks across tests if not cleaned up. Prefer `pop(specific_key, None)` over `app.dependency_overrides = {}`: the latter silently wipes overrides set by other fixtures (e.g. an autouse session fixture) and is a footgun. Reserve `app.dependency_overrides = {}` for top-level pytest teardown fixtures that intentionally own all override state.
-
-### When to prefer which pattern
-
-| Use Pattern 1 (`patch.object`) when | Use Pattern 2 (`dependency_overrides`) when |
-|---|---|
-| Mocking one or two methods on the service | Replacing the entire service with a fake |
-| Test only exercises a single endpoint | Test exercises multiple endpoints with cross-call state |
-| You want minimal setup and automatic cleanup | You need to control method behavior in a fixture |
-
-## Why no protocol layer?
-
-A repository `Protocol` would only be useful if a second backend implementation existed. Today the repositories return Beanie `Document` subclasses (`Log`, `Movie`, `User`, `MovieRating`), which carry MongoDB-specific machinery (`PydanticObjectId`, `find_one`, `save`, `Settings`/indexes). A non-Mongo repository couldn't satisfy that contract without dragging Mongo concepts into a different store, so the abstraction wouldn't deliver real flexibility.
-
-If a second backend is added later, the prerequisite is splitting persistence-neutral domain types from the Beanie `Document` models — at that point repository protocols become genuinely load-bearing and can be reintroduced.
-
 ## Related Docs
 
 - [Redis Caching](redis-caching.md)
 - [TMDB Service](tmdb-service.md)
+- [Postgres Migration](postgres-migration.md)

--- a/main.py
+++ b/main.py
@@ -4,7 +4,6 @@ load_dotenv()
 
 from app import app as app  # noqa: E402, F401
 
-
 if __name__ == "__main__":
     import uvicorn
 

--- a/migrations/runner.py
+++ b/migrations/runner.py
@@ -1,7 +1,7 @@
 """Migration runner for Cinelog database migrations.
 
 This module provides a CLI tool to discover and run database migrations.
-Migrations are numbered Python files in the migrations/ directory.
+Migrations are ``NNN_*`` Python files in the migrations/ directory.
 
 Usage:
     python -m migrations.runner [--dry-run] [--yes] [--rollback <version>]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,8 @@ dev = [
     "pytest==9.0.2",
     "pytest-asyncio==1.3.0",
     "pytest-cov==7.1.0",
+    "pytest-postgresql==8.1.0",
+    "psycopg[binary]==3.3.4",
     "ruff==0.15.7",
     "pip-audit>=2.10.0",
 ]
@@ -82,3 +84,4 @@ disallow_untyped_defs = false
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
+

--- a/tests/units/db_migrations/test_migrate_movies.py
+++ b/tests/units/db_migrations/test_migrate_movies.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+import importlib.util
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+MIGRATION_FILE = Path(__file__).resolve().parents[3] / "db_migrations" / "m001_migrate_movies.py"
+spec = importlib.util.spec_from_file_location("migrate_movies_module", MIGRATION_FILE)
+assert spec is not None
+assert spec.loader is not None
+migrate_movies = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(migrate_movies)
+
+
+class _FakeMongoCollection:
+    def __init__(self, docs: list[dict]):
+        self._docs = docs
+        self.last_query: dict | None = None
+        self.last_batch_size: int | None = None
+
+    def find(self, query: dict, batch_size: int | None = None):
+        self.last_query = query
+        self.last_batch_size = batch_size
+        if query == {"deleted": {"$ne": True}}:
+            return iter(doc for doc in self._docs if doc.get("deleted") is not True)
+
+        return iter(self._docs)
+
+
+class _FakeMongoDB:
+    def __init__(self, docs: list[dict]):
+        self.movies = _FakeMongoCollection(docs)
+
+
+def _mock_scalar_result(values: list[int]) -> MagicMock:
+    """Build a SQLAlchemy-result-like mock whose ``.scalars().all()`` returns ``values``."""
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = values
+    return result
+
+
+@pytest.mark.asyncio
+async def test_migrate_movies_up_skips_deleted_and_missing_tmdb_id(capsys):
+    mongo_db = _FakeMongoDB(
+        [
+            {"_id": "507f1f77bcf86cd799439011", "tmdbId": 10, "title": "A", "deleted": False},
+            {"_id": "507f1f77bcf86cd799439012", "tmdbId": 11, "title": "B", "deleted": True},
+            {"_id": "507f1f77bcf86cd799439013", "title": "C", "deleted": False},
+        ]
+    )
+
+    pg_session = AsyncMock()
+    pg_session.execute.return_value = _mock_scalar_result([10])
+
+    await migrate_movies.up(mongo_db, pg_session, dry_run=False)
+
+    assert mongo_db.movies.last_query == {"deleted": {"$ne": True}}
+    assert mongo_db.movies.last_batch_size == migrate_movies.BATCH_SIZE
+    pg_session.execute.assert_awaited_once()
+    pg_session.commit.assert_awaited_once()
+
+    captured = capsys.readouterr().out
+    assert "total=2" in captured
+    assert "inserted=1" in captured
+    assert "skipped=1" in captured
+
+
+@pytest.mark.asyncio
+async def test_migrate_movies_up_dry_run_reports_progress(capsys):
+    mongo_db = _FakeMongoDB([{"_id": "507f1f77bcf86cd799439011", "tmdbId": 10, "title": "A", "deleted": False}])
+    pg_session = AsyncMock()
+    pg_session.execute.return_value = _mock_scalar_result([])
+
+    await migrate_movies.up(mongo_db, pg_session, dry_run=True)
+
+    assert mongo_db.movies.last_query == {"deleted": {"$ne": True}}
+    pg_session.execute.assert_awaited_once()
+    pg_session.commit.assert_not_awaited()
+
+    captured = capsys.readouterr().out
+    assert "dry_run=True" in captured
+    assert "inserted=1" in captured
+    assert "skipped=0" in captured
+
+
+@pytest.mark.asyncio
+async def test_migrate_movies_up_dry_run_accounts_for_existing_and_prior_batch_conflicts(capsys, monkeypatch):
+    monkeypatch.setattr(migrate_movies, "BATCH_SIZE", 2)
+
+    mongo_db = _FakeMongoDB(
+        [
+            {"_id": "507f1f77bcf86cd799439011", "tmdbId": 10, "title": "A", "deleted": False},
+            {"_id": "507f1f77bcf86cd799439012", "tmdbId": 11, "title": "B", "deleted": False},
+            {"_id": "507f1f77bcf86cd799439013", "tmdbId": 10, "title": "A again", "deleted": False},
+            {"_id": "507f1f77bcf86cd799439014", "tmdbId": 12, "title": "C", "deleted": False},
+        ]
+    )
+
+    pg_session = AsyncMock()
+    pg_session.execute.side_effect = [
+        _mock_scalar_result([11]),
+        _mock_scalar_result([]),
+    ]
+
+    await migrate_movies.up(mongo_db, pg_session, dry_run=True)
+
+    assert pg_session.execute.await_count == 2
+    pg_session.commit.assert_not_awaited()
+
+    captured = capsys.readouterr().out
+    assert "total=4" in captured
+    assert "inserted=2" in captured
+    assert "skipped=2" in captured
+    assert "dry_run=True" in captured
+
+
+@pytest.mark.asyncio
+async def test_migrate_movies_up_handles_datetime_release_date():
+    release_date = datetime(2024, 1, 2, 12, 30, tzinfo=UTC)
+    mongo_db = _FakeMongoDB(
+        [
+            {
+                "_id": "507f1f77bcf86cd799439011",
+                "tmdbId": 10,
+                "title": "A",
+                "releaseDate": release_date,
+                "deleted": False,
+            }
+        ]
+    )
+
+    pg_session = AsyncMock()
+    pg_session.execute.return_value = _mock_scalar_result([10])
+
+    await migrate_movies.up(mongo_db, pg_session, dry_run=False)
+
+    statement = pg_session.execute.await_args.args[0]
+    compiled_params = statement.compile().params
+    release_date_values = [v for k, v in compiled_params.items() if k.startswith("release_date")]
+    assert release_date_values == [datetime(2024, 1, 2, 12, 30)]
+
+
+@pytest.mark.asyncio
+async def test_migrate_movies_up_flushes_in_batches(capsys, monkeypatch):
+    monkeypatch.setattr(migrate_movies, "BATCH_SIZE", 2)
+
+    mongo_db = _FakeMongoDB(
+        [
+            {"_id": f"507f1f77bcf86cd79943901{i}", "tmdbId": 100 + i, "title": f"M{i}", "deleted": False}
+            for i in range(5)
+        ]
+    )
+
+    pg_session = AsyncMock()
+    pg_session.execute.side_effect = [
+        _mock_scalar_result([100, 101]),
+        _mock_scalar_result([102, 103]),
+        _mock_scalar_result([104]),
+    ]
+
+    await migrate_movies.up(mongo_db, pg_session, dry_run=False)
+
+    assert pg_session.execute.await_count == 3
+    pg_session.commit.assert_awaited_once()
+
+    captured = capsys.readouterr().out
+    assert "total=5" in captured
+    assert "inserted=5" in captured
+    assert "skipped=0" in captured
+
+
+@pytest.mark.asyncio
+async def test_migrate_movies_down_is_noop_when_mongo_empty(capsys):
+    mongo_db = _FakeMongoDB([])
+    pg_session = AsyncMock()
+
+    await migrate_movies.down(mongo_db, pg_session)
+
+    pg_session.execute.assert_not_awaited()
+    pg_session.commit.assert_not_awaited()
+
+    captured = capsys.readouterr().out
+    assert "derived_ids=0" in captured
+    assert "deleted=0" in captured
+
+
+@pytest.mark.asyncio
+async def test_migrate_movies_down_deletes_only_derived_ids(capsys):
+    from app.utils.id_utils import mongo_id_to_uuid
+
+    mongo_db = _FakeMongoDB(
+        [
+            {"_id": "507f1f77bcf86cd799439011", "tmdbId": 10, "title": "A"},
+            {"_id": "507f1f77bcf86cd799439012", "tmdbId": 11, "title": "B"},
+        ]
+    )
+
+    pg_session = AsyncMock()
+    delete_result = MagicMock()
+    delete_result.scalars.return_value.all.return_value = [
+        mongo_id_to_uuid("507f1f77bcf86cd799439011"),
+        mongo_id_to_uuid("507f1f77bcf86cd799439012"),
+    ]
+    pg_session.execute.return_value = delete_result
+
+    await migrate_movies.down(mongo_db, pg_session)
+
+    pg_session.execute.assert_awaited_once()
+    pg_session.commit.assert_awaited_once()
+
+    statement = pg_session.execute.await_args.args[0]
+    sql = str(statement.compile(compile_kwargs={"literal_binds": True}))
+    assert mongo_id_to_uuid("507f1f77bcf86cd799439011").hex in sql
+    assert mongo_id_to_uuid("507f1f77bcf86cd799439012").hex in sql
+
+    captured = capsys.readouterr().out
+    assert "derived_ids=2" in captured
+    assert "deleted=2" in captured

--- a/tests/units/db_migrations/test_runner.py
+++ b/tests/units/db_migrations/test_runner.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from db_migrations import runner
+
+
+def test_migration_id():
+    assert runner._migration_id("001", "migrate_movies") == "001_migrate_movies"
+
+
+def test_get_pending_migrations():
+    applied = {"001_first"}
+    discovered = [("001", "first"), ("002", "second"), ("003", "third")]
+
+    pending = runner._get_pending_migrations(applied, discovered)
+
+    assert pending == [("002", "second"), ("003", "third")]
+
+
+def test_discover_migrations_filters_and_sorts(monkeypatch):
+    monkeypatch.setattr(runner.Path, "exists", lambda _: True)
+    monkeypatch.setattr(
+        runner.os,
+        "listdir",
+        lambda _: [
+            "m003_third.py",
+            "notes.txt",
+            "m001_first.py",
+            "__init__.py",
+            "runner.py",
+            "m002_second.py",
+        ],
+    )
+
+    discovered = runner._discover_migrations()
+
+    assert discovered == [("001", "first"), ("002", "second"), ("003", "third")]
+
+
+@pytest.mark.asyncio
+async def test_run_pending_migrations_dry_run(monkeypatch):
+    async def _applied_versions(_session):
+        return {"001_first"}
+
+    monkeypatch.setattr(runner, "_get_applied_versions", _applied_versions)
+    monkeypatch.setattr(runner, "_discover_migrations", lambda: [("001", "first"), ("002", "second")])
+
+    calls: list[tuple[str, str, bool]] = []
+
+    async def _run_up(_mongo_db, _pg_session, version, module_name, dry_run=False):
+        calls.append((version, module_name, dry_run))
+        return True
+
+    monkeypatch.setattr(runner, "_run_up_migration", _run_up)
+
+    success = await runner._run_pending_migrations(
+        mongo_db=MagicMock(),
+        pg_session=AsyncMock(),
+        dry_run=True,
+        yes=False,
+    )
+
+    assert success is True
+    assert calls == [("002", "second", True)]
+
+
+@pytest.mark.asyncio
+async def test_run_pending_migrations_no_pending(monkeypatch):
+    async def _applied_versions(_session):
+        return {"001_first"}
+
+    monkeypatch.setattr(runner, "_get_applied_versions", _applied_versions)
+    monkeypatch.setattr(runner, "_discover_migrations", lambda: [("001", "first")])
+
+    run_up = AsyncMock(return_value=True)
+    monkeypatch.setattr(runner, "_run_up_migration", run_up)
+
+    success = await runner._run_pending_migrations(
+        mongo_db=MagicMock(),
+        pg_session=AsyncMock(),
+        dry_run=False,
+        yes=True,
+    )
+
+    assert success is True
+    run_up.assert_not_awaited()

--- a/tests/units/dependencies/test_repository_dependency.py
+++ b/tests/units/dependencies/test_repository_dependency.py
@@ -1,0 +1,26 @@
+import pytest
+
+from app.dependencies.repository_dependency import RepositoryActivationError, get_movie_repository
+from app.repository.movie_repository import MovieRepository
+
+
+@pytest.fixture(autouse=True)
+def clear_movie_repository_cache():
+    get_movie_repository.cache_clear()
+    yield
+    get_movie_repository.cache_clear()
+
+
+def test_get_movie_repository_defaults_to_mongo(monkeypatch):
+    monkeypatch.delenv("DB_BACKEND", raising=False)
+
+    repository = get_movie_repository()
+
+    assert isinstance(repository, MovieRepository)
+
+
+def test_get_movie_repository_raises_for_unsafe_postgres_activation(monkeypatch):
+    monkeypatch.setenv("DB_BACKEND", "postgres")
+
+    with pytest.raises(RepositoryActivationError, match="not yet safe"):
+        get_movie_repository()

--- a/tests/units/repository/test_postgres_movie_repository.py
+++ b/tests/units/repository/test_postgres_movie_repository.py
@@ -1,0 +1,270 @@
+"""Unit tests for ``PostgresMovieRepository``.
+
+A real PostgreSQL instance is spawned per test session by ``pytest-postgresql``
+(via ``pg_ctl``), and a fresh database is created/dropped per test by
+``DatabaseJanitor``. SQLAlchemy async sessions connect to that database through
+``asyncpg``; the repository's ``session_provider`` seam is used to inject the
+test session without monkeypatching module globals.
+
+The host needs PostgreSQL binaries available on ``PATH`` (``brew install
+postgresql@16`` on macOS, ``apt-get install postgresql`` on Debian/Ubuntu).
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from pytest_postgresql.janitor import DatabaseJanitor
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.models.base_model import Base
+from app.models.movie_model import PostgresMovie
+from app.repository.postgres_movie_repository import PostgresMovieRepository
+from app.schemas.movie_schemas import MovieCreateRequest, MovieUpdateRequest
+from app.schemas.tmdb_schemas import TMDBMovieDetails
+
+
+def _async_url(pg, dbname: str) -> str:
+    return f"postgresql+asyncpg://{pg.user}:{pg.password}@{pg.host}:{pg.port}/{dbname}"
+
+
+@pytest_asyncio.fixture
+async def pg_engine(postgresql_proc):
+    """Create a fresh database per test and return an async SQLAlchemy engine."""
+    dbname = f"cinelog_test_{uuid4().hex[:8]}"
+
+    with DatabaseJanitor(
+        user=postgresql_proc.user,
+        host=postgresql_proc.host,
+        port=postgresql_proc.port,
+        dbname=dbname,
+        version=postgresql_proc.version,
+        password=postgresql_proc.password,
+    ):
+        engine = create_async_engine(_async_url(postgresql_proc, dbname))
+        async with engine.begin() as connection:
+            await connection.execute(text("CREATE EXTENSION IF NOT EXISTS pgcrypto"))
+            await connection.run_sync(Base.metadata.create_all)
+
+        try:
+            yield engine
+        finally:
+            await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def session_factory(pg_engine):
+    return async_sessionmaker(pg_engine, class_=AsyncSession, expire_on_commit=False)
+
+
+@pytest.fixture
+def repository(session_factory) -> PostgresMovieRepository:
+    @asynccontextmanager
+    async def _provider():
+        async with session_factory() as session:
+            yield session
+
+    return PostgresMovieRepository(session_provider=_provider)
+
+
+@pytest_asyncio.fixture
+async def seed_session(session_factory):
+    async with session_factory() as session:
+        yield session
+
+
+def _tmdb_details(tmdb_id: int, *, release_date: str | None = "2024-01-01") -> TMDBMovieDetails:
+    return TMDBMovieDetails(
+        id=tmdb_id,
+        title=f"Movie {tmdb_id}",
+        original_title=f"Movie {tmdb_id} Original",
+        release_date=release_date,
+        overview=f"Overview {tmdb_id}",
+        poster_path=f"/{tmdb_id}.jpg",
+        backdrop_path=None,
+        vote_average=7.5,
+        vote_count=100,
+        runtime=120,
+        budget=10,
+        revenue=100,
+        status="Released",
+        tagline=None,
+        homepage=None,
+        imdb_id=None,
+        original_language="en",
+        popularity=10.0,
+        adult=False,
+        genres=[],
+        production_companies=[],
+        production_countries=[],
+        spoken_languages=[],
+    )
+
+
+async def _add(seed_session: AsyncSession, *movies: PostgresMovie) -> None:
+    seed_session.add_all(movies)
+    await seed_session.commit()
+    for movie in movies:
+        await seed_session.refresh(movie)
+
+
+@pytest.mark.asyncio
+async def test_create_movie_persists_row(repository: PostgresMovieRepository, seed_session: AsyncSession):
+    movie = await repository.create_movie(MovieCreateRequest(title="Inception", tmdb_id=111))
+
+    assert movie.id is not None
+    assert movie.title == "Inception"
+    assert movie.tmdb_id == 111
+    assert movie.deleted is False
+
+    persisted = await seed_session.get(PostgresMovie, movie.id)
+    assert persisted is not None
+    assert persisted.title == "Inception"
+
+
+@pytest.mark.asyncio
+async def test_update_movie_changes_title_and_touches_updated_at(
+    repository: PostgresMovieRepository, seed_session: AsyncSession
+):
+    movie = PostgresMovie(tmdb_id=222, title="Old")
+    await _add(seed_session, movie)
+    original_updated_at = movie.updated_at
+
+    await repository.update_movie(movie.id, MovieUpdateRequest(title="New"))
+
+    await seed_session.refresh(movie)
+    assert movie.title == "New"
+    assert movie.updated_at >= original_updated_at
+
+
+@pytest.mark.asyncio
+async def test_update_movie_is_silent_when_id_missing(repository: PostgresMovieRepository):
+    await repository.update_movie(uuid4(), MovieUpdateRequest(title="Ghost"))
+
+
+@pytest.mark.asyncio
+async def test_update_movie_does_not_touch_soft_deleted_rows(
+    repository: PostgresMovieRepository, seed_session: AsyncSession
+):
+    deleted_movie = PostgresMovie(
+        tmdb_id=223,
+        title="Original",
+        deleted=True,
+        deleted_at=datetime.now(UTC),
+    )
+    await _add(seed_session, deleted_movie)
+
+    await repository.update_movie(deleted_movie.id, MovieUpdateRequest(title="Resurrected"))
+
+    await seed_session.refresh(deleted_movie)
+    assert deleted_movie.title == "Original"
+    assert deleted_movie.deleted is True
+
+
+@pytest.mark.asyncio
+async def test_find_movie_by_id_returns_active_row(repository: PostgresMovieRepository, seed_session: AsyncSession):
+    active = PostgresMovie(tmdb_id=333, title="Active")
+    deleted = PostgresMovie(tmdb_id=334, title="Gone", deleted=True, deleted_at=datetime.now(UTC))
+    await _add(seed_session, active, deleted)
+
+    assert (await repository.find_movie_by_id(active.id)) is not None
+    assert (await repository.find_movie_by_id(deleted.id)) is None
+    assert (await repository.find_movie_by_id(uuid4())) is None
+
+
+@pytest.mark.asyncio
+async def test_find_movie_by_tmdb_id_skips_soft_deleted(
+    repository: PostgresMovieRepository, seed_session: AsyncSession
+):
+    active = PostgresMovie(tmdb_id=444, title="Active")
+    deleted = PostgresMovie(tmdb_id=445, title="Gone", deleted=True, deleted_at=datetime.now(UTC))
+    await _add(seed_session, active, deleted)
+
+    assert (await repository.find_movie_by_tmdb_id(444)) is not None
+    assert (await repository.find_movie_by_tmdb_id(445)) is None
+    assert (await repository.find_movie_by_tmdb_id(9999)) is None
+
+
+@pytest.mark.asyncio
+async def test_create_from_tmdb_data_persists_payload_and_sync_timestamp(
+    repository: PostgresMovieRepository, seed_session: AsyncSession
+):
+    movie = await repository.create_from_tmdb_data(_tmdb_details(555))
+
+    assert movie.tmdb_id == 555
+    assert movie.release_date == datetime(2024, 1, 1)
+    assert movie.tmdb_payload is not None
+    assert movie.tmdb_payload["id"] == 555
+    assert movie.tmdb_last_synced_at is not None
+
+    persisted = await seed_session.get(PostgresMovie, movie.id)
+    assert persisted is not None
+    assert persisted.tmdb_payload is not None
+
+
+@pytest.mark.asyncio
+async def test_create_from_tmdb_data_returns_existing_on_duplicate_tmdb_id(
+    repository: PostgresMovieRepository, seed_session: AsyncSession
+):
+    existing = PostgresMovie(tmdb_id=666, title="First")
+    await _add(seed_session, existing)
+
+    duplicate = await repository.create_from_tmdb_data(_tmdb_details(666))
+
+    assert duplicate.id == existing.id
+    assert duplicate.tmdb_id == 666
+
+
+@pytest.mark.asyncio
+async def test_create_from_tmdb_data_with_invalid_release_date_returns_none(
+    repository: PostgresMovieRepository,
+):
+    movie = await repository.create_from_tmdb_data(_tmdb_details(777, release_date="not-a-date"))
+
+    assert movie.release_date is None
+
+
+@pytest.mark.asyncio
+async def test_find_movies_by_ids_filters_deleted_and_unknown(
+    repository: PostgresMovieRepository, seed_session: AsyncSession
+):
+    a = PostgresMovie(tmdb_id=801, title="A")
+    b = PostgresMovie(tmdb_id=802, title="B", deleted=True, deleted_at=datetime.now(UTC))
+    c = PostgresMovie(tmdb_id=803, title="C")
+    await _add(seed_session, a, b, c)
+
+    found = await repository.find_movies_by_ids({a.id, b.id, c.id, uuid4()})
+
+    assert {m.id for m in found} == {a.id, c.id}
+
+
+@pytest.mark.asyncio
+async def test_find_movies_by_ids_with_empty_set_short_circuits(repository: PostgresMovieRepository):
+    assert await repository.find_movies_by_ids(set()) == []
+
+
+@pytest.mark.asyncio
+async def test_get_movie_stats_sums_runtime_excluding_deleted(
+    repository: PostgresMovieRepository, seed_session: AsyncSession
+):
+    a = PostgresMovie(tmdb_id=901, title="A", runtime=120)
+    b = PostgresMovie(tmdb_id=902, title="B", runtime=90)
+    deleted = PostgresMovie(tmdb_id=903, title="C", runtime=999, deleted=True, deleted_at=datetime.now(UTC))
+    null_runtime = PostgresMovie(tmdb_id=904, title="D", runtime=None)
+    await _add(seed_session, a, b, deleted, null_runtime)
+
+    stats = await repository.get_movie_stats({a.id, b.id, deleted.id, null_runtime.id})
+
+    assert stats.total_runtime == 210
+
+
+@pytest.mark.asyncio
+async def test_get_movie_stats_with_empty_set_short_circuits(repository: PostgresMovieRepository):
+    stats = await repository.get_movie_stats(set())
+
+    assert stats.total_runtime == 0

--- a/tests/units/utils/test_datetime_utils.py
+++ b/tests/units/utils/test_datetime_utils.py
@@ -1,6 +1,6 @@
 from datetime import UTC, date, datetime
 
-from app.utils.datetime_utils import date_end_utc, date_start_utc, to_utc_datetime
+from app.utils.datetime_utils import date_end_utc, date_start_utc, parse_iso_date, to_utc_datetime
 
 
 class TestDateTimeUtils:
@@ -32,3 +32,18 @@ class TestDateTimeUtils:
         result = to_utc_datetime(aware_datetime)
 
         assert result is aware_datetime
+
+    def test_parse_iso_date_parses_valid_string(self):
+        assert parse_iso_date("2024-06-15") == datetime(2024, 6, 15)
+
+    def test_parse_iso_date_returns_none_for_malformed_string(self):
+        assert parse_iso_date("not-a-date") is None
+
+    def test_parse_iso_date_returns_none_for_empty_string(self):
+        assert parse_iso_date("") is None
+
+    def test_parse_iso_date_returns_none_for_none(self):
+        assert parse_iso_date(None) is None
+
+    def test_parse_iso_date_accepts_custom_format(self):
+        assert parse_iso_date("15/06/2024", fmt="%d/%m/%Y") == datetime(2024, 6, 15)

--- a/uv.lock
+++ b/uv.lock
@@ -321,9 +321,11 @@ dev = [
     { name = "mongomock-motor" },
     { name = "mypy" },
     { name = "pip-audit" },
+    { name = "psycopg", extra = ["binary"] },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-postgresql" },
     { name = "ruff" },
 ]
 
@@ -352,9 +354,11 @@ dev = [
     { name = "mongomock-motor", specifier = "==0.0.36" },
     { name = "mypy", specifier = "==1.19.1" },
     { name = "pip-audit", specifier = ">=2.10.0" },
+    { name = "psycopg", extras = ["binary"], specifier = "==3.3.4" },
     { name = "pytest", specifier = "==9.0.2" },
     { name = "pytest-asyncio", specifier = "==1.3.0" },
     { name = "pytest-cov", specifier = "==7.1.0" },
+    { name = "pytest-postgresql", specifier = "==8.1.0" },
     { name = "ruff", specifier = "==0.15.7" },
 ]
 
@@ -936,6 +940,18 @@ wheels = [
 ]
 
 [[package]]
+name = "mirakuru"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "psutil", marker = "sys_platform != 'cygwin'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/23/db9034ba28c7d89a540ffb8ca789f70dc12079108ece1cd1762295d5c807/mirakuru-3.0.2.tar.gz", hash = "sha256:21192186a8680ea7567ca68170261df3785768b12962dd19fe8cccab15ad3441", size = 29338, upload-time = "2026-02-11T19:41:15.42Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/5f/a3f1a7f1f6e55de9285b03ae7e0d3c2a15e044b6e3f9b53bef5609ca05f2/mirakuru-3.0.2-py3-none-any.whl", hash = "sha256:10e5dac4a8f26872c63e9cdfdc01b775aaa2beb3ced98abc497279d2dc525b8f", size = 27583, upload-time = "2026-02-11T19:41:13.578Z" },
+]
+
+[[package]]
 name = "mongomock"
 version = "4.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1161,6 +1177,101 @@ wheels = [
 ]
 
 [[package]]
+name = "port-for"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/a0/80a64e8cc096c7a9d0f546a28994af849b4775afc5e4ee44bf2739a55115/port_for-1.0.0.tar.gz", hash = "sha256:404d161b1b2c82e2f6b31d8646396b4847d02bf5ee10068c92b7263657a14582", size = 21681, upload-time = "2025-09-30T10:22:51.149Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/2c/b1faca65b9728b4ac43f0bee4bb9e7294bd0a62cc2ee59fd59403bf575f6/port_for-1.0.0-py3-none-any.whl", hash = "sha256:35a848b98cf4cc075fe80dc49ae5c3a78e3ca345a23bd39bf5252277b4eef5c2", size = 17544, upload-time = "2025-09-30T10:22:49.878Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
+name = "psycopg"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/2f/cb91e5502ec9de1de6f1b76cfbf69531932725361168bb06963620c77e2e/psycopg-3.3.4.tar.gz", hash = "sha256:e21207764952cff81b6b8bdacad9a3939f2793367fdac2987b3aac36a651b5bc", size = 165799, upload-time = "2026-05-01T23:31:55.179Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e0/7b3dee031daae7743609ce3c746565d4a3ed7c2c186479eb48e34e838c64/psycopg-3.3.4-py3-none-any.whl", hash = "sha256:b6bbc25ccf05c8fad3b061d9db2ef0909a555171b84b07f29458a447253d679a", size = 213001, upload-time = "2026-05-01T23:20:50.816Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/7d/03818e13ba7f36de93573c93ee3482006d3dfa8b0f8d28df511bad0a1a92/psycopg_binary-3.3.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5ab28a2a7649df3b72e6b674b4c190e448e8e77cf496a65bd846472048de2089", size = 4591122, upload-time = "2026-05-01T23:27:56.162Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b9/11b341edf8d54e2694726b273fe9652b254d989f4f63e3ac6816ad6b55f4/psycopg_binary-3.3.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6402a9d8146cf4b3974ded3fd28a971e83dc6a0333eb7822524a3aa20b546578", size = 4669943, upload-time = "2026-05-01T23:28:04.522Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/18/4665bacd65e7865b4372fcd8abb8b9186ada4b0025f8c2ca691b364a556c/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:580ae30a5f95ccd90008ec697d3ed6a4a2047a516407ad904283fa42086936e9", size = 5469697, upload-time = "2026-05-01T23:28:11.337Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b1/b83136c6e510593d9b0c759ba5384337bc4ad82d19fda675adc4b2703c84/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e7510c37550f91a187e3660a8cc50d4b760f8c3b8b2f89ebc5698cd2c7f2c85d", size = 5152995, upload-time = "2026-05-01T23:28:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/67/8d/a9821e2a648afe6091989929982a3b0f00b2631a859cb81379728f08fb75/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77df19583501ea288eaf15ac0fe7ad01e6d8091a91d5c41df5c718f307d8e31b", size = 6738180, upload-time = "2026-05-01T23:28:30.654Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/58/2e349e8d23905dc2317b80ac65f48fb6f821a4777a4e994a60da91c4850f/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:018fbed325936da502feb546642c982dcc4b9ffdea32dfef78dbf3b7f7ad4070", size = 4978828, upload-time = "2026-05-01T23:28:37.277Z" },
+    { url = "https://files.pythonhosted.org/packages/45/48/57b00d03b4721878326122a1f1e6b0a90b85bcaec56b5b2f8ea6cfa45235/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:17a21953a9e5ff3a16dab692625a3676e2f101db5e40072f39dbee2250194d68", size = 4509757, upload-time = "2026-05-01T23:28:43.078Z" },
+    { url = "https://files.pythonhosted.org/packages/25/37/33b47d8c007df69aec500df5889767c4d313748e8e9e27a2fef8a6dabcee/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:eb05ee1c2b817d27c537333224c9e83c7afb86fe7296ba970990068baf819b16", size = 4190546, upload-time = "2026-05-01T23:28:50.016Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/c6/32b0835dbc2122617902b649d76a91c1e75406e76bf3d595b0c3bb5ffad6/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:773d573e11f437ce0bdb95b7c18dc58390494f96d43f8b45b9760436114f7652", size = 3926197, upload-time = "2026-05-01T23:28:55.55Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/68/d190ef0c0c5b16ded07831dabc8ddd412f4cdab07ec6e30ed38d9bda0e1f/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:71e55ccbdfae79a2ed9c6369c3008a3025817ff9d7e27b32a2d84e2a4267e66e", size = 4236627, upload-time = "2026-05-01T23:29:05.336Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8f/81dcbc2e8454b74d14881275ea45f00791052dac531a9fa8be1730d1685b/psycopg_binary-3.3.4-cp312-cp312-win_amd64.whl", hash = "sha256:494ca54901be8cf9eb7e02c25b731f2317c378efa44f43e8f9bd0e1184ae7be4", size = 3560782, upload-time = "2026-05-01T23:29:11.967Z" },
+    { url = "https://files.pythonhosted.org/packages/09/43/13e9c406fbbf354580476e248a16b64802a376873ebe6339e30bb655572d/psycopg_binary-3.3.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fbd1d4ed566895ad2d3bf4ddfd8bae90026930ddf29df3b9d91d32c8c47866a7", size = 4590377, upload-time = "2026-05-01T23:29:18.782Z" },
+    { url = "https://files.pythonhosted.org/packages/22/be/2923cd7c3683e7afdecf4f10796a18de02f5c5ddc0969aa2ad0a8cdd3bbd/psycopg_binary-3.3.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:75a9067e236f9b9ae3535b66fe99bddb33d39c0de10112e49b9ab11eee53dc31", size = 4669023, upload-time = "2026-05-01T23:29:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/96/a0/2c913d6fe13d6a8bd13597d36739bf47af063ad9399e402cfecab16f3c1e/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:b56b603ebcea8aa10b46228b8410ba7f13e7c2ee54389d4d9be0927fd8ce2a70", size = 5467423, upload-time = "2026-05-01T23:29:33.416Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/38/205d10bc1ad0df4a21c5c51659126bd3ea0ef98fcad1e852f78c249bb9c3/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c677c4ad433cb7150c8cd304a0769ae3bcfbe5ea0676eb53faa7b1443b16d0d3", size = 5151137, upload-time = "2026-05-01T23:29:42.013Z" },
+    { url = "https://files.pythonhosted.org/packages/36/fc/f0381ddcd45eff3bb70dbca6823a996048d7f507b2ec3fc92c6fabc0fe87/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:26df2717e59c0473e4465a97dfb1b7afebaa479277870fd5784d1436470db47c", size = 6736671, upload-time = "2026-05-01T23:29:51.626Z" },
+    { url = "https://files.pythonhosted.org/packages/95/40/fa545ae152c24327651e5624e4902121e808270be36c10b12e9939be09bc/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1dc1f79fd16bb1f3f4421417a514607539f17804d95c7ed617265369d1981cae", size = 4979601, upload-time = "2026-05-01T23:29:56.961Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e4/2f8a47ee97f90cd2b933d0463081d35631ff419de2b8c984a5f369857de0/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:136f199a407b5348b9b857c504aff60c77622a28482e7195839ce1b51238c4cc", size = 4510513, upload-time = "2026-05-01T23:30:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0e/94e842ff4a7f98ed162580ca2e8b8864b28c1e0350f2443f8ee47f821167/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b6f5a29e9c775b9f12a1a717aa7a2c80f9e1db6f27ba44a5b59c80ac61d2ffcf", size = 4187243, upload-time = "2026-05-01T23:30:15.352Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/83/fc6c174b672e29b7de996ea77b6cbddf46c891751c3355f6974292baa6b4/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:ee17a2cf4943cde261adfad1bbc5bf38d6b3776d7afff74c7cabcbeaeb08c260", size = 3927347, upload-time = "2026-05-01T23:30:21.186Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/65/768364d4a97a15b1a7f47ba52688c1686f22941d8332a8398cefc468e25f/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c4ab71be17bdca30cb34c34c4e1496e2f5d6f20c199c12bad226070b22ef9bf", size = 4236393, upload-time = "2026-05-01T23:30:26.211Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3b/218efbc9e645becd80cdf651acda05f85cfe546b7a9c0458c7cbc8fe1f74/psycopg_binary-3.3.4-cp313-cp313-win_amd64.whl", hash = "sha256:dbfdb9b6cc79f31104a7b162a2b921b765fcc62af6c00540a167a8de47e4ed38", size = 3564592, upload-time = "2026-05-01T23:30:31.764Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a6/828c9185701dab71b234c2a76c38a08b098ebfec5020716b4e93807492b5/psycopg_binary-3.3.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:28b7398fdd19db3232c884fb24550bdfe951221f510e195e233299e4c9b78f97", size = 4607292, upload-time = "2026-05-01T23:30:38.962Z" },
+    { url = "https://files.pythonhosted.org/packages/92/58/5b40dbc9d839045c9dae956960e4fb6d20bcabe6c59a2aa34fc3a371913f/psycopg_binary-3.3.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1fbaa292a3c8bb61b45df1ad3da1908ccee7cb889db9425e3557d9e34e2a4829", size = 4687023, upload-time = "2026-05-01T23:30:47.227Z" },
+    { url = "https://files.pythonhosted.org/packages/85/a9/793f0ac107a9003b48441d0d1f9f616d96e0f37458dd8dc12528ceff55fb/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94596f9e7633ee3f6440711d43bb70aa31cc0a46a900ab8b4201a366ace5c9e7", size = 5486985, upload-time = "2026-05-01T23:30:55.517Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/26/42e8533497e2592334f68ec529cf5f840f7fa4e99575a4bb61aa184dbfbf/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8c0056529e68dbe9184cd4019a1f3d8f3a4ead2f6fc7a5afcf27d3314edd1277", size = 5168745, upload-time = "2026-05-01T23:31:01.904Z" },
+    { url = "https://files.pythonhosted.org/packages/15/af/b7151776cc08d5935d45c833ec818a9beb417cf7c08239af1aafbdae78ee/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c09aad7051326e7603c14e50636db9c01f78272dc54b3accff03d46370461e6", size = 6761486, upload-time = "2026-05-01T23:31:14.511Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ed/c92533b9124712d592cbf1cd6c76da933a2e0acea81dfe1fbe7e735f0cff/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:514404ed543efd620c85602b747df2a23cf1241b4067199e1a66f2d2757aaa41", size = 4997427, upload-time = "2026-05-01T23:31:20.901Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/23/ccadfd0de416aa188356daa199453af24087b042e296088706d190ae0295/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:46893c26858be12cc49ca4226ed6a60b4bfccadd946b3bebb783a60b38788228", size = 4533549, upload-time = "2026-05-01T23:31:26.204Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a0/c8f43cee36386f7bc891ab41a9d31ea07cf9826038e732da79f26b1e5f34/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:df1d567fc430f6df15c9fcf67d87685fc49bdb325adc0db5af1adfb2f44eb5c9", size = 4210256, upload-time = "2026-05-01T23:31:33.884Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/2c/c1547871be3790676e8868b38655496422f94f0978dfb66b74bdba2f1676/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:6b9016b1714da4dd5ecaaa75b82098aa5a0b87854ce9b092e21c27c4ae23e014", size = 3946204, upload-time = "2026-05-01T23:31:39.626Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b1/f6670f00fa7ea601584623f6c11602ab92117d83eaff885e0210f6de7418/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:47c656a8a7ba6eb0cff1801a4caaa9c8bdc12d03080e273aff1c8ac39971a77e", size = 4255811, upload-time = "2026-05-01T23:31:44.986Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e6/5fff07a70d1f945ed90ae131c3bd76cab32beff7c58c6db15ad5820b6d1f/psycopg_binary-3.3.4-cp314-cp314-win_amd64.whl", hash = "sha256:c37e024c07308cd06cf3ec51bfd0e7f6157585a4d84d1bce4a7f5f7913719bf8", size = 3666849, upload-time = "2026-05-01T23:31:51.165Z" },
+]
+
+[[package]]
 name = "py-serializable"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1382,6 +1493,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-postgresql"
+version = "8.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mirakuru" },
+    { name = "packaging" },
+    { name = "port-for" },
+    { name = "psycopg" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/54/e5/3855f2e69cab10968564d797db2c3a4a7eabad68964047984a2533cddd46/pytest_postgresql-8.1.0.tar.gz", hash = "sha256:ffd24027a28aba3d05a909fb03ee87d1d474574c3504f332d6047e8699170adc", size = 58995, upload-time = "2026-05-15T19:59:36.85Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/5a/1a9dbe730bfeeebf0e442225285550148cc85efcbfe0ad85b02b74a12e91/pytest_postgresql-8.1.0-py3-none-any.whl", hash = "sha256:0868bb3374fa4f454efd73ac1d7b23d2da623782044371b84d39f83a0893f56f", size = 42311, upload-time = "2026-05-15T19:59:34.955Z" },
 ]
 
 [[package]]
@@ -1720,6 +1847,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- rename legacy Beanie movie repository to `MongoMovieRepository`
- add new PostgreSQL `MovieRepository` with async SQLAlchemy implementation
- add PostgreSQL movie ORM model + Alembic migration for `movies` table
- add data migration script `db_migrations/001_migrate_movies.py` using deterministic `mongo_id_to_uuid(...)`
- add repository dependency wiring guardrails (`DB_BACKEND`) with fail-fast unsafe mixed-mode protection
- keep Mongo as active runtime backend by default
- update migration/service dependency docs and `.env.example`

## Tests
- `make lint`
- `make typecheck`
- `make test-unit`

## Notes
- `_id_mapping` crosswalk persistence was intentionally removed from this ticket scope per product direction; deterministic ID conversion remains in place.

Closes #126
