### PR TITLE
feat(user-repository): migrate users repository to postgres

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import async_engine_from_config
 # Import all ORM modules so their tables register with ``Base.metadata`` before
 # ``--autogenerate`` snapshots it. Imports are side-effect only.
 from alembic import context, util
-from app.models import movie_model  # noqa: F401
+from app.models import movie_model, user_model  # noqa: F401
 from app.models.base_model import Base
 
 config = context.config

--- a/alembic/versions/002_create_users_table.py
+++ b/alembic/versions/002_create_users_table.py
@@ -1,0 +1,52 @@
+"""create users table
+
+Revision ID: 002_create_users_table
+Revises: 001_create_movies_table
+Create Date: 2026-06-01 12:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "002_create_users_table"
+down_revision: str | Sequence[str] | None = "001_create_movies_table"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Apply the migration."""
+    op.execute("CREATE EXTENSION IF NOT EXISTS pgcrypto")
+
+    op.create_table(
+        "users",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("email", sa.Text(), nullable=False),
+        sa.Column("handle", sa.Text(), nullable=False),
+        sa.Column("first_name", sa.Text(), nullable=False),
+        sa.Column("last_name", sa.Text(), nullable=False),
+        sa.Column("bio", sa.Text(), nullable=True),
+        sa.Column("profile_visibility", sa.Text(), nullable=False, server_default=sa.text("'private'")),
+        sa.Column("date_of_birth", sa.Date(), nullable=True),
+        sa.Column("password_hash", sa.Text(), nullable=True),
+        sa.Column("reset_password_code", sa.Text(), nullable=True),
+        sa.Column("reset_password_expires", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("deleted", sa.Boolean(), nullable=False, server_default=sa.text("FALSE")),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
+    )
+
+    op.create_index("uq_users_email_lower", "users", [sa.text("LOWER(email)")], unique=True)
+    op.create_index("ix_users_handle", "users", ["handle"], unique=True)
+
+
+def downgrade() -> None:
+    """Rollback the migration."""
+    op.drop_index("ix_users_handle", table_name="users")
+    op.drop_index("uq_users_email_lower", table_name="users")
+    op.drop_table("users")

--- a/alembic/versions/002_create_users_table.py
+++ b/alembic/versions/002_create_users_table.py
@@ -46,11 +46,11 @@ def upgrade() -> None:
     )
 
     op.create_index("uq_users_email_lower", "users", [sa.text("LOWER(email)")], unique=True)
-    op.create_index("ix_users_handle", "users", ["handle"], unique=True)
+    op.create_index("uq_users_handle_lower", "users", [sa.text("LOWER(handle)")], unique=True)
 
 
 def downgrade() -> None:
     """Rollback the migration."""
-    op.drop_index("ix_users_handle", table_name="users")
+    op.drop_index("uq_users_handle_lower", table_name="users")
     op.drop_index("uq_users_email_lower", table_name="users")
     op.drop_table("users")

--- a/alembic/versions/002_create_users_table.py
+++ b/alembic/versions/002_create_users_table.py
@@ -39,6 +39,10 @@ def upgrade() -> None:
         sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
         sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.CheckConstraint(
+            "profile_visibility IN ('public', 'friends_only', 'private')",
+            name="ck_users_profile_visibility",
+        ),
     )
 
     op.create_index("uq_users_email_lower", "users", [sa.text("LOWER(email)")], unique=True)

--- a/app/dependencies/repository_dependency.py
+++ b/app/dependencies/repository_dependency.py
@@ -4,6 +4,7 @@ from functools import lru_cache
 
 from app.db.postgres import is_postgres_required
 from app.repository.movie_repository import MovieRepository
+from app.repository.user_repository import UserRepository
 
 
 class RepositoryActivationError(RuntimeError):
@@ -27,3 +28,24 @@ def get_movie_repository() -> MovieRepository:
         )
 
     return MovieRepository()
+
+
+@lru_cache
+def get_user_repository() -> UserRepository:
+    """Return the active user repository implementation.
+
+    UserRepository PostgreSQL activation is intentionally blocked in mixed mode
+    because JWT ``sub`` values, auth dependency parsing, user-owned resource
+    checks, Redis keys, and Mongo repositories still depend on ObjectId user
+    identifiers.
+    """
+
+    if is_postgres_required():
+        raise RepositoryActivationError(
+            "DB_BACKEND=postgres is not yet safe for UserRepository activation: "
+            "JWT subjects, auth dependency parsing, caches, and still-active Mongo repositories "
+            "depend on Mongo ObjectId user references. Keep DB_BACKEND=mongo until related "
+            "repositories and ID adapters are migrated."
+        )
+
+    return UserRepository()

--- a/app/dependencies/service_dependency.py
+++ b/app/dependencies/service_dependency.py
@@ -8,11 +8,10 @@ Tests can swap a whole service through
 
 from functools import lru_cache
 
-from app.dependencies.repository_dependency import get_movie_repository
+from app.dependencies.repository_dependency import get_movie_repository, get_user_repository
 from app.repository.log_cache_repository import LogCacheRepository
 from app.repository.log_repository import LogRepository
 from app.repository.movie_rating_repository import MovieRatingRepository
-from app.repository.user_repository import UserRepository
 from app.services.auth_rate_limit_service import AuthRateLimitService
 from app.services.auth_service import AuthService
 from app.services.log_service import LogService
@@ -24,7 +23,7 @@ from app.services.user_service import UserService
 
 @lru_cache
 def get_auth_service() -> AuthService:
-    return AuthService(UserRepository())
+    return AuthService(get_user_repository())
 
 
 @lru_cache
@@ -34,7 +33,7 @@ def get_auth_rate_limit_service() -> AuthRateLimitService:
 
 @lru_cache
 def get_user_service() -> UserService:
-    return UserService(user_repository=UserRepository())
+    return UserService(user_repository=get_user_repository())
 
 
 @lru_cache
@@ -57,7 +56,7 @@ def get_log_service() -> LogService:
         movie_service=get_movie_service(),
         movie_repository=get_movie_repository(),
         movie_rating_repository=MovieRatingRepository(),
-        user_repository=UserRepository(),
+        user_repository=get_user_repository(),
     )
 
 

--- a/app/models/user_model.py
+++ b/app/models/user_model.py
@@ -47,5 +47,5 @@ class PostgresUser(PostgresBaseEntity):
             name="ck_users_profile_visibility",
         ),
         Index("uq_users_email_lower", func.lower(email), unique=True),
-        Index("ix_users_handle", handle, unique=True),
+        Index("uq_users_handle_lower", func.lower(handle), unique=True),
     )

--- a/app/models/user_model.py
+++ b/app/models/user_model.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 from datetime import date, datetime
 from uuid import UUID
 
-from sqlalchemy import Date, DateTime, Index, Text, func, text
+from sqlalchemy import CheckConstraint, Date, DateTime, Index, Text, func, text
 from sqlalchemy.dialects.postgresql import UUID as PGUUID
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.models.base_model import PostgresBaseEntity
+from app.types import PROFILE_VISIBILITY_CHOICES
 
 
 class PostgresUser(PostgresBaseEntity):
@@ -38,7 +39,13 @@ class PostgresUser(PostgresBaseEntity):
     reset_password_code: Mapped[str | None] = mapped_column(Text, nullable=True)
     reset_password_expires: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
+    _profile_visibility_sql = ", ".join(f"'{choice}'" for choice in PROFILE_VISIBILITY_CHOICES)
+
     __table_args__ = (
+        CheckConstraint(
+            f"profile_visibility IN ({_profile_visibility_sql})",
+            name="ck_users_profile_visibility",
+        ),
         Index("uq_users_email_lower", func.lower(email), unique=True),
         Index("ix_users_handle", handle, unique=True),
     )

--- a/app/models/user_model.py
+++ b/app/models/user_model.py
@@ -1,0 +1,44 @@
+"""PostgreSQL user ORM model."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from uuid import UUID
+
+from sqlalchemy import Date, DateTime, Index, Text, func, text
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base_model import PostgresBaseEntity
+
+
+class PostgresUser(PostgresBaseEntity):
+    """User record stored in PostgreSQL."""
+
+    __tablename__ = "users"
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    email: Mapped[str] = mapped_column(Text, nullable=False)
+    handle: Mapped[str] = mapped_column(Text, nullable=False)
+    first_name: Mapped[str] = mapped_column(Text, nullable=False)
+    last_name: Mapped[str] = mapped_column(Text, nullable=False)
+    bio: Mapped[str | None] = mapped_column(Text, nullable=True)
+    profile_visibility: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+        server_default=text("'private'"),
+        default="private",
+    )
+    date_of_birth: Mapped[date | None] = mapped_column(Date, nullable=True)
+    password_hash: Mapped[str | None] = mapped_column(Text, nullable=True)
+    reset_password_code: Mapped[str | None] = mapped_column(Text, nullable=True)
+    reset_password_expires: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    __table_args__ = (
+        Index("uq_users_email_lower", func.lower(email), unique=True),
+        Index("ix_users_handle", handle, unique=True),
+    )

--- a/app/repository/postgres_user_repository.py
+++ b/app/repository/postgres_user_repository.py
@@ -1,0 +1,215 @@
+"""PostgreSQL user repository implementation."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import func, or_, select
+
+from app.models.user_model import PostgresUser
+from app.repository.repository_base import RepositoryBase
+from app.schemas.user_schemas import UserCreateRequest
+
+ALLOWED_PROFILE_FIELDS = {
+    "first_name",
+    "last_name",
+    "bio",
+    "profile_visibility",
+    "date_of_birth",
+}
+
+
+class PostgresUserRepository(RepositoryBase):
+    """Repository class for PostgreSQL user-related operations."""
+
+    async def create_user(self, request: UserCreateRequest) -> PostgresUser:
+        """Create a new user in PostgreSQL."""
+
+        if request.handle is None:
+            raise ValueError("User handle is required.")
+
+        async with self._session_provider() as session:
+            user = PostgresUser(
+                email=request.email,
+                handle=request.handle,
+                first_name=request.first_name,
+                last_name=request.last_name,
+                bio=request.bio,
+                profile_visibility=request.profile_visibility,
+                date_of_birth=request.date_of_birth,
+                password_hash=request.password_hash,
+            )
+            session.add(user)
+            await session.commit()
+            await session.refresh(user)
+            return user
+
+    async def find_user_by_email(self, email: str) -> PostgresUser | None:
+        """Find an active user by email, case-insensitively."""
+
+        async with self._session_provider() as session:
+            statement = select(PostgresUser).where(
+                func.lower(PostgresUser.email) == email.lower(),
+                PostgresUser.active(),
+            )
+            result = await session.execute(statement)
+            return result.scalar_one_or_none()
+
+    async def find_user_by_handle(self, handle: str) -> PostgresUser | None:
+        """Find an active user by handle."""
+
+        async with self._session_provider() as session:
+            statement = select(PostgresUser).where(
+                PostgresUser.handle == handle,
+                PostgresUser.active(),
+            )
+            result = await session.execute(statement)
+            return result.scalar_one_or_none()
+
+    async def find_user_by_email_or_handle(self, email_or_handle: str) -> PostgresUser | None:
+        """Find an active user by case-insensitive email or exact handle."""
+
+        async with self._session_provider() as session:
+            statement = select(PostgresUser).where(
+                or_(
+                    func.lower(PostgresUser.email) == email_or_handle.lower(),
+                    PostgresUser.handle == email_or_handle,
+                ),
+                PostgresUser.active(),
+            )
+            result = await session.execute(statement)
+            return result.scalar_one_or_none()
+
+    async def find_user_by_id(self, user_id: UUID) -> PostgresUser | None:
+        """Find an active user by UUID."""
+
+        async with self._session_provider() as session:
+            statement = select(PostgresUser).where(
+                PostgresUser.id == user_id,
+                PostgresUser.active(),
+            )
+            result = await session.execute(statement)
+            return result.scalar_one_or_none()
+
+    async def delete_user(self, user_id: UUID) -> bool:
+        """Soft-delete an active user by UUID."""
+
+        async with self._session_provider() as session:
+            statement = select(PostgresUser).where(
+                PostgresUser.id == user_id,
+                PostgresUser.active(),
+            )
+            result = await session.execute(statement)
+            user = result.scalar_one_or_none()
+            if user is None:
+                return False
+
+            user.deleted = True
+            user.deleted_at = datetime.now(UTC)
+            user.updated_at = datetime.now(UTC)
+            await session.commit()
+            return True
+
+    async def delete_user_oblivion(self, user_id: UUID) -> bool:
+        """Obliterate user PII and soft-delete the active row."""
+
+        async with self._session_provider() as session:
+            statement = select(PostgresUser).where(
+                PostgresUser.id == user_id,
+                PostgresUser.active(),
+            )
+            result = await session.execute(statement)
+            user = result.scalar_one_or_none()
+            if user is None:
+                return False
+
+            user.first_name = "Deleted"
+            user.last_name = "User"
+            user.email = f"deleted_{user_id}@deleted.local"
+            user.handle = f"deleted_{user_id}"
+            user.bio = None
+            user.password_hash = None
+            user.reset_password_code = None
+            user.reset_password_expires = None
+            user.date_of_birth = None
+            user.deleted = True
+            user.deleted_at = datetime.now(UTC)
+            user.updated_at = datetime.now(UTC)
+            await session.commit()
+            return True
+
+    async def update_password(self, user: PostgresUser, password_hash: str) -> PostgresUser:
+        """Update password hash for the active user row."""
+
+        async with self._session_provider() as session:
+            persisted_user = await session.get(PostgresUser, user.id)
+            if persisted_user is None or persisted_user.deleted:
+                raise LookupError("User not found.")
+
+            persisted_user.password_hash = password_hash
+            persisted_user.updated_at = datetime.now(UTC)
+            await session.commit()
+            await session.refresh(persisted_user)
+            return persisted_user
+
+    async def set_reset_password_code(
+        self,
+        user: PostgresUser,
+        code: str,
+        expires_at: datetime,
+    ) -> PostgresUser:
+        """Persist password-reset metadata for the active user row."""
+
+        async with self._session_provider() as session:
+            persisted_user = await session.get(PostgresUser, user.id)
+            if persisted_user is None or persisted_user.deleted:
+                raise LookupError("User not found.")
+
+            persisted_user.reset_password_code = code
+            persisted_user.reset_password_expires = expires_at
+            persisted_user.updated_at = datetime.now(UTC)
+            await session.commit()
+            await session.refresh(persisted_user)
+            return persisted_user
+
+    async def clear_reset_password_code(self, user: PostgresUser) -> PostgresUser:
+        """Clear password-reset metadata for the active user row."""
+
+        async with self._session_provider() as session:
+            persisted_user = await session.get(PostgresUser, user.id)
+            if persisted_user is None or persisted_user.deleted:
+                raise LookupError("User not found.")
+
+            persisted_user.reset_password_code = None
+            persisted_user.reset_password_expires = None
+            persisted_user.updated_at = datetime.now(UTC)
+            await session.commit()
+            await session.refresh(persisted_user)
+            return persisted_user
+
+    async def update_user_profile(self, user_id: UUID, update_data: dict[str, Any]) -> PostgresUser | None:
+        """Update whitelisted profile fields for the active user row."""
+
+        filtered_updates = {field: value for field, value in update_data.items() if field in ALLOWED_PROFILE_FIELDS}
+        if not filtered_updates:
+            return await self.find_user_by_id(user_id)
+
+        async with self._session_provider() as session:
+            statement = select(PostgresUser).where(
+                PostgresUser.id == user_id,
+                PostgresUser.active(),
+            )
+            result = await session.execute(statement)
+            user = result.scalar_one_or_none()
+            if user is None:
+                return None
+
+            for field, value in filtered_updates.items():
+                setattr(user, field, value)
+
+            user.updated_at = datetime.now(UTC)
+            await session.commit()
+            await session.refresh(user)
+            return user

--- a/app/repository/postgres_user_repository.py
+++ b/app/repository/postgres_user_repository.py
@@ -58,24 +58,24 @@ class PostgresUserRepository(RepositoryBase):
             return result.scalar_one_or_none()
 
     async def find_user_by_handle(self, handle: str) -> PostgresUser | None:
-        """Find an active user by handle."""
+        """Find an active user by handle, case-insensitively."""
 
         async with self._session_provider() as session:
             statement = select(PostgresUser).where(
-                PostgresUser.handle == handle,
+                func.lower(PostgresUser.handle) == handle.lower(),
                 PostgresUser.active(),
             )
             result = await session.execute(statement)
             return result.scalar_one_or_none()
 
     async def find_user_by_email_or_handle(self, email_or_handle: str) -> PostgresUser | None:
-        """Find an active user by case-insensitive email or exact handle."""
+        """Find an active user by case-insensitive email or handle."""
 
         async with self._session_provider() as session:
             statement = select(PostgresUser).where(
                 or_(
                     func.lower(PostgresUser.email) == email_or_handle.lower(),
-                    PostgresUser.handle == email_or_handle,
+                    func.lower(PostgresUser.handle) == email_or_handle.lower(),
                 ),
                 PostgresUser.active(),
             )

--- a/app/repository/user_repository.py
+++ b/app/repository/user_repository.py
@@ -10,7 +10,14 @@ from app.utils.object_id_utils import to_object_id
 
 
 class UserRepository:
-    """Repository class for User-related operations."""
+    """MongoDB user repository — active runtime implementation.
+
+    Pending replacement by ``PostgresUserRepository`` (in
+    ``app/repository/postgres_user_repository.py``) once JWT/auth, profile
+    ownership checks, caches, and Mongo repositories no longer depend on
+    ObjectId-based user identifiers. ``PostgresUserRepository`` is
+    intentionally unwired today — do not import it from runtime code paths.
+    """
 
     async def create_user(self, request: UserCreateRequest) -> User:
         """Create a new user in the database."""

--- a/app/schemas/user_schemas.py
+++ b/app/schemas/user_schemas.py
@@ -19,7 +19,10 @@ class UserCreateRequest(BaseSchema):
     bio: BioStr = Field(None, description="User biography")
     date_of_birth: date = Field(..., description="Date of birth in YYYY-MM-DD format")
     password_hash: str | None = Field(None, description="Hashed password for local auth")
-    profile_visibility: str = Field(default="private", description="Profile visibility setting")
+    profile_visibility: ProfileVisibilityStr = Field(
+        default="private",
+        description="Profile visibility setting (public, friends_only, private)",
+    )
 
 
 class UserCreateResponse(BaseSchema):

--- a/app/services/log_service.py
+++ b/app/services/log_service.py
@@ -1,6 +1,6 @@
 from beanie import PydanticObjectId
 
-from app.dependencies.repository_dependency import get_movie_repository
+from app.dependencies.repository_dependency import get_movie_repository, get_user_repository
 from app.models.movie import Movie
 from app.repository.log_cache_repository import LogCacheRepository
 from app.repository.movie_rating_repository import MovieRatingRepository
@@ -42,7 +42,7 @@ class LogService:
         self.movie_rating_repository = movie_rating_repository or MovieRatingRepository()
         self.movie_repository = resolved_movie_repository
         self.stats_cache_service = stats_cache_service or StatsCacheService()
-        self.user_repository = user_repository or UserRepository()
+        self.user_repository = user_repository or get_user_repository()
 
     def _map_movie_to_response(self, movie: Movie) -> MovieResponse:
         return MovieResponse(

--- a/db_migrations/m002_migrate_users.py
+++ b/db_migrations/m002_migrate_users.py
@@ -9,6 +9,7 @@ from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.user_model import PostgresUser
+from app.types import PROFILE_VISIBILITY_CHOICES
 from app.utils.id_utils import mongo_id_to_uuid
 
 BATCH_SIZE = 100
@@ -37,6 +38,15 @@ def _parse_date_of_birth(value: str | date | datetime | None) -> date | None:
 
 
 def _normalize_user_doc(mongo_user: dict) -> dict:
+    profile_visibility = mongo_user.get("profileVisibility")
+    if isinstance(profile_visibility, str):
+        normalized_profile_visibility = profile_visibility.strip().lower()
+    else:
+        normalized_profile_visibility = ""
+
+    if normalized_profile_visibility not in PROFILE_VISIBILITY_CHOICES:
+        normalized_profile_visibility = "private"
+
     return {
         "id": mongo_id_to_uuid(str(mongo_user["_id"])),
         "email": mongo_user.get("email") or "",
@@ -44,7 +54,7 @@ def _normalize_user_doc(mongo_user: dict) -> dict:
         "first_name": mongo_user.get("firstName") or "",
         "last_name": mongo_user.get("lastName") or "",
         "bio": mongo_user.get("bio"),
-        "profile_visibility": mongo_user.get("profileVisibility") or "private",
+        "profile_visibility": normalized_profile_visibility,
         "date_of_birth": _parse_date_of_birth(mongo_user.get("dateOfBirth")),
         "password_hash": mongo_user.get("passwordHash"),
         "reset_password_code": mongo_user.get("resetPasswordCode"),

--- a/db_migrations/m002_migrate_users.py
+++ b/db_migrations/m002_migrate_users.py
@@ -75,11 +75,11 @@ async def _count_dry_run_insertable_users(
     """Count dry-run inserts after case-insensitive email and handle conflicts."""
 
     batch_lower_emails = {values["email"].lower() for values in batch}
-    batch_handles = {values["handle"] for values in batch}
-    statement = select(func.lower(PostgresUser.email), PostgresUser.handle).where(
+    batch_lower_handles = {values["handle"].lower() for values in batch}
+    statement = select(func.lower(PostgresUser.email), func.lower(PostgresUser.handle)).where(
         or_(
             func.lower(PostgresUser.email).in_(batch_lower_emails),
-            PostgresUser.handle.in_(batch_handles),
+            func.lower(PostgresUser.handle).in_(batch_lower_handles),
         )
     )
     result = await pg_session.execute(statement)
@@ -96,7 +96,7 @@ async def _count_dry_run_insertable_users(
 
     for values in batch:
         lower_email = values["email"].lower()
-        handle = values["handle"]
+        handle = values["handle"].lower()
         if (
             lower_email in occupied_lower_emails
             or handle in occupied_handles

--- a/db_migrations/m002_migrate_users.py
+++ b/db_migrations/m002_migrate_users.py
@@ -1,0 +1,196 @@
+"""Migrate users data from MongoDB to PostgreSQL."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+
+from sqlalchemy import delete, func, or_, select
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.user_model import PostgresUser
+from app.utils.id_utils import mongo_id_to_uuid
+
+BATCH_SIZE = 100
+
+
+def _parse_date_of_birth(value: str | date | datetime | None) -> date | None:
+    if value is None:
+        return None
+
+    if isinstance(value, datetime):
+        return value.date()
+
+    if isinstance(value, date):
+        return value
+
+    if not isinstance(value, str) or not value:
+        return None
+
+    try:
+        return date.fromisoformat(value)
+    except ValueError:
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00")).date()
+        except ValueError:
+            return None
+
+
+def _normalize_user_doc(mongo_user: dict) -> dict:
+    return {
+        "id": mongo_id_to_uuid(str(mongo_user["_id"])),
+        "email": mongo_user.get("email") or "",
+        "handle": mongo_user.get("handle") or "",
+        "first_name": mongo_user.get("firstName") or "",
+        "last_name": mongo_user.get("lastName") or "",
+        "bio": mongo_user.get("bio"),
+        "profile_visibility": mongo_user.get("profileVisibility") or "private",
+        "date_of_birth": _parse_date_of_birth(mongo_user.get("dateOfBirth")),
+        "password_hash": mongo_user.get("passwordHash"),
+        "reset_password_code": mongo_user.get("resetPasswordCode"),
+        "reset_password_expires": mongo_user.get("resetPasswordExpires"),
+        "deleted": bool(mongo_user.get("deleted", False)),
+        "deleted_at": mongo_user.get("deletedAt"),
+        "created_at": mongo_user.get("createdAt") or datetime.now(UTC),
+        "updated_at": mongo_user.get("updatedAt") or datetime.now(UTC),
+    }
+
+
+async def _count_dry_run_insertable_users(
+    pg_session: AsyncSession,
+    batch: list[dict],
+    projected_lower_emails: set[str],
+    projected_handles: set[str],
+) -> int:
+    """Count dry-run inserts after case-insensitive email and handle conflicts."""
+
+    batch_lower_emails = {values["email"].lower() for values in batch}
+    batch_handles = {values["handle"] for values in batch}
+    statement = select(func.lower(PostgresUser.email), PostgresUser.handle).where(
+        or_(
+            func.lower(PostgresUser.email).in_(batch_lower_emails),
+            PostgresUser.handle.in_(batch_handles),
+        )
+    )
+    result = await pg_session.execute(statement)
+
+    occupied_lower_emails = set(projected_lower_emails)
+    occupied_handles = set(projected_handles)
+
+    for lower_email, handle in result.all():
+        occupied_lower_emails.add(str(lower_email))
+        occupied_handles.add(str(handle))
+
+    insertable_lower_emails: set[str] = set()
+    insertable_handles: set[str] = set()
+
+    for values in batch:
+        lower_email = values["email"].lower()
+        handle = values["handle"]
+        if (
+            lower_email in occupied_lower_emails
+            or handle in occupied_handles
+            or lower_email in insertable_lower_emails
+            or handle in insertable_handles
+        ):
+            continue
+
+        insertable_lower_emails.add(lower_email)
+        insertable_handles.add(handle)
+
+    projected_lower_emails.update(insertable_lower_emails)
+    projected_handles.update(insertable_handles)
+    return len(insertable_lower_emails)
+
+
+async def _flush_batch(
+    pg_session: AsyncSession,
+    batch: list[dict],
+    *,
+    dry_run: bool,
+    projected_lower_emails: set[str] | None = None,
+    projected_handles: set[str] | None = None,
+) -> int:
+    """Insert a batch and return how many rows were actually persisted."""
+
+    if not batch:
+        return 0
+
+    if dry_run:
+        return await _count_dry_run_insertable_users(
+            pg_session,
+            batch,
+            projected_lower_emails if projected_lower_emails is not None else set(),
+            projected_handles if projected_handles is not None else set(),
+        )
+
+    statement = insert(PostgresUser).values(batch).on_conflict_do_nothing().returning(PostgresUser.id)
+    result = await pg_session.execute(statement)
+    return len(result.scalars().all())
+
+
+async def up(mongo_db, pg_session: AsyncSession, dry_run: bool = False) -> None:
+    """Migrate active users from MongoDB into PostgreSQL in batches."""
+
+    cursor = mongo_db.users.find({"deleted": {"$ne": True}}, batch_size=BATCH_SIZE)
+
+    total = 0
+    inserted = 0
+    skipped = 0
+    batch: list[dict] = []
+    projected_lower_emails: set[str] = set()
+    projected_handles: set[str] = set()
+
+    for mongo_user in cursor:
+        total += 1
+        values = _normalize_user_doc(mongo_user)
+        if not values["email"] or not values["handle"] or not values["first_name"] or not values["last_name"]:
+            skipped += 1
+            continue
+
+        batch.append(values)
+
+        if len(batch) >= BATCH_SIZE:
+            inserted_in_batch = await _flush_batch(
+                pg_session,
+                batch,
+                dry_run=dry_run,
+                projected_lower_emails=projected_lower_emails,
+                projected_handles=projected_handles,
+            )
+            inserted += inserted_in_batch
+            skipped += len(batch) - inserted_in_batch
+            batch = []
+
+    if batch:
+        inserted_in_batch = await _flush_batch(
+            pg_session,
+            batch,
+            dry_run=dry_run,
+            projected_lower_emails=projected_lower_emails,
+            projected_handles=projected_handles,
+        )
+        inserted += inserted_in_batch
+        skipped += len(batch) - inserted_in_batch
+
+    if not dry_run:
+        await pg_session.commit()
+
+    print(f"[users-migration] total={total} inserted={inserted} skipped={skipped} dry_run={dry_run}")
+
+
+async def down(mongo_db, pg_session: AsyncSession) -> None:
+    """Rollback user migration by deleting only rows derived from current Mongo users."""
+
+    cursor = mongo_db.users.find({}, batch_size=BATCH_SIZE)
+    derived_ids = [mongo_id_to_uuid(str(doc["_id"])) for doc in cursor]
+
+    deleted = 0
+    if derived_ids:
+        result = await pg_session.execute(
+            delete(PostgresUser).where(PostgresUser.id.in_(derived_ids)).returning(PostgresUser.id)
+        )
+        deleted = len(result.scalars().all())
+        await pg_session.commit()
+
+    print(f"[users-migration:down] derived_ids={len(derived_ids)} deleted={deleted}")

--- a/docs/technical/postgres-migration.md
+++ b/docs/technical/postgres-migration.md
@@ -154,7 +154,9 @@ Case-insensitive email uniqueness is enforced with a functional unique index:
 
 - `CREATE UNIQUE INDEX uq_users_email_lower ON users (LOWER(email))`
 
-Handles remain uniquely indexed with `ix_users_handle`.
+Case-insensitive handle uniqueness is also enforced while preserving the user's chosen casing:
+
+- `CREATE UNIQUE INDEX uq_users_handle_lower ON users (LOWER(handle))`
 
 ### GDPR oblivion behavior
 

--- a/docs/technical/postgres-migration.md
+++ b/docs/technical/postgres-migration.md
@@ -130,11 +130,68 @@ Migration rules:
 - Idempotent inserts by `tmdb_id` uniqueness
 - Progress reporting (total / inserted / skipped)
 
+## User Collection Migration
+
+`#127` adds PostgreSQL user persistence and data migration scaffolding while keeping Mongo active at runtime.
+
+### Repository split
+
+- Legacy Mongo implementation remains in `app/repository/user_repository.py` as `UserRepository` (deprecated during migration).
+- New PostgreSQL implementation lives in `app/repository/postgres_user_repository.py` as `PostgresUserRepository`.
+- Runtime activation is intentionally blocked by `get_user_repository()` until the user-ID cutover is safe.
+
+### Table shape
+
+Alembic migration creates `users` with canonical account/profile fields and soft-delete metadata:
+
+- `email TEXT NOT NULL`
+- `handle TEXT NOT NULL`
+- `first_name`, `last_name`, `bio`, `profile_visibility`
+- `date_of_birth DATE NULL`
+- `password_hash`, `reset_password_code`, `reset_password_expires`
+
+Case-insensitive email uniqueness is enforced with a functional unique index:
+
+- `CREATE UNIQUE INDEX uq_users_email_lower ON users (LOWER(email))`
+
+Handles remain uniquely indexed with `ix_users_handle`.
+
+### GDPR oblivion behavior
+
+The PostgreSQL user repository mirrors the Mongo oblivion workflow by overwriting or clearing sensitive fields before soft deletion:
+
+- `first_name -> "Deleted"`
+- `last_name -> "User"`
+- `email -> deleted_<uuid>@deleted.local`
+- `handle -> deleted_<uuid>`
+- `bio`, `password_hash`, `reset_password_code`, `reset_password_expires`, `date_of_birth` -> `NULL`
+- `deleted = TRUE`, `deleted_at = now()`
+
+### Data migration script
+
+Use `db_migrations/m002_migrate_users.py` with async session wiring:
+
+- `up(mongo_db, pg_session, dry_run=False)` migrates active (non-deleted) users
+- `down(mongo_db, pg_session)` deletes only PostgreSQL rows whose UUIDs derive from the current Mongo `users` collection
+
+Migration rules:
+
+- Skip `deleted=True` Mongo rows
+- Map Mongo `_id` -> Postgres UUID via `mongo_id_to_uuid(...)`
+- Normalize Mongo `dateOfBirth` into SQL `DATE`
+- Preserve password-reset fields, profile visibility, and timestamps
+- Idempotent inserts via PostgreSQL `ON CONFLICT DO NOTHING`
+- Progress reporting (total / inserted / skipped)
+
 ## Activation Guardrails
 
 PostgreSQL movie activation is intentionally blocked in mixed mode while `LogRepository` and `MovieRatingRepository` still persist/query Mongo ObjectId movie references.
 
 Activation must happen through dependency wiring (`app/dependencies/repository_dependency.py`), not controller imports.
+
+PostgreSQL user activation is also intentionally blocked in mixed mode while JWT subjects, `auth_dependency`, ownership checks, Redis cache keys, and still-active Mongo repositories depend on ObjectId user references.
+
+JWT `sub` values and public response IDs remain Mongo ObjectId strings until the core cutover is complete.
 
 ## Later Tickets
 

--- a/docs/technical/profile-visibility.md
+++ b/docs/technical/profile-visibility.md
@@ -18,6 +18,14 @@ Default is `"private"` for existing users (set via migration 002).
 
 `ProfileVisibilityStr` is a reusable `Annotated` type in `app/types/user_validation.py`. It normalizes input (strip + lowercase) and validates against `PROFILE_VISIBILITY_CHOICES`. For optional fields, use `ProfileVisibilityStr | None` inline — do not create a separate `OptionalProfileVisibilityStr` alias.
 
+`RegisterRequest`, `UpdateProfileRequest`, and `UserCreateRequest` all use this type, so application-level writes are limited to:
+
+- `"public"`
+- `"friends_only"`
+- `"private"`
+
+The PostgreSQL `users` table also enforces the same set with `CHECK (profile_visibility IN (...))`, so invalid values are rejected even if data bypasses Pydantic.
+
 ## API Endpoints
 
 | Endpoint | Method | Visibility Check |

--- a/docs/technical/pydantic_types_and_validators.md
+++ b/docs/technical/pydantic_types_and_validators.md
@@ -31,7 +31,7 @@ User-related validators used by `auth_schemas` and `user_schemas`.
 | Type | Description |
 |------|-------------|
 | `NameStr` | Required name (1–50 chars, letters/accents/hyphens only) |
-| `HandleStr` | Required handle (3–20 chars, alphanumeric + underscore, no leading digit) |
+| `HandleStr` | Required handle (3–20 chars, alphanumeric + underscore, no leading digit; casing preserved) |
 | `BioStr` | Optional bio (`None` or up to 500 chars, HTML tags stripped) |
 | `ProfileVisibilityStr` | Required profile visibility (`public`, `friends_only`, or `private`) |
 

--- a/docs/technical/service-dependencies.md
+++ b/docs/technical/service-dependencies.md
@@ -11,12 +11,16 @@ Controllers receive services through FastAPI `Depends(...)`.
 
 ## Repository Provider Guardrails
 
-`get_movie_repository()` is the runtime activation gate for movie persistence:
+`get_movie_repository()` and `get_user_repository()` are the runtime activation gates for mixed-mode persistence:
 
 - `DB_BACKEND` unset or `mongo` -> returns Mongo-backed `MovieRepository`.
+- `DB_BACKEND` unset or `mongo` -> returns Mongo-backed `UserRepository`.
 - `DB_BACKEND=postgres` while mixed-mode is unsafe -> raises `RepositoryActivationError` (fail-fast).
 
-This prevents accidental cutover while Mongo `LogRepository` and `MovieRatingRepository` still depend on ObjectId `movie_id` references.
+This prevents accidental cutover while:
+
+- Mongo `LogRepository` and `MovieRatingRepository` still depend on ObjectId `movie_id` references.
+- JWT `sub` values, `auth_dependency`, profile ownership checks, and user-scoped cache keys still depend on ObjectId `user_id` references.
 
 ## Service Providers
 

--- a/tests/units/db_migrations/test_migrate_users.py
+++ b/tests/units/db_migrations/test_migrate_users.py
@@ -212,6 +212,35 @@ async def test_migrate_users_up_normalizes_datetime_date_of_birth():
 
 
 @pytest.mark.asyncio
+async def test_migrate_users_up_normalizes_invalid_profile_visibility():
+    mongo_db = _FakeMongoDB(
+        [
+            {
+                "_id": "507f1f77bcf86cd799439011",
+                "email": "user@example.com",
+                "handle": "userhandle",
+                "firstName": "Test",
+                "lastName": "User",
+                "profileVisibility": " hidden ",
+                "deleted": False,
+            }
+        ]
+    )
+
+    pg_session = AsyncMock()
+    pg_session.execute.return_value = _mock_scalar_result(["inserted-user-id"])
+
+    await migrate_users.up(mongo_db, pg_session, dry_run=False)
+
+    statement = pg_session.execute.await_args.args[0]
+    compiled_params = statement.compile().params
+    profile_visibility_values = [
+        value for key, value in compiled_params.items() if key.startswith("profile_visibility")
+    ]
+    assert profile_visibility_values == ["private"]
+
+
+@pytest.mark.asyncio
 async def test_migrate_users_up_flushes_in_batches(capsys, monkeypatch):
     monkeypatch.setattr(migrate_users, "BATCH_SIZE", 2)
 

--- a/tests/units/db_migrations/test_migrate_users.py
+++ b/tests/units/db_migrations/test_migrate_users.py
@@ -183,6 +183,40 @@ async def test_migrate_users_up_dry_run_accounts_for_existing_and_prior_batch_co
 
 
 @pytest.mark.asyncio
+async def test_migrate_users_up_dry_run_treats_handle_conflicts_case_insensitively(capsys):
+    mongo_db = _FakeMongoDB(
+        [
+            {
+                "_id": "507f1f77bcf86cd799439011",
+                "email": "user@example.com",
+                "handle": "Antonio",
+                "firstName": "A",
+                "lastName": "User",
+                "deleted": False,
+            },
+            {
+                "_id": "507f1f77bcf86cd799439012",
+                "email": "other@example.com",
+                "handle": "antonio",
+                "firstName": "B",
+                "lastName": "User",
+                "deleted": False,
+            },
+        ]
+    )
+
+    pg_session = AsyncMock()
+    pg_session.execute.return_value = _mock_query_result([])
+
+    await migrate_users.up(mongo_db, pg_session, dry_run=True)
+
+    captured = capsys.readouterr().out
+    assert "total=2" in captured
+    assert "inserted=1" in captured
+    assert "skipped=1" in captured
+
+
+@pytest.mark.asyncio
 async def test_migrate_users_up_normalizes_datetime_date_of_birth():
     mongo_db = _FakeMongoDB(
         [

--- a/tests/units/db_migrations/test_migrate_users.py
+++ b/tests/units/db_migrations/test_migrate_users.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+import importlib.util
+from datetime import UTC, date, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+MIGRATION_FILE = Path(__file__).resolve().parents[3] / "db_migrations" / "m002_migrate_users.py"
+spec = importlib.util.spec_from_file_location("migrate_users_module", MIGRATION_FILE)
+assert spec is not None
+assert spec.loader is not None
+migrate_users = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(migrate_users)
+
+
+class _FakeMongoCollection:
+    def __init__(self, docs: list[dict]):
+        self._docs = docs
+        self.last_query: dict | None = None
+        self.last_batch_size: int | None = None
+
+    def find(self, query: dict, batch_size: int | None = None):
+        self.last_query = query
+        self.last_batch_size = batch_size
+        if query == {"deleted": {"$ne": True}}:
+            return iter(doc for doc in self._docs if doc.get("deleted") is not True)
+
+        return iter(self._docs)
+
+
+class _FakeMongoDB:
+    def __init__(self, docs: list[dict]):
+        self.users = _FakeMongoCollection(docs)
+
+
+def _mock_scalar_result(values: list[object]) -> MagicMock:
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = values
+    return result
+
+
+def _mock_query_result(rows: list[tuple[str, str]]) -> MagicMock:
+    result = MagicMock()
+    result.all.return_value = rows
+    return result
+
+
+@pytest.mark.asyncio
+async def test_migrate_users_up_skips_deleted_and_duplicate_rows(capsys):
+    mongo_db = _FakeMongoDB(
+        [
+            {
+                "_id": "507f1f77bcf86cd799439011",
+                "email": "user@example.com",
+                "handle": "first",
+                "firstName": "First",
+                "lastName": "User",
+                "deleted": False,
+            },
+            {
+                "_id": "507f1f77bcf86cd799439012",
+                "email": "deleted@example.com",
+                "handle": "deleted",
+                "firstName": "Deleted",
+                "lastName": "User",
+                "deleted": True,
+            },
+            {
+                "_id": "507f1f77bcf86cd799439013",
+                "email": "USER@example.com",
+                "handle": "second",
+                "firstName": "Second",
+                "lastName": "User",
+                "deleted": False,
+            },
+        ]
+    )
+
+    pg_session = AsyncMock()
+    pg_session.execute.return_value = _mock_scalar_result(["inserted-user-id"])
+
+    await migrate_users.up(mongo_db, pg_session, dry_run=False)
+
+    assert mongo_db.users.last_query == {"deleted": {"$ne": True}}
+    assert mongo_db.users.last_batch_size == migrate_users.BATCH_SIZE
+    pg_session.execute.assert_awaited_once()
+    pg_session.commit.assert_awaited_once()
+
+    captured = capsys.readouterr().out
+    assert "total=2" in captured
+    assert "inserted=1" in captured
+    assert "skipped=1" in captured
+
+
+@pytest.mark.asyncio
+async def test_migrate_users_up_dry_run_reports_progress(capsys):
+    mongo_db = _FakeMongoDB(
+        [
+            {
+                "_id": "507f1f77bcf86cd799439011",
+                "email": "user@example.com",
+                "handle": "userhandle",
+                "firstName": "Test",
+                "lastName": "User",
+                "deleted": False,
+            }
+        ]
+    )
+    pg_session = AsyncMock()
+    pg_session.execute.return_value = _mock_query_result([])
+
+    await migrate_users.up(mongo_db, pg_session, dry_run=True)
+
+    assert mongo_db.users.last_query == {"deleted": {"$ne": True}}
+    pg_session.execute.assert_awaited_once()
+    pg_session.commit.assert_not_awaited()
+
+    captured = capsys.readouterr().out
+    assert "dry_run=True" in captured
+    assert "inserted=1" in captured
+    assert "skipped=0" in captured
+
+
+@pytest.mark.asyncio
+async def test_migrate_users_up_dry_run_accounts_for_existing_and_prior_batch_conflicts(capsys, monkeypatch):
+    monkeypatch.setattr(migrate_users, "BATCH_SIZE", 2)
+
+    mongo_db = _FakeMongoDB(
+        [
+            {
+                "_id": "507f1f77bcf86cd799439011",
+                "email": "user@example.com",
+                "handle": "available",
+                "firstName": "A",
+                "lastName": "User",
+                "deleted": False,
+            },
+            {
+                "_id": "507f1f77bcf86cd799439012",
+                "email": "other@example.com",
+                "handle": "taken",
+                "firstName": "B",
+                "lastName": "User",
+                "deleted": False,
+            },
+            {
+                "_id": "507f1f77bcf86cd799439013",
+                "email": "USER@example.com",
+                "handle": "new-handle",
+                "firstName": "C",
+                "lastName": "User",
+                "deleted": False,
+            },
+            {
+                "_id": "507f1f77bcf86cd799439014",
+                "email": "third@example.com",
+                "handle": "third-handle",
+                "firstName": "D",
+                "lastName": "User",
+                "deleted": False,
+            },
+        ]
+    )
+
+    pg_session = AsyncMock()
+    pg_session.execute.side_effect = [
+        _mock_query_result([("someone@example.com", "taken")]),
+        _mock_query_result([]),
+    ]
+
+    await migrate_users.up(mongo_db, pg_session, dry_run=True)
+
+    assert pg_session.execute.await_count == 2
+    pg_session.commit.assert_not_awaited()
+
+    captured = capsys.readouterr().out
+    assert "total=4" in captured
+    assert "inserted=2" in captured
+    assert "skipped=2" in captured
+    assert "dry_run=True" in captured
+
+
+@pytest.mark.asyncio
+async def test_migrate_users_up_normalizes_datetime_date_of_birth():
+    mongo_db = _FakeMongoDB(
+        [
+            {
+                "_id": "507f1f77bcf86cd799439011",
+                "email": "user@example.com",
+                "handle": "userhandle",
+                "firstName": "Test",
+                "lastName": "User",
+                "dateOfBirth": datetime(1990, 1, 2, 12, 30, tzinfo=UTC),
+                "createdAt": datetime(2024, 1, 3, 9, 0, tzinfo=UTC),
+                "updatedAt": datetime(2024, 1, 4, 9, 0, tzinfo=UTC),
+                "deleted": False,
+            }
+        ]
+    )
+
+    pg_session = AsyncMock()
+    pg_session.execute.return_value = _mock_scalar_result(["inserted-user-id"])
+
+    await migrate_users.up(mongo_db, pg_session, dry_run=False)
+
+    statement = pg_session.execute.await_args.args[0]
+    compiled_params = statement.compile().params
+    date_of_birth_values = [value for key, value in compiled_params.items() if key.startswith("date_of_birth")]
+    assert date_of_birth_values == [date(1990, 1, 2)]
+
+
+@pytest.mark.asyncio
+async def test_migrate_users_up_flushes_in_batches(capsys, monkeypatch):
+    monkeypatch.setattr(migrate_users, "BATCH_SIZE", 2)
+
+    mongo_db = _FakeMongoDB(
+        [
+            {
+                "_id": f"507f1f77bcf86cd79943901{i}",
+                "email": f"user{i}@example.com",
+                "handle": f"user{i}",
+                "firstName": "Batch",
+                "lastName": "User",
+                "deleted": False,
+            }
+            for i in range(5)
+        ]
+    )
+
+    pg_session = AsyncMock()
+    pg_session.execute.side_effect = [
+        _mock_scalar_result(["a", "b"]),
+        _mock_scalar_result(["c", "d"]),
+        _mock_scalar_result(["e"]),
+    ]
+
+    await migrate_users.up(mongo_db, pg_session, dry_run=False)
+
+    assert pg_session.execute.await_count == 3
+    pg_session.commit.assert_awaited_once()
+
+    captured = capsys.readouterr().out
+    assert "total=5" in captured
+    assert "inserted=5" in captured
+    assert "skipped=0" in captured
+
+
+@pytest.mark.asyncio
+async def test_migrate_users_down_is_noop_when_mongo_empty(capsys):
+    mongo_db = _FakeMongoDB([])
+    pg_session = AsyncMock()
+
+    await migrate_users.down(mongo_db, pg_session)
+
+    pg_session.execute.assert_not_awaited()
+    pg_session.commit.assert_not_awaited()
+
+    captured = capsys.readouterr().out
+    assert "derived_ids=0" in captured
+    assert "deleted=0" in captured
+
+
+@pytest.mark.asyncio
+async def test_migrate_users_down_deletes_only_derived_ids(capsys):
+    from app.utils.id_utils import mongo_id_to_uuid
+
+    mongo_db = _FakeMongoDB(
+        [
+            {"_id": "507f1f77bcf86cd799439011", "email": "a@example.com"},
+            {"_id": "507f1f77bcf86cd799439012", "email": "b@example.com"},
+        ]
+    )
+
+    pg_session = AsyncMock()
+    delete_result = MagicMock()
+    delete_result.scalars.return_value.all.return_value = [
+        mongo_id_to_uuid("507f1f77bcf86cd799439011"),
+        mongo_id_to_uuid("507f1f77bcf86cd799439012"),
+    ]
+    pg_session.execute.return_value = delete_result
+
+    await migrate_users.down(mongo_db, pg_session)
+
+    pg_session.execute.assert_awaited_once()
+    pg_session.commit.assert_awaited_once()
+
+    statement = pg_session.execute.await_args.args[0]
+    sql = str(statement.compile(compile_kwargs={"literal_binds": True}))
+    assert mongo_id_to_uuid("507f1f77bcf86cd799439011").hex in sql
+    assert mongo_id_to_uuid("507f1f77bcf86cd799439012").hex in sql
+
+    captured = capsys.readouterr().out
+    assert "derived_ids=2" in captured
+    assert "deleted=2" in captured

--- a/tests/units/dependencies/test_repository_dependency.py
+++ b/tests/units/dependencies/test_repository_dependency.py
@@ -1,14 +1,21 @@
 import pytest
 
-from app.dependencies.repository_dependency import RepositoryActivationError, get_movie_repository
+from app.dependencies.repository_dependency import (
+    RepositoryActivationError,
+    get_movie_repository,
+    get_user_repository,
+)
 from app.repository.movie_repository import MovieRepository
+from app.repository.user_repository import UserRepository
 
 
 @pytest.fixture(autouse=True)
-def clear_movie_repository_cache():
+def clear_repository_caches():
     get_movie_repository.cache_clear()
+    get_user_repository.cache_clear()
     yield
     get_movie_repository.cache_clear()
+    get_user_repository.cache_clear()
 
 
 def test_get_movie_repository_defaults_to_mongo(monkeypatch):
@@ -24,3 +31,18 @@ def test_get_movie_repository_raises_for_unsafe_postgres_activation(monkeypatch)
 
     with pytest.raises(RepositoryActivationError, match="not yet safe"):
         get_movie_repository()
+
+
+def test_get_user_repository_defaults_to_mongo(monkeypatch):
+    monkeypatch.delenv("DB_BACKEND", raising=False)
+
+    repository = get_user_repository()
+
+    assert isinstance(repository, UserRepository)
+
+
+def test_get_user_repository_raises_for_unsafe_postgres_activation(monkeypatch):
+    monkeypatch.setenv("DB_BACKEND", "postgres")
+
+    with pytest.raises(RepositoryActivationError, match="not yet safe"):
+        get_user_repository()

--- a/tests/units/repository/test_postgres_user_repository.py
+++ b/tests/units/repository/test_postgres_user_repository.py
@@ -132,10 +132,18 @@ async def test_email_uniqueness_is_case_insensitive(repository: PostgresUserRepo
 
 
 @pytest.mark.asyncio
+async def test_handle_uniqueness_is_case_insensitive(repository: PostgresUserRepository):
+    await repository.create_user(_user_request(email="first-handle@example.com", handle="Antonio"))
+
+    with pytest.raises(IntegrityError):
+        await repository.create_user(_user_request(email="second-handle@example.com", handle="antonio"))
+
+
+@pytest.mark.asyncio
 async def test_find_user_by_handle_returns_active_row(repository: PostgresUserRepository):
     created = await repository.create_user(_user_request(handle="janedoe", email="jane@example.com"))
 
-    found = await repository.find_user_by_handle("janedoe")
+    found = await repository.find_user_by_handle("JANEDOE")
 
     assert found is not None
     assert found.id == created.id
@@ -143,7 +151,7 @@ async def test_find_user_by_handle_returns_active_row(repository: PostgresUserRe
 
 @pytest.mark.asyncio
 async def test_find_user_by_email_or_handle_matches_both_paths(repository: PostgresUserRepository):
-    created = await repository.create_user(_user_request(email="lookup@example.com", handle="lookuphandle"))
+    created = await repository.create_user(_user_request(email="lookup@example.com", handle="LookupHandle"))
 
     found_by_email = await repository.find_user_by_email_or_handle("LOOKUP@example.com")
     found_by_handle = await repository.find_user_by_email_or_handle("lookuphandle")

--- a/tests/units/repository/test_postgres_user_repository.py
+++ b/tests/units/repository/test_postgres_user_repository.py
@@ -1,0 +1,308 @@
+"""Unit tests for ``PostgresUserRepository``."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from datetime import UTC, date, datetime
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from pytest_postgresql.janitor import DatabaseJanitor
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.models.base_model import Base
+from app.models.user_model import PostgresUser
+from app.repository.postgres_user_repository import PostgresUserRepository
+from app.schemas.user_schemas import UserCreateRequest
+from app.utils.id_utils import mongo_id_to_uuid
+
+
+def _async_url(pg, dbname: str) -> str:
+    return f"postgresql+asyncpg://{pg.user}:{pg.password}@{pg.host}:{pg.port}/{dbname}"
+
+
+@pytest_asyncio.fixture
+async def pg_engine(postgresql_proc):
+    """Create a fresh database per test and return an async SQLAlchemy engine."""
+    dbname = f"cinelog_user_test_{uuid4().hex[:8]}"
+
+    with DatabaseJanitor(
+        user=postgresql_proc.user,
+        host=postgresql_proc.host,
+        port=postgresql_proc.port,
+        dbname=dbname,
+        version=postgresql_proc.version,
+        password=postgresql_proc.password,
+    ):
+        engine = create_async_engine(_async_url(postgresql_proc, dbname))
+        async with engine.begin() as connection:
+            await connection.execute(text("CREATE EXTENSION IF NOT EXISTS pgcrypto"))
+            await connection.run_sync(Base.metadata.create_all)
+
+        try:
+            yield engine
+        finally:
+            await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def session_factory(pg_engine):
+    return async_sessionmaker(pg_engine, class_=AsyncSession, expire_on_commit=False)
+
+
+@pytest.fixture
+def repository(session_factory) -> PostgresUserRepository:
+    @asynccontextmanager
+    async def _provider():
+        async with session_factory() as session:
+            yield session
+
+    return PostgresUserRepository(session_provider=_provider)
+
+
+@pytest_asyncio.fixture
+async def seed_session(session_factory):
+    async with session_factory() as session:
+        yield session
+
+
+def _user_request(
+    *,
+    first_name: str = "John",
+    last_name: str = "Doe",
+    email: str = "john@example.com",
+    handle: str = "johndoe",
+    bio: str | None = None,
+    date_of_birth: date = date(1990, 1, 1),
+    password_hash: str | None = "$2b$12$hashed",
+    profile_visibility: str = "private",
+) -> UserCreateRequest:
+    return UserCreateRequest(
+        first_name=first_name,
+        last_name=last_name,
+        email=email,
+        handle=handle,
+        bio=bio,
+        date_of_birth=date_of_birth,
+        password_hash=password_hash,
+        profile_visibility=profile_visibility,
+    )
+
+
+async def _add(seed_session: AsyncSession, *users: PostgresUser) -> None:
+    seed_session.add_all(users)
+    await seed_session.commit()
+    for user in users:
+        await seed_session.refresh(user)
+
+
+@pytest.mark.asyncio
+async def test_create_user_persists_row(repository: PostgresUserRepository, seed_session: AsyncSession):
+    user = await repository.create_user(_user_request())
+
+    assert user.id is not None
+    assert user.email == "john@example.com"
+    assert user.handle == "johndoe"
+    assert user.deleted is False
+
+    persisted = await seed_session.get(PostgresUser, user.id)
+    assert persisted is not None
+    assert persisted.first_name == "John"
+
+
+@pytest.mark.asyncio
+async def test_find_user_by_email_is_case_insensitive(repository: PostgresUserRepository):
+    await repository.create_user(_user_request(email="User@Example.com", handle="mixedcase"))
+
+    found = await repository.find_user_by_email("user@example.com")
+
+    assert found is not None
+    assert found.handle == "mixedcase"
+
+
+@pytest.mark.asyncio
+async def test_email_uniqueness_is_case_insensitive(repository: PostgresUserRepository):
+    await repository.create_user(_user_request(email="User@Example.com", handle="firsthandle"))
+
+    with pytest.raises(IntegrityError):
+        await repository.create_user(_user_request(email="user@example.com", handle="secondhandle"))
+
+
+@pytest.mark.asyncio
+async def test_find_user_by_handle_returns_active_row(repository: PostgresUserRepository):
+    created = await repository.create_user(_user_request(handle="janedoe", email="jane@example.com"))
+
+    found = await repository.find_user_by_handle("janedoe")
+
+    assert found is not None
+    assert found.id == created.id
+
+
+@pytest.mark.asyncio
+async def test_find_user_by_email_or_handle_matches_both_paths(repository: PostgresUserRepository):
+    created = await repository.create_user(_user_request(email="lookup@example.com", handle="lookuphandle"))
+
+    found_by_email = await repository.find_user_by_email_or_handle("LOOKUP@example.com")
+    found_by_handle = await repository.find_user_by_email_or_handle("lookuphandle")
+
+    assert found_by_email is not None
+    assert found_by_handle is not None
+    assert found_by_email.id == created.id
+    assert found_by_handle.id == created.id
+
+
+@pytest.mark.asyncio
+async def test_find_user_by_id_excludes_deleted_and_unknown(
+    repository: PostgresUserRepository, seed_session: AsyncSession
+):
+    active = PostgresUser(
+        email="active@example.com",
+        handle="active",
+        first_name="Active",
+        last_name="User",
+        date_of_birth=date(1990, 1, 1),
+    )
+    deleted = PostgresUser(
+        email="deleted@example.com",
+        handle="deleted",
+        first_name="Deleted",
+        last_name="User",
+        date_of_birth=date(1990, 1, 1),
+        deleted=True,
+        deleted_at=datetime.now(UTC),
+    )
+    await _add(seed_session, active, deleted)
+
+    assert (await repository.find_user_by_id(active.id)) is not None
+    assert (await repository.find_user_by_id(deleted.id)) is None
+    assert (await repository.find_user_by_id(uuid4())) is None
+
+
+@pytest.mark.asyncio
+async def test_delete_user_soft_deletes_row(repository: PostgresUserRepository, seed_session: AsyncSession):
+    user = await repository.create_user(_user_request(email="softdelete@example.com", handle="softdelete"))
+
+    deleted = await repository.delete_user(user.id)
+
+    assert deleted is True
+    assert await repository.find_user_by_id(user.id) is None
+
+    persisted = await seed_session.get(PostgresUser, user.id)
+    assert persisted is not None
+    assert persisted.deleted is True
+    assert persisted.deleted_at is not None
+
+
+@pytest.mark.asyncio
+async def test_delete_user_returns_false_for_unknown_id(repository: PostgresUserRepository):
+    assert await repository.delete_user(uuid4()) is False
+
+
+@pytest.mark.asyncio
+async def test_delete_user_oblivion_overwrites_sensitive_fields(
+    repository: PostgresUserRepository, seed_session: AsyncSession
+):
+    user = await repository.create_user(
+        _user_request(
+            email="obliterate@example.com",
+            handle="obliterate",
+            bio="Sensitive bio",
+        )
+    )
+    user = await repository.set_reset_password_code(user, "RESET", datetime.now(UTC))
+
+    deleted = await repository.delete_user_oblivion(user.id)
+
+    assert deleted is True
+    persisted = await seed_session.get(PostgresUser, user.id)
+    assert persisted is not None
+    assert persisted.first_name == "Deleted"
+    assert persisted.last_name == "User"
+    assert persisted.email == f"deleted_{user.id}@deleted.local"
+    assert persisted.handle == f"deleted_{user.id}"
+    assert persisted.bio is None
+    assert persisted.password_hash is None
+    assert persisted.reset_password_code is None
+    assert persisted.reset_password_expires is None
+    assert persisted.date_of_birth is None
+    assert persisted.deleted is True
+
+
+@pytest.mark.asyncio
+async def test_update_password_changes_hash(repository: PostgresUserRepository, seed_session: AsyncSession):
+    user = await repository.create_user(_user_request(email="password@example.com", handle="passwordhandle"))
+
+    updated = await repository.update_password(user, "$2b$12$new_hashed")
+
+    assert updated.password_hash == "$2b$12$new_hashed"
+    persisted = await seed_session.get(PostgresUser, user.id)
+    assert persisted is not None
+    assert persisted.password_hash == "$2b$12$new_hashed"
+
+
+@pytest.mark.asyncio
+async def test_set_reset_password_code_updates_fields(repository: PostgresUserRepository):
+    user = await repository.create_user(_user_request(email="reset@example.com", handle="resethandle"))
+    expires_at = datetime.now(UTC)
+
+    updated = await repository.set_reset_password_code(user, "ABC123", expires_at)
+
+    assert updated.reset_password_code == "ABC123"
+    assert updated.reset_password_expires == expires_at
+
+
+@pytest.mark.asyncio
+async def test_clear_reset_password_code_nulls_fields(repository: PostgresUserRepository):
+    user = await repository.create_user(_user_request(email="clear@example.com", handle="clearhandle"))
+    user = await repository.set_reset_password_code(user, "ABC123", datetime.now(UTC))
+
+    updated = await repository.clear_reset_password_code(user)
+
+    assert updated.reset_password_code is None
+    assert updated.reset_password_expires is None
+
+
+@pytest.mark.asyncio
+async def test_update_user_profile_only_changes_whitelisted_fields(
+    repository: PostgresUserRepository, seed_session: AsyncSession
+):
+    user = await repository.create_user(
+        _user_request(
+            email="profile@example.com",
+            handle="profilehandle",
+            bio="Old bio",
+        )
+    )
+
+    updated = await repository.update_user_profile(
+        user.id,
+        {
+            "first_name": "Jane",
+            "last_name": "Smith",
+            "bio": "New bio",
+            "profile_visibility": "public",
+            "date_of_birth": date(1991, 2, 3),
+            "email": "ignored@example.com",
+        },
+    )
+
+    assert updated is not None
+    assert updated.first_name == "Jane"
+    assert updated.last_name == "Smith"
+    assert updated.bio == "New bio"
+    assert updated.profile_visibility == "public"
+    assert updated.date_of_birth == date(1991, 2, 3)
+
+    persisted = await seed_session.get(PostgresUser, user.id)
+    assert persisted is not None
+    assert persisted.email == "profile@example.com"
+
+
+def test_mongo_id_to_uuid_is_deterministic_for_user_migration():
+    first = mongo_id_to_uuid("507f1f77bcf86cd799439011")
+    second = mongo_id_to_uuid("507f1f77bcf86cd799439011")
+
+    assert first == second

--- a/tests/units/repository/test_postgres_user_repository.py
+++ b/tests/units/repository/test_postgres_user_repository.py
@@ -306,3 +306,20 @@ def test_mongo_id_to_uuid_is_deterministic_for_user_migration():
     second = mongo_id_to_uuid("507f1f77bcf86cd799439011")
 
     assert first == second
+
+
+@pytest.mark.asyncio
+async def test_profile_visibility_check_constraint_rejects_invalid_value(seed_session: AsyncSession):
+    invalid_user = PostgresUser(
+        email="invalid-visibility@example.com",
+        handle="invalidvisibility",
+        first_name="Invalid",
+        last_name="Visibility",
+        date_of_birth=date(1990, 1, 1),
+        profile_visibility="hidden",
+    )
+
+    seed_session.add(invalid_user)
+
+    with pytest.raises(IntegrityError):
+        await seed_session.commit()

--- a/tests/units/schemas/test_user_schemas.py
+++ b/tests/units/schemas/test_user_schemas.py
@@ -1,0 +1,31 @@
+from datetime import date
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.user_schemas import UserCreateRequest
+
+
+def test_user_create_request_rejects_invalid_profile_visibility():
+    with pytest.raises(ValidationError):
+        UserCreateRequest(
+            first_name="John",
+            last_name="Doe",
+            email="john@example.com",
+            handle="johndoe",
+            date_of_birth=date(1990, 1, 1),
+            profile_visibility="hidden",
+        )
+
+
+def test_user_create_request_normalizes_profile_visibility():
+    request = UserCreateRequest(
+        first_name="John",
+        last_name="Doe",
+        email="john@example.com",
+        handle="johndoe",
+        date_of_birth=date(1990, 1, 1),
+        profile_visibility=" PUBLIC ",
+    )
+
+    assert request.profile_visibility == "public"


### PR DESCRIPTION
## Summary
- add the PostgreSQL user model, repository, Alembic schema migration, and Mongo-to-Postgres data migration script
- keep the Mongo user repository active while adding `get_user_repository()` mixed-mode activation guardrails and wiring services through it
- add Postgres-specific repository and migration tests, and update technical migration docs

## Testing
- make test-unit
- make lint
- make typecheck

Closes #127
