### PR TITLE
[Migration] MovieRating Repository → PostgreSQL

### DIFF
--- a/alembic/versions/003_create_movie_ratings_table.py
+++ b/alembic/versions/003_create_movie_ratings_table.py
@@ -1,0 +1,47 @@
+"""create movie ratings table
+
+Revision ID: 003_create_movie_ratings_table
+Revises: 002_create_users_table
+Create Date: 2026-06-01 14:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "003_create_movie_ratings_table"
+down_revision: str | Sequence[str] | None = "002_create_users_table"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Apply the migration."""
+    op.execute("CREATE EXTENSION IF NOT EXISTS pgcrypto")
+
+    op.create_table(
+        "movie_ratings",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("movie_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("movies.id"), nullable=False),
+        sa.Column("tmdb_id", sa.Integer(), nullable=False),
+        sa.Column("rating", sa.Integer(), nullable=True),
+        sa.Column("review", sa.Text(), nullable=True),
+        sa.Column("deleted", sa.Boolean(), nullable=False, server_default=sa.text("FALSE")),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.CheckConstraint("rating BETWEEN 1 AND 10", name="ck_movie_ratings_rating_range"),
+        sa.UniqueConstraint("user_id", "tmdb_id", name="uq_movie_ratings_user_tmdb"),
+    )
+
+    op.create_index("ix_movie_ratings_user_movie", "movie_ratings", ["user_id", "movie_id"], unique=False)
+
+
+def downgrade() -> None:
+    """Rollback the migration."""
+    op.drop_index("ix_movie_ratings_user_movie", table_name="movie_ratings")
+    op.drop_table("movie_ratings")

--- a/app/dependencies/repository_dependency.py
+++ b/app/dependencies/repository_dependency.py
@@ -3,6 +3,7 @@
 from functools import lru_cache
 
 from app.db.postgres import is_postgres_required
+from app.repository.movie_rating_repository import MovieRatingRepository
 from app.repository.movie_repository import MovieRepository
 from app.repository.user_repository import UserRepository
 
@@ -49,3 +50,24 @@ def get_user_repository() -> UserRepository:
         )
 
     return UserRepository()
+
+
+@lru_cache
+def get_movie_rating_repository() -> MovieRatingRepository:
+    """Return the active movie-rating repository implementation.
+
+    MovieRatingRepository PostgreSQL activation is intentionally blocked in
+    mixed mode because auth still provides Mongo ObjectId user identifiers,
+    LogRepository still consumes ObjectId movie references, and MovieRepository
+    activation remains blocked until later cutover work.
+    """
+
+    if is_postgres_required():
+        raise RepositoryActivationError(
+            "DB_BACKEND=postgres is not yet safe for MovieRatingRepository activation: "
+            "auth still provides Mongo ObjectId user IDs, LogRepository still depends on "
+            "Mongo ObjectId movie references, and MovieRepository cutover remains blocked. "
+            "Keep DB_BACKEND=mongo until related repositories and ID adapters are migrated."
+        )
+
+    return MovieRatingRepository()

--- a/app/dependencies/service_dependency.py
+++ b/app/dependencies/service_dependency.py
@@ -8,10 +8,13 @@ Tests can swap a whole service through
 
 from functools import lru_cache
 
-from app.dependencies.repository_dependency import get_movie_repository, get_user_repository
+from app.dependencies.repository_dependency import (
+    get_movie_rating_repository,
+    get_movie_repository,
+    get_user_repository,
+)
 from app.repository.log_cache_repository import LogCacheRepository
 from app.repository.log_repository import LogRepository
-from app.repository.movie_rating_repository import MovieRatingRepository
 from app.services.auth_rate_limit_service import AuthRateLimitService
 from app.services.auth_service import AuthService
 from app.services.log_service import LogService
@@ -44,7 +47,7 @@ def get_movie_service() -> MovieService:
 @lru_cache
 def get_movie_rating_service() -> MovieRatingService:
     return MovieRatingService(
-        movie_rating_repository=MovieRatingRepository(),
+        movie_rating_repository=get_movie_rating_repository(),
         movie_service=get_movie_service(),
     )
 
@@ -55,7 +58,7 @@ def get_log_service() -> LogService:
         log_repository=LogCacheRepository(LogRepository()),
         movie_service=get_movie_service(),
         movie_repository=get_movie_repository(),
-        movie_rating_repository=MovieRatingRepository(),
+        movie_rating_repository=get_movie_rating_repository(),
         user_repository=get_user_repository(),
     )
 
@@ -64,6 +67,6 @@ def get_log_service() -> LogService:
 def get_stats_service() -> StatsService:
     return StatsService(
         log_repository=LogCacheRepository(LogRepository()),
-        movie_rating_repository=MovieRatingRepository(),
+        movie_rating_repository=get_movie_rating_repository(),
         movie_repository=get_movie_repository(),
     )

--- a/app/models/movie_rating_model.py
+++ b/app/models/movie_rating_model.py
@@ -1,0 +1,42 @@
+"""PostgreSQL movie-rating ORM model."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import CheckConstraint, ForeignKey, Index, Integer, Text, UniqueConstraint, text
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base_model import PostgresBaseEntity
+
+
+class PostgresMovieRating(PostgresBaseEntity):
+    """Movie rating record stored in PostgreSQL."""
+
+    __tablename__ = "movie_ratings"
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    user_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("users.id"),
+        nullable=False,
+    )
+    movie_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("movies.id"),
+        nullable=False,
+    )
+    tmdb_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    rating: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    review: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    __table_args__ = (
+        CheckConstraint("rating BETWEEN 1 AND 10", name="ck_movie_ratings_rating_range"),
+        UniqueConstraint("user_id", "tmdb_id", name="uq_movie_ratings_user_tmdb"),
+        Index("ix_movie_ratings_user_movie", "user_id", "movie_id"),
+    )

--- a/app/repository/movie_rating_repository.py
+++ b/app/repository/movie_rating_repository.py
@@ -6,6 +6,16 @@ from app.utils.object_id_utils import to_object_id
 
 
 class MovieRatingRepository:
+    """MongoDB movie-rating repository — active runtime implementation.
+
+    Pending replacement by ``PostgresMovieRatingRepository`` (in
+    ``app/repository/postgres_movie_rating_repository.py``) once auth,
+    movie/log repository dependencies, and mixed-mode ID adapters no longer
+    depend on ObjectId-based user and movie identifiers. The PostgreSQL
+    repository is intentionally unwired today — do not import it from runtime
+    code paths.
+    """
+
     async def find_movie_rating_by_user_and_movie(
         self, user_id: PydanticObjectId, movie_id: PydanticObjectId
     ) -> MovieRating | None:

--- a/app/repository/postgres_movie_rating_repository.py
+++ b/app/repository/postgres_movie_rating_repository.py
@@ -1,0 +1,137 @@
+"""PostgreSQL movie-rating repository implementation."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import func, select
+from sqlalchemy.dialects.postgresql import insert
+
+from app.models.movie_rating_model import PostgresMovieRating
+from app.repository.repository_base import RepositoryBase
+from app.schemas.movie_rating_schemas import MovieRatingStats
+
+
+class PostgresMovieRatingRepository(RepositoryBase):
+    """Repository class for PostgreSQL movie-rating operations."""
+
+    async def find_movie_rating_by_user_and_movie(
+        self,
+        user_id: UUID,
+        movie_id: UUID,
+    ) -> PostgresMovieRating | None:
+        """Find an active movie rating by user ID and movie ID."""
+
+        async with self._session_provider() as session:
+            statement = select(PostgresMovieRating).where(
+                PostgresMovieRating.user_id == user_id,
+                PostgresMovieRating.movie_id == movie_id,
+                PostgresMovieRating.active(),
+            )
+            result = await session.execute(statement)
+            return result.scalar_one_or_none()
+
+    async def find_movie_rating_by_user_and_tmdb(
+        self,
+        user_id: UUID,
+        tmdb_id: int,
+    ) -> PostgresMovieRating | None:
+        """Find an active movie rating by user ID and TMDB ID."""
+
+        async with self._session_provider() as session:
+            statement = select(PostgresMovieRating).where(
+                PostgresMovieRating.user_id == user_id,
+                PostgresMovieRating.tmdb_id == tmdb_id,
+                PostgresMovieRating.active(),
+            )
+            result = await session.execute(statement)
+            return result.scalar_one_or_none()
+
+    async def create_update_movie_rating(
+        self,
+        user_id: UUID,
+        movie_id: UUID,
+        rating: int,
+        comment: str | None,
+        tmdb_id: int,
+    ) -> PostgresMovieRating:
+        """Insert or update a movie rating using PostgreSQL native upsert."""
+
+        async with self._session_provider() as session:
+            statement = (
+                insert(PostgresMovieRating)
+                .values(
+                    user_id=user_id,
+                    movie_id=movie_id,
+                    tmdb_id=tmdb_id,
+                    rating=rating,
+                    review=comment,
+                )
+                .on_conflict_do_update(
+                    index_elements=[PostgresMovieRating.user_id, PostgresMovieRating.tmdb_id],
+                    set_={
+                        "movie_id": movie_id,
+                        "rating": rating,
+                        "review": comment,
+                        "updated_at": func.now(),
+                        "deleted": False,
+                        "deleted_at": None,
+                    },
+                )
+                .returning(PostgresMovieRating.id)
+            )
+            result = await session.execute(statement)
+            rating_id = result.scalar_one()
+            await session.commit()
+
+            rating_record = await session.get(PostgresMovieRating, rating_id)
+            if rating_record is None:
+                raise LookupError("Movie rating not found after upsert.")
+
+            return rating_record
+
+    async def find_movie_ratings_by_user_and_movie_ids(
+        self,
+        user_id: UUID,
+        movie_ids: set[UUID],
+    ) -> list[PostgresMovieRating]:
+        """Find active movie ratings for a user across movie IDs."""
+
+        if not movie_ids:
+            return []
+
+        async with self._session_provider() as session:
+            statement = select(PostgresMovieRating).where(
+                PostgresMovieRating.user_id == user_id,
+                PostgresMovieRating.movie_id.in_(movie_ids),
+                PostgresMovieRating.active(),
+            )
+            result = await session.execute(statement)
+            return list(result.scalars().all())
+
+    async def get_user_movie_ratings_average(
+        self,
+        user_id: UUID,
+        movie_ids: set[UUID],
+    ) -> MovieRatingStats:
+        """Compute average movie rating and count for the user's active ratings."""
+
+        if not movie_ids:
+            return MovieRatingStats(average_rating=0.0, total_ratings=0)
+
+        async with self._session_provider() as session:
+            statement = select(
+                func.avg(PostgresMovieRating.rating),
+                func.count(PostgresMovieRating.id),
+            ).where(
+                PostgresMovieRating.user_id == user_id,
+                PostgresMovieRating.movie_id.in_(movie_ids),
+                PostgresMovieRating.active(),
+                PostgresMovieRating.rating.is_not(None),
+            )
+            result = await session.execute(statement)
+            average_rating, total_ratings = result.one()
+            return MovieRatingStats(
+                average_rating=float(average_rating or 0.0),
+                total_ratings=int(total_ratings or 0),
+            )

--- a/app/services/log_service.py
+++ b/app/services/log_service.py
@@ -1,6 +1,10 @@
 from beanie import PydanticObjectId
 
-from app.dependencies.repository_dependency import get_movie_repository, get_user_repository
+from app.dependencies.repository_dependency import (
+    get_movie_rating_repository,
+    get_movie_repository,
+    get_user_repository,
+)
 from app.models.movie import Movie
 from app.repository.log_cache_repository import LogCacheRepository
 from app.repository.movie_rating_repository import MovieRatingRepository
@@ -39,7 +43,7 @@ class LogService:
             movie_service = MovieService(resolved_movie_repository)
 
         self.movie_service = movie_service
-        self.movie_rating_repository = movie_rating_repository or MovieRatingRepository()
+        self.movie_rating_repository = movie_rating_repository or get_movie_rating_repository()
         self.movie_repository = resolved_movie_repository
         self.stats_cache_service = stats_cache_service or StatsCacheService()
         self.user_repository = user_repository or get_user_repository()

--- a/app/services/stats_service.py
+++ b/app/services/stats_service.py
@@ -3,7 +3,7 @@ from datetime import date
 
 from beanie import PydanticObjectId
 
-from app.dependencies.repository_dependency import get_movie_repository
+from app.dependencies.repository_dependency import get_movie_rating_repository, get_movie_repository
 from app.repository.log_cache_repository import LogCacheRepository
 from app.repository.movie_rating_repository import MovieRatingRepository
 from app.repository.movie_repository import MovieRepository
@@ -27,7 +27,7 @@ class StatsService:
         stats_cache_service: StatsCacheService | None = None,
     ):
         self.log_repository = log_repository or LogCacheRepository()
-        self.movie_rating_repository = movie_rating_repository or MovieRatingRepository()
+        self.movie_rating_repository = movie_rating_repository or get_movie_rating_repository()
         self.movie_repository = movie_repository or get_movie_repository()
         self.stats_cache_service = stats_cache_service or StatsCacheService()
 

--- a/db_migrations/m003_migrate_movie_ratings.py
+++ b/db_migrations/m003_migrate_movie_ratings.py
@@ -1,0 +1,221 @@
+"""Migrate movie ratings data from MongoDB to PostgreSQL."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import NamedTuple
+from uuid import UUID
+
+from sqlalchemy import delete, select
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.movie_model import PostgresMovie
+from app.models.movie_rating_model import PostgresMovieRating
+from app.models.user_model import PostgresUser
+from app.utils.id_utils import mongo_id_to_uuid
+
+BATCH_SIZE = 100
+
+
+class BatchOutcome(NamedTuple):
+    inserted: int
+    skipped: int
+    warnings: int
+
+
+def _normalize_movie_rating_doc(mongo_rating: dict) -> dict:
+    mongo_user_id = mongo_rating.get("userId")
+    mongo_movie_id = mongo_rating.get("movieId")
+
+    return {
+        "id": mongo_id_to_uuid(str(mongo_rating["_id"])),
+        "user_id": mongo_id_to_uuid(str(mongo_user_id)) if mongo_user_id is not None else None,
+        "movie_id": mongo_id_to_uuid(str(mongo_movie_id)) if mongo_movie_id is not None else None,
+        "tmdb_id": mongo_rating.get("tmdbId"),
+        "rating": mongo_rating.get("rating"),
+        "review": mongo_rating.get("review"),
+        "deleted": bool(mongo_rating.get("deleted", False)),
+        "deleted_at": mongo_rating.get("deletedAt"),
+        "created_at": mongo_rating.get("createdAt") or datetime.now(UTC),
+        "updated_at": mongo_rating.get("updatedAt") or datetime.now(UTC),
+    }
+
+
+def _warn_missing_reference(values: dict, reason: str) -> None:
+    print(f"[movie-ratings-migration:warn] rating_id={values['id']} {reason}")
+
+
+async def _validate_batch_foreign_keys(
+    pg_session: AsyncSession,
+    batch: list[dict],
+) -> tuple[list[dict], int]:
+    """Filter out rows with missing required values or unresolved foreign keys."""
+
+    prelim_valid: list[dict] = []
+    warnings = 0
+
+    for values in batch:
+        if values["user_id"] is None or values["movie_id"] is None or values["tmdb_id"] is None:
+            _warn_missing_reference(values, "missing required user_id, movie_id, or tmdb_id")
+            warnings += 1
+            continue
+        prelim_valid.append(values)
+
+    if not prelim_valid:
+        return [], warnings
+
+    user_ids = {values["user_id"] for values in prelim_valid}
+    movie_ids = {values["movie_id"] for values in prelim_valid}
+
+    user_result = await pg_session.execute(select(PostgresUser.id).where(PostgresUser.id.in_(user_ids)))
+    movie_result = await pg_session.execute(select(PostgresMovie.id).where(PostgresMovie.id.in_(movie_ids)))
+
+    existing_user_ids = set(user_result.scalars().all())
+    existing_movie_ids = set(movie_result.scalars().all())
+
+    valid: list[dict] = []
+    for values in prelim_valid:
+        missing_parts: list[str] = []
+        if values["user_id"] not in existing_user_ids:
+            missing_parts.append("user FK missing")
+        if values["movie_id"] not in existing_movie_ids:
+            missing_parts.append("movie FK missing")
+
+        if missing_parts:
+            _warn_missing_reference(values, ", ".join(missing_parts))
+            warnings += 1
+            continue
+
+        valid.append(values)
+
+    return valid, warnings
+
+
+async def _count_dry_run_insertable_ratings(
+    pg_session: AsyncSession,
+    batch: list[dict],
+    projected_pairs: set[tuple[UUID, int]],
+) -> int:
+    """Count how many valid rows a dry-run batch would insert after conflicts."""
+
+    batch_user_ids = {values["user_id"] for values in batch}
+    batch_tmdb_ids = {values["tmdb_id"] for values in batch}
+    statement = select(PostgresMovieRating.user_id, PostgresMovieRating.tmdb_id).where(
+        PostgresMovieRating.user_id.in_(batch_user_ids),
+        PostgresMovieRating.tmdb_id.in_(batch_tmdb_ids),
+    )
+    result = await pg_session.execute(statement)
+
+    occupied_pairs = set(projected_pairs)
+    occupied_pairs.update((user_id, tmdb_id) for user_id, tmdb_id in result.all())
+
+    insertable_pairs: set[tuple[UUID, int]] = set()
+    for values in batch:
+        pair = (values["user_id"], values["tmdb_id"])
+        if pair in occupied_pairs or pair in insertable_pairs:
+            continue
+        insertable_pairs.add(pair)
+
+    projected_pairs.update(insertable_pairs)
+    return len(insertable_pairs)
+
+
+async def _flush_batch(
+    pg_session: AsyncSession,
+    batch: list[dict],
+    *,
+    dry_run: bool,
+    projected_pairs: set[tuple[UUID, int]] | None = None,
+) -> BatchOutcome:
+    """Insert a batch and return inserted/skipped/warning counts."""
+
+    if not batch:
+        return BatchOutcome(inserted=0, skipped=0, warnings=0)
+
+    valid_batch, warnings = await _validate_batch_foreign_keys(pg_session, batch)
+    if not valid_batch:
+        return BatchOutcome(inserted=0, skipped=len(batch), warnings=warnings)
+
+    if dry_run:
+        inserted = await _count_dry_run_insertable_ratings(
+            pg_session,
+            valid_batch,
+            projected_pairs if projected_pairs is not None else set(),
+        )
+        return BatchOutcome(inserted=inserted, skipped=len(batch) - inserted, warnings=warnings)
+
+    statement = (
+        insert(PostgresMovieRating)
+        .values(valid_batch)
+        .on_conflict_do_nothing(index_elements=[PostgresMovieRating.user_id, PostgresMovieRating.tmdb_id])
+        .returning(PostgresMovieRating.id)
+    )
+    result = await pg_session.execute(statement)
+    inserted = len(result.scalars().all())
+    return BatchOutcome(inserted=inserted, skipped=len(batch) - inserted, warnings=warnings)
+
+
+async def up(mongo_db, pg_session: AsyncSession, dry_run: bool = False) -> None:
+    """Migrate active movie ratings from MongoDB into PostgreSQL in batches."""
+
+    cursor = mongo_db.movie_ratings.find({"deleted": {"$ne": True}}, batch_size=BATCH_SIZE)
+
+    total = 0
+    inserted = 0
+    skipped = 0
+    warnings = 0
+    batch: list[dict] = []
+    projected_pairs: set[tuple[UUID, int]] = set()
+
+    for mongo_rating in cursor:
+        total += 1
+        batch.append(_normalize_movie_rating_doc(mongo_rating))
+
+        if len(batch) >= BATCH_SIZE:
+            outcome = await _flush_batch(
+                pg_session,
+                batch,
+                dry_run=dry_run,
+                projected_pairs=projected_pairs,
+            )
+            inserted += outcome.inserted
+            skipped += outcome.skipped
+            warnings += outcome.warnings
+            batch = []
+
+    if batch:
+        outcome = await _flush_batch(
+            pg_session,
+            batch,
+            dry_run=dry_run,
+            projected_pairs=projected_pairs,
+        )
+        inserted += outcome.inserted
+        skipped += outcome.skipped
+        warnings += outcome.warnings
+
+    if not dry_run:
+        await pg_session.commit()
+
+    print(
+        "[movie-ratings-migration] "
+        f"total={total} inserted={inserted} skipped={skipped} warnings={warnings} dry_run={dry_run}"
+    )
+
+
+async def down(mongo_db, pg_session: AsyncSession) -> None:
+    """Rollback movie-rating migration by deleting only rows derived from Mongo."""
+
+    cursor = mongo_db.movie_ratings.find({}, batch_size=BATCH_SIZE)
+    derived_ids = [mongo_id_to_uuid(str(doc["_id"])) for doc in cursor]
+
+    deleted_count = 0
+    if derived_ids:
+        result = await pg_session.execute(
+            delete(PostgresMovieRating).where(PostgresMovieRating.id.in_(derived_ids)).returning(PostgresMovieRating.id)
+        )
+        deleted_count = len(result.scalars().all())
+        await pg_session.commit()
+
+    print(f"[movie-ratings-migration:down] derived_ids={len(derived_ids)} deleted={deleted_count}")

--- a/docs/technical/postgres-migration.md
+++ b/docs/technical/postgres-migration.md
@@ -185,6 +185,61 @@ Migration rules:
 - Idempotent inserts via PostgreSQL `ON CONFLICT DO NOTHING`
 - Progress reporting (total / inserted / skipped)
 
+## MovieRating Collection Migration
+
+`#128` adds PostgreSQL movie-rating persistence and migration scaffolding while Mongo remains active at runtime.
+
+### Repository split
+
+- Legacy Mongo implementation remains in `app/repository/movie_rating_repository.py` as `MovieRatingRepository` (deprecated during migration).
+- New PostgreSQL implementation lives in `app/repository/postgres_movie_rating_repository.py` as `PostgresMovieRatingRepository`.
+- Runtime activation is intentionally blocked by `get_movie_rating_repository()` until user/movie/log ID dependencies are safe.
+
+### Table shape
+
+Alembic migration creates `movie_ratings` with canonical rating fields and soft-delete metadata:
+
+- `user_id UUID NOT NULL REFERENCES users(id)`
+- `movie_id UUID NOT NULL REFERENCES movies(id)`
+- `tmdb_id INTEGER NOT NULL`
+- `rating INTEGER NULL CHECK (rating BETWEEN 1 AND 10)`
+- `review TEXT NULL`
+
+The current Mongo uniqueness/upsert identity is preserved with:
+
+- `UNIQUE (user_id, tmdb_id)`
+
+The main read path also gets a supporting composite index:
+
+- `CREATE INDEX ix_movie_ratings_user_movie ON movie_ratings (user_id, movie_id)`
+
+### Native upsert behavior
+
+`PostgresMovieRatingRepository.create_update_movie_rating(...)` uses PostgreSQL `INSERT .. ON CONFLICT .. DO UPDATE` keyed by `(user_id, tmdb_id)` instead of Mongo's application-level check-then-save flow.
+
+Conflict updates:
+
+- overwrite `movie_id`, `rating`, and `review`
+- refresh `updated_at`
+- clear `deleted` / `deleted_at` so a matching soft-deleted row is revived
+
+### Data migration script
+
+Use `db_migrations/m003_migrate_movie_ratings.py` with async session wiring:
+
+- `up(mongo_db, pg_session, dry_run=False)` migrates active (non-deleted) movie ratings
+- `down(mongo_db, pg_session)` deletes only PostgreSQL rows whose UUIDs derive from the current Mongo `movie_ratings` collection
+
+Migration rules:
+
+- Skip `deleted=True` Mongo rows
+- Map Mongo `_id`, `userId`, and `movieId` -> Postgres UUID via `mongo_id_to_uuid(...)`
+- Validate that derived `user_id` and `movie_id` already exist in PostgreSQL before insert
+- Skip missing-FK rows with warnings
+- Preserve `tmdbId`, `rating`, `review`, and timestamps
+- Idempotent inserts via PostgreSQL `ON CONFLICT (user_id, tmdb_id) DO NOTHING`
+- Progress reporting (total / inserted / skipped / warnings)
+
 ## Activation Guardrails
 
 PostgreSQL movie activation is intentionally blocked in mixed mode while `LogRepository` and `MovieRatingRepository` still persist/query Mongo ObjectId movie references.
@@ -193,12 +248,14 @@ Activation must happen through dependency wiring (`app/dependencies/repository_d
 
 PostgreSQL user activation is also intentionally blocked in mixed mode while JWT subjects, `auth_dependency`, ownership checks, Redis cache keys, and still-active Mongo repositories depend on ObjectId user references.
 
+PostgreSQL movie-rating activation is intentionally blocked in mixed mode while auth still emits ObjectId user IDs, `LogRepository` still consumes ObjectId movie IDs, and `MovieRepository` cutover remains blocked behind the earlier movie guard.
+
 JWT `sub` values and public response IDs remain Mongo ObjectId strings until the core cutover is complete.
 
 ## Later Tickets
 
 Future migration tickets should add:
 
-- User/movie_rating/log PostgreSQL repository migrations
+- Log PostgreSQL repository migration
 - Safe full backend cutover once ID dependencies are resolved
 - Final MongoDB decommissioning

--- a/docs/technical/service-dependencies.md
+++ b/docs/technical/service-dependencies.md
@@ -11,16 +11,18 @@ Controllers receive services through FastAPI `Depends(...)`.
 
 ## Repository Provider Guardrails
 
-`get_movie_repository()` and `get_user_repository()` are the runtime activation gates for mixed-mode persistence:
+`get_movie_repository()`, `get_user_repository()`, and `get_movie_rating_repository()` are the runtime activation gates for mixed-mode persistence:
 
 - `DB_BACKEND` unset or `mongo` -> returns Mongo-backed `MovieRepository`.
 - `DB_BACKEND` unset or `mongo` -> returns Mongo-backed `UserRepository`.
+- `DB_BACKEND` unset or `mongo` -> returns Mongo-backed `MovieRatingRepository`.
 - `DB_BACKEND=postgres` while mixed-mode is unsafe -> raises `RepositoryActivationError` (fail-fast).
 
 This prevents accidental cutover while:
 
 - Mongo `LogRepository` and `MovieRatingRepository` still depend on ObjectId `movie_id` references.
 - JWT `sub` values, `auth_dependency`, profile ownership checks, and user-scoped cache keys still depend on ObjectId `user_id` references.
+- `MovieRatingService`, `LogService`, and `StatsService` still rely on mixed Mongo user/movie identifiers for rating lookups.
 
 ## Service Providers
 

--- a/tests/units/db_migrations/test_migrate_movie_ratings.py
+++ b/tests/units/db_migrations/test_migrate_movie_ratings.py
@@ -1,0 +1,336 @@
+from __future__ import annotations
+
+import importlib.util
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+MIGRATION_FILE = Path(__file__).resolve().parents[3] / "db_migrations" / "m003_migrate_movie_ratings.py"
+spec = importlib.util.spec_from_file_location("migrate_movie_ratings_module", MIGRATION_FILE)
+assert spec is not None
+assert spec.loader is not None
+migrate_movie_ratings = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(migrate_movie_ratings)
+
+
+class _FakeMongoCollection:
+    def __init__(self, docs: list[dict]):
+        self._docs = docs
+        self.last_query: dict | None = None
+        self.last_batch_size: int | None = None
+
+    def find(self, query: dict, batch_size: int | None = None):
+        self.last_query = query
+        self.last_batch_size = batch_size
+        if query == {"deleted": {"$ne": True}}:
+            return iter(doc for doc in self._docs if doc.get("deleted") is not True)
+
+        return iter(self._docs)
+
+
+class _FakeMongoDB:
+    def __init__(self, docs: list[dict]):
+        self.movie_ratings = _FakeMongoCollection(docs)
+
+
+def _mock_scalar_result(values: list[object]) -> MagicMock:
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = values
+    return result
+
+
+def _mock_query_result(rows: list[tuple[object, object]]) -> MagicMock:
+    result = MagicMock()
+    result.all.return_value = rows
+    return result
+
+
+@pytest.mark.asyncio
+async def test_migrate_movie_ratings_up_skips_deleted_and_missing_foreign_keys(capsys):
+    from app.utils.id_utils import mongo_id_to_uuid
+
+    valid_user_id = mongo_id_to_uuid("507f1f77bcf86cd799439021")
+    valid_movie_id = mongo_id_to_uuid("507f1f77bcf86cd799439031")
+    missing_user_id = mongo_id_to_uuid("507f1f77bcf86cd799439022")
+
+    mongo_db = _FakeMongoDB(
+        [
+            {
+                "_id": "507f1f77bcf86cd799439011",
+                "userId": "507f1f77bcf86cd799439021",
+                "movieId": "507f1f77bcf86cd799439031",
+                "tmdbId": 550,
+                "rating": 8,
+                "review": "Valid",
+                "deleted": False,
+            },
+            {
+                "_id": "507f1f77bcf86cd799439012",
+                "userId": "507f1f77bcf86cd799439022",
+                "movieId": "507f1f77bcf86cd799439031",
+                "tmdbId": 551,
+                "rating": 6,
+                "review": "Missing user",
+                "deleted": False,
+            },
+            {
+                "_id": "507f1f77bcf86cd799439013",
+                "userId": "507f1f77bcf86cd799439021",
+                "movieId": "507f1f77bcf86cd799439031",
+                "tmdbId": 552,
+                "deleted": True,
+            },
+        ]
+    )
+
+    pg_session = AsyncMock()
+    pg_session.execute.side_effect = [
+        _mock_scalar_result([valid_user_id]),
+        _mock_scalar_result([valid_movie_id]),
+        _mock_scalar_result([mongo_id_to_uuid("507f1f77bcf86cd799439011")]),
+    ]
+
+    await migrate_movie_ratings.up(mongo_db, pg_session, dry_run=False)
+
+    assert mongo_db.movie_ratings.last_query == {"deleted": {"$ne": True}}
+    assert mongo_db.movie_ratings.last_batch_size == migrate_movie_ratings.BATCH_SIZE
+    assert pg_session.execute.await_count == 3
+    pg_session.commit.assert_awaited_once()
+
+    captured = capsys.readouterr().out
+    assert str(missing_user_id) not in captured
+    assert "warnings=1" in captured
+    assert "inserted=1" in captured
+    assert "skipped=1" in captured
+
+
+@pytest.mark.asyncio
+async def test_migrate_movie_ratings_up_dry_run_reports_progress(capsys):
+    from app.utils.id_utils import mongo_id_to_uuid
+
+    mongo_db = _FakeMongoDB(
+        [
+            {
+                "_id": "507f1f77bcf86cd799439011",
+                "userId": "507f1f77bcf86cd799439021",
+                "movieId": "507f1f77bcf86cd799439031",
+                "tmdbId": 550,
+                "rating": 8,
+                "review": "Valid",
+                "deleted": False,
+            }
+        ]
+    )
+    pg_session = AsyncMock()
+    pg_session.execute.side_effect = [
+        _mock_scalar_result([mongo_id_to_uuid("507f1f77bcf86cd799439021")]),
+        _mock_scalar_result([mongo_id_to_uuid("507f1f77bcf86cd799439031")]),
+        _mock_query_result([]),
+    ]
+
+    await migrate_movie_ratings.up(mongo_db, pg_session, dry_run=True)
+
+    assert pg_session.execute.await_count == 3
+    pg_session.commit.assert_not_awaited()
+
+    captured = capsys.readouterr().out
+    assert "dry_run=True" in captured
+    assert "inserted=1" in captured
+    assert "skipped=0" in captured
+    assert "warnings=0" in captured
+
+
+@pytest.mark.asyncio
+async def test_migrate_movie_ratings_up_dry_run_accounts_for_existing_and_prior_batch_conflicts(
+    capsys, monkeypatch
+):
+    from app.utils.id_utils import mongo_id_to_uuid
+
+    monkeypatch.setattr(migrate_movie_ratings, "BATCH_SIZE", 2)
+
+    user_a = "507f1f77bcf86cd799439021"
+    user_b = "507f1f77bcf86cd799439022"
+    movie_a = "507f1f77bcf86cd799439031"
+    movie_b = "507f1f77bcf86cd799439032"
+    user_a_uuid = mongo_id_to_uuid(user_a)
+    user_b_uuid = mongo_id_to_uuid(user_b)
+    movie_a_uuid = mongo_id_to_uuid(movie_a)
+    movie_b_uuid = mongo_id_to_uuid(movie_b)
+
+    mongo_db = _FakeMongoDB(
+        [
+            {"_id": "507f1f77bcf86cd799439011", "userId": user_a, "movieId": movie_a, "tmdbId": 550, "deleted": False},
+            {"_id": "507f1f77bcf86cd799439012", "userId": user_a, "movieId": movie_b, "tmdbId": 551, "deleted": False},
+            {"_id": "507f1f77bcf86cd799439013", "userId": user_a, "movieId": movie_a, "tmdbId": 550, "deleted": False},
+            {"_id": "507f1f77bcf86cd799439014", "userId": user_b, "movieId": movie_b, "tmdbId": 552, "deleted": False},
+        ]
+    )
+
+    pg_session = AsyncMock()
+    pg_session.execute.side_effect = [
+        _mock_scalar_result([user_a_uuid]),
+        _mock_scalar_result([movie_a_uuid, movie_b_uuid]),
+        _mock_query_result([(user_a_uuid, 551)]),
+        _mock_scalar_result([user_a_uuid, user_b_uuid]),
+        _mock_scalar_result([movie_a_uuid, movie_b_uuid]),
+        _mock_query_result([]),
+    ]
+
+    await migrate_movie_ratings.up(mongo_db, pg_session, dry_run=True)
+
+    assert pg_session.execute.await_count == 6
+    pg_session.commit.assert_not_awaited()
+
+    captured = capsys.readouterr().out
+    assert "total=4" in captured
+    assert "inserted=2" in captured
+    assert "skipped=2" in captured
+    assert "warnings=0" in captured
+
+
+@pytest.mark.asyncio
+async def test_migrate_movie_ratings_up_preserves_rating_review_and_timestamps():
+    from app.utils.id_utils import mongo_id_to_uuid
+
+    mongo_db = _FakeMongoDB(
+        [
+            {
+                "_id": "507f1f77bcf86cd799439011",
+                "userId": "507f1f77bcf86cd799439021",
+                "movieId": "507f1f77bcf86cd799439031",
+                "tmdbId": 550,
+                "rating": 9,
+                "review": "Excellent",
+                "createdAt": datetime(2024, 1, 3, 9, 0, tzinfo=UTC),
+                "updatedAt": datetime(2024, 1, 4, 9, 0, tzinfo=UTC),
+                "deleted": False,
+            }
+        ]
+    )
+
+    pg_session = AsyncMock()
+    pg_session.execute.side_effect = [
+        _mock_scalar_result([mongo_id_to_uuid("507f1f77bcf86cd799439021")]),
+        _mock_scalar_result([mongo_id_to_uuid("507f1f77bcf86cd799439031")]),
+        _mock_scalar_result([mongo_id_to_uuid("507f1f77bcf86cd799439011")]),
+    ]
+
+    await migrate_movie_ratings.up(mongo_db, pg_session, dry_run=False)
+
+    statement = pg_session.execute.await_args_list[2].args[0]
+    compiled_params = statement.compile().params
+    assert [value for key, value in compiled_params.items() if key.startswith("rating")] == [9]
+    assert [value for key, value in compiled_params.items() if key.startswith("review")] == ["Excellent"]
+    assert [value for key, value in compiled_params.items() if key.startswith("created_at")] == [
+        datetime(2024, 1, 3, 9, 0, tzinfo=UTC)
+    ]
+    assert [value for key, value in compiled_params.items() if key.startswith("updated_at")] == [
+        datetime(2024, 1, 4, 9, 0, tzinfo=UTC)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_migrate_movie_ratings_up_flushes_in_batches(capsys, monkeypatch):
+    from app.utils.id_utils import mongo_id_to_uuid
+
+    monkeypatch.setattr(migrate_movie_ratings, "BATCH_SIZE", 2)
+    mongo_db = _FakeMongoDB(
+        [
+            {
+                "_id": f"507f1f77bcf86cd79943901{i}",
+                "userId": "507f1f77bcf86cd799439021",
+                "movieId": "507f1f77bcf86cd799439031",
+                "tmdbId": 600 + i,
+                "rating": 7,
+                "deleted": False,
+            }
+            for i in range(5)
+        ]
+    )
+
+    user_uuid = mongo_id_to_uuid("507f1f77bcf86cd799439021")
+    movie_uuid = mongo_id_to_uuid("507f1f77bcf86cd799439031")
+
+    pg_session = AsyncMock()
+    pg_session.execute.side_effect = [
+        _mock_scalar_result([user_uuid]),
+        _mock_scalar_result([movie_uuid]),
+        _mock_scalar_result(
+            [
+                mongo_id_to_uuid("507f1f77bcf86cd799439010"),
+                mongo_id_to_uuid("507f1f77bcf86cd799439011"),
+            ]
+        ),
+        _mock_scalar_result([user_uuid]),
+        _mock_scalar_result([movie_uuid]),
+        _mock_scalar_result(
+            [
+                mongo_id_to_uuid("507f1f77bcf86cd799439012"),
+                mongo_id_to_uuid("507f1f77bcf86cd799439013"),
+            ]
+        ),
+        _mock_scalar_result([user_uuid]),
+        _mock_scalar_result([movie_uuid]),
+        _mock_scalar_result([mongo_id_to_uuid("507f1f77bcf86cd799439014")]),
+    ]
+
+    await migrate_movie_ratings.up(mongo_db, pg_session, dry_run=False)
+
+    assert pg_session.execute.await_count == 9
+    pg_session.commit.assert_awaited_once()
+
+    captured = capsys.readouterr().out
+    assert "total=5" in captured
+    assert "inserted=5" in captured
+    assert "skipped=0" in captured
+    assert "warnings=0" in captured
+
+
+@pytest.mark.asyncio
+async def test_migrate_movie_ratings_down_is_noop_when_mongo_empty(capsys):
+    mongo_db = _FakeMongoDB([])
+    pg_session = AsyncMock()
+
+    await migrate_movie_ratings.down(mongo_db, pg_session)
+
+    pg_session.execute.assert_not_awaited()
+    pg_session.commit.assert_not_awaited()
+
+    captured = capsys.readouterr().out
+    assert "derived_ids=0" in captured
+    assert "deleted=0" in captured
+
+
+@pytest.mark.asyncio
+async def test_migrate_movie_ratings_down_deletes_only_derived_ids(capsys):
+    from app.utils.id_utils import mongo_id_to_uuid
+
+    mongo_db = _FakeMongoDB(
+        [
+            {"_id": "507f1f77bcf86cd799439011"},
+            {"_id": "507f1f77bcf86cd799439012"},
+        ]
+    )
+    pg_session = AsyncMock()
+    delete_result = MagicMock()
+    delete_result.scalars.return_value.all.return_value = [
+        mongo_id_to_uuid("507f1f77bcf86cd799439011"),
+        mongo_id_to_uuid("507f1f77bcf86cd799439012"),
+    ]
+    pg_session.execute.return_value = delete_result
+
+    await migrate_movie_ratings.down(mongo_db, pg_session)
+
+    pg_session.execute.assert_awaited_once()
+    pg_session.commit.assert_awaited_once()
+
+    statement = pg_session.execute.await_args.args[0]
+    sql = str(statement.compile(compile_kwargs={"literal_binds": True}))
+    assert mongo_id_to_uuid("507f1f77bcf86cd799439011").hex in sql
+    assert mongo_id_to_uuid("507f1f77bcf86cd799439012").hex in sql
+
+    captured = capsys.readouterr().out
+    assert "derived_ids=2" in captured
+    assert "deleted=2" in captured

--- a/tests/units/dependencies/test_repository_dependency.py
+++ b/tests/units/dependencies/test_repository_dependency.py
@@ -2,18 +2,22 @@ import pytest
 
 from app.dependencies.repository_dependency import (
     RepositoryActivationError,
+    get_movie_rating_repository,
     get_movie_repository,
     get_user_repository,
 )
+from app.repository.movie_rating_repository import MovieRatingRepository
 from app.repository.movie_repository import MovieRepository
 from app.repository.user_repository import UserRepository
 
 
 @pytest.fixture(autouse=True)
 def clear_repository_caches():
+    get_movie_rating_repository.cache_clear()
     get_movie_repository.cache_clear()
     get_user_repository.cache_clear()
     yield
+    get_movie_rating_repository.cache_clear()
     get_movie_repository.cache_clear()
     get_user_repository.cache_clear()
 
@@ -31,6 +35,21 @@ def test_get_movie_repository_raises_for_unsafe_postgres_activation(monkeypatch)
 
     with pytest.raises(RepositoryActivationError, match="not yet safe"):
         get_movie_repository()
+
+
+def test_get_movie_rating_repository_defaults_to_mongo(monkeypatch):
+    monkeypatch.delenv("DB_BACKEND", raising=False)
+
+    repository = get_movie_rating_repository()
+
+    assert isinstance(repository, MovieRatingRepository)
+
+
+def test_get_movie_rating_repository_raises_for_unsafe_postgres_activation(monkeypatch):
+    monkeypatch.setenv("DB_BACKEND", "postgres")
+
+    with pytest.raises(RepositoryActivationError, match="not yet safe"):
+        get_movie_rating_repository()
 
 
 def test_get_user_repository_defaults_to_mongo(monkeypatch):

--- a/tests/units/repository/test_postgres_movie_rating_repository.py
+++ b/tests/units/repository/test_postgres_movie_rating_repository.py
@@ -1,0 +1,305 @@
+"""Unit tests for ``PostgresMovieRatingRepository``."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from datetime import UTC, date, datetime
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from pytest_postgresql.janitor import DatabaseJanitor
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.models.base_model import Base
+from app.models.movie_model import PostgresMovie
+from app.models.movie_rating_model import PostgresMovieRating
+from app.models.user_model import PostgresUser
+from app.repository.postgres_movie_rating_repository import PostgresMovieRatingRepository
+
+
+def _async_url(pg, dbname: str) -> str:
+    return f"postgresql+asyncpg://{pg.user}:{pg.password}@{pg.host}:{pg.port}/{dbname}"
+
+
+@pytest_asyncio.fixture
+async def pg_engine(postgresql_proc):
+    """Create a fresh database per test and return an async SQLAlchemy engine."""
+    dbname = f"cinelog_movie_rating_test_{uuid4().hex[:8]}"
+
+    with DatabaseJanitor(
+        user=postgresql_proc.user,
+        host=postgresql_proc.host,
+        port=postgresql_proc.port,
+        dbname=dbname,
+        version=postgresql_proc.version,
+        password=postgresql_proc.password,
+    ):
+        engine = create_async_engine(_async_url(postgresql_proc, dbname))
+        async with engine.begin() as connection:
+            await connection.execute(text("CREATE EXTENSION IF NOT EXISTS pgcrypto"))
+            await connection.run_sync(Base.metadata.create_all)
+
+        try:
+            yield engine
+        finally:
+            await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def session_factory(pg_engine):
+    return async_sessionmaker(pg_engine, class_=AsyncSession, expire_on_commit=False)
+
+
+@pytest.fixture
+def repository(session_factory) -> PostgresMovieRatingRepository:
+    @asynccontextmanager
+    async def _provider():
+        async with session_factory() as session:
+            yield session
+
+    return PostgresMovieRatingRepository(session_provider=_provider)
+
+
+@pytest_asyncio.fixture
+async def seed_session(session_factory):
+    async with session_factory() as session:
+        yield session
+
+
+async def _add(seed_session: AsyncSession, *entities) -> None:
+    seed_session.add_all(entities)
+    await seed_session.commit()
+    for entity in entities:
+        await seed_session.refresh(entity)
+
+
+async def _seed_fk_entities(seed_session: AsyncSession) -> tuple[PostgresUser, PostgresMovie, PostgresMovie]:
+    user = PostgresUser(
+        email="ratings@example.com",
+        handle="ratings-user",
+        first_name="Ratings",
+        last_name="User",
+        date_of_birth=date(1990, 1, 1),
+    )
+    movie_a = PostgresMovie(tmdb_id=550, title="Fight Club")
+    movie_b = PostgresMovie(tmdb_id=551, title="Movie B")
+    await _add(seed_session, user, movie_a, movie_b)
+    return user, movie_a, movie_b
+
+
+@pytest.mark.asyncio
+async def test_create_update_movie_rating_creates_new_row(
+    repository: PostgresMovieRatingRepository,
+    seed_session: AsyncSession,
+):
+    user, movie, _ = await _seed_fk_entities(seed_session)
+
+    rating = await repository.create_update_movie_rating(
+        user_id=user.id,
+        movie_id=movie.id,
+        rating=8,
+        comment="Great movie!",
+        tmdb_id=movie.tmdb_id,
+    )
+
+    assert rating.id is not None
+    assert rating.user_id == user.id
+    assert rating.movie_id == movie.id
+    assert rating.rating == 8
+    assert rating.review == "Great movie!"
+    assert rating.deleted is False
+
+
+@pytest.mark.asyncio
+async def test_find_movie_rating_by_user_and_movie_excludes_deleted_and_unknown(
+    repository: PostgresMovieRatingRepository,
+    seed_session: AsyncSession,
+):
+    user, movie, _ = await _seed_fk_entities(seed_session)
+    active = PostgresMovieRating(user_id=user.id, movie_id=movie.id, tmdb_id=movie.tmdb_id, rating=9, review="Loved it")
+    deleted = PostgresMovieRating(
+        user_id=user.id,
+        movie_id=movie.id,
+        tmdb_id=999,
+        rating=7,
+        review="Deleted",
+        deleted=True,
+        deleted_at=datetime.now(UTC),
+    )
+    await _add(seed_session, active, deleted)
+
+    found = await repository.find_movie_rating_by_user_and_movie(user.id, movie.id)
+
+    assert found is not None
+    assert found.id == active.id
+    assert await repository.find_movie_rating_by_user_and_movie(user.id, uuid4()) is None
+
+
+@pytest.mark.asyncio
+async def test_find_movie_rating_by_user_and_tmdb_returns_active_row(
+    repository: PostgresMovieRatingRepository,
+    seed_session: AsyncSession,
+):
+    user, movie, _ = await _seed_fk_entities(seed_session)
+    deleted_rating = PostgresMovieRating(
+        user_id=user.id,
+        movie_id=movie.id,
+        tmdb_id=777,
+        rating=5,
+        review="Gone",
+        deleted=True,
+        deleted_at=datetime.now(UTC),
+    )
+    active_rating = PostgresMovieRating(
+        user_id=user.id,
+        movie_id=movie.id,
+        tmdb_id=movie.tmdb_id,
+        rating=8,
+        review="Active",
+    )
+    await _add(seed_session, deleted_rating, active_rating)
+
+    found = await repository.find_movie_rating_by_user_and_tmdb(user.id, movie.tmdb_id)
+
+    assert found is not None
+    assert found.id == active_rating.id
+    assert await repository.find_movie_rating_by_user_and_tmdb(user.id, 777) is None
+    assert await repository.find_movie_rating_by_user_and_tmdb(uuid4(), movie.tmdb_id) is None
+
+
+@pytest.mark.asyncio
+async def test_create_update_movie_rating_updates_existing_row_on_conflict(
+    repository: PostgresMovieRatingRepository,
+    seed_session: AsyncSession,
+):
+    user, movie, _ = await _seed_fk_entities(seed_session)
+    existing = PostgresMovieRating(
+        user_id=user.id,
+        movie_id=movie.id,
+        tmdb_id=movie.tmdb_id,
+        rating=6,
+        review="Initial",
+    )
+    await _add(seed_session, existing)
+
+    updated = await repository.create_update_movie_rating(
+        user_id=user.id,
+        movie_id=movie.id,
+        rating=10,
+        comment="Updated",
+        tmdb_id=movie.tmdb_id,
+    )
+
+    assert updated.id == existing.id
+    assert updated.rating == 10
+    assert updated.review == "Updated"
+
+
+@pytest.mark.asyncio
+async def test_create_update_movie_rating_revives_soft_deleted_row(
+    repository: PostgresMovieRatingRepository,
+    seed_session: AsyncSession,
+):
+    user, movie, _ = await _seed_fk_entities(seed_session)
+    deleted = PostgresMovieRating(
+        user_id=user.id,
+        movie_id=movie.id,
+        tmdb_id=movie.tmdb_id,
+        rating=4,
+        review="Old",
+        deleted=True,
+        deleted_at=datetime.now(UTC),
+    )
+    await _add(seed_session, deleted)
+
+    revived = await repository.create_update_movie_rating(
+        user_id=user.id,
+        movie_id=movie.id,
+        rating=9,
+        comment="Back",
+        tmdb_id=movie.tmdb_id,
+    )
+
+    assert revived.id == deleted.id
+    assert revived.deleted is False
+    assert revived.deleted_at is None
+    assert revived.rating == 9
+    assert revived.review == "Back"
+
+
+@pytest.mark.asyncio
+async def test_find_movie_ratings_by_user_and_movie_ids_filters_deleted_and_unknown(
+    repository: PostgresMovieRatingRepository,
+    seed_session: AsyncSession,
+):
+    user, movie_a, movie_b = await _seed_fk_entities(seed_session)
+    active = PostgresMovieRating(user_id=user.id, movie_id=movie_a.id, tmdb_id=movie_a.tmdb_id, rating=7, review="A")
+    deleted = PostgresMovieRating(
+        user_id=user.id,
+        movie_id=movie_b.id,
+        tmdb_id=movie_b.tmdb_id,
+        rating=3,
+        review="B",
+        deleted=True,
+        deleted_at=datetime.now(UTC),
+    )
+    await _add(seed_session, active, deleted)
+
+    found = await repository.find_movie_ratings_by_user_and_movie_ids(user.id, {movie_a.id, movie_b.id, uuid4()})
+
+    assert [rating.id for rating in found] == [active.id]
+
+
+@pytest.mark.asyncio
+async def test_find_movie_ratings_by_user_and_movie_ids_short_circuits_empty_set(
+    repository: PostgresMovieRatingRepository,
+):
+    assert await repository.find_movie_ratings_by_user_and_movie_ids(uuid4(), set()) == []
+
+
+@pytest.mark.asyncio
+async def test_get_user_movie_ratings_average_excludes_deleted_and_null(
+    repository: PostgresMovieRatingRepository,
+    seed_session: AsyncSession,
+):
+    user, movie_a, movie_b = await _seed_fk_entities(seed_session)
+    movie_c = PostgresMovie(tmdb_id=552, title="Movie C")
+    movie_d = PostgresMovie(tmdb_id=553, title="Movie D")
+    await _add(seed_session, movie_c, movie_d)
+
+    rating_a = PostgresMovieRating(user_id=user.id, movie_id=movie_a.id, tmdb_id=movie_a.tmdb_id, rating=8, review="A")
+    rating_b = PostgresMovieRating(user_id=user.id, movie_id=movie_b.id, tmdb_id=movie_b.tmdb_id, rating=6, review="B")
+    deleted = PostgresMovieRating(
+        user_id=user.id,
+        movie_id=movie_c.id,
+        tmdb_id=movie_c.tmdb_id,
+        rating=10,
+        review="Deleted",
+        deleted=True,
+        deleted_at=datetime.now(UTC),
+    )
+    unrated = PostgresMovieRating(
+        user_id=user.id,
+        movie_id=movie_d.id,
+        tmdb_id=movie_d.tmdb_id,
+        rating=None,
+        review="No score",
+    )
+    await _add(seed_session, rating_a, rating_b, deleted, unrated)
+
+    stats = await repository.get_user_movie_ratings_average(user.id, {movie_a.id, movie_b.id, movie_c.id, movie_d.id})
+
+    assert stats.average_rating == 7.0
+    assert stats.total_ratings == 2
+
+
+@pytest.mark.asyncio
+async def test_get_user_movie_ratings_average_returns_zeroes_when_empty(
+    repository: PostgresMovieRatingRepository,
+):
+    stats = await repository.get_user_movie_ratings_average(uuid4(), {uuid4()})
+
+    assert stats.average_rating == 0.0
+    assert stats.total_ratings == 0


### PR DESCRIPTION
## Summary
- add PostgreSQL movie-rating persistence with `PostgresMovieRating`, `PostgresMovieRatingRepository`, Alembic table creation, and the `m003` Mongo -> Postgres data migration
- keep the Mongo movie-rating repository active for runtime, add the `get_movie_rating_repository()` mixed-mode fail-fast guard, and wire `MovieRatingService`, `LogService`, and `StatsService` through it
- document the migration/guardrail behavior and add repository, migration, and dependency tests for the new Postgres path

## Verification
- `make test-unit`
- `make lint`
- `make typecheck`

Closes #128
