### PR TITLE
feat(log-repository): migrate logs repository to postgres

### DIFF
--- a/alembic/versions/004_create_logs_table.py
+++ b/alembic/versions/004_create_logs_table.py
@@ -1,0 +1,61 @@
+"""create logs table
+
+Revision ID: 004_create_logs_table
+Revises: 003_create_movie_ratings_table
+Create Date: 2026-06-01 16:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "004_create_logs_table"
+down_revision: str | Sequence[str] | None = "003_create_movie_ratings_table"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Apply the migration."""
+    op.execute("CREATE EXTENSION IF NOT EXISTS pgcrypto")
+
+    op.create_table(
+        "logs",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("movie_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("movies.id"), nullable=False),
+        sa.Column("tmdb_id", sa.Integer(), nullable=False),
+        sa.Column("date_watched", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("viewing_notes", sa.Text(), nullable=True),
+        sa.Column("poster_path", sa.Text(), nullable=True),
+        sa.Column("watched_where", sa.Text(), nullable=False, server_default=sa.text("'other'")),
+        sa.Column("deleted", sa.Boolean(), nullable=False, server_default=sa.text("FALSE")),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.CheckConstraint(
+            "watched_where IN ('cinema', 'streaming', 'homeVideo', 'tv', 'other')",
+            name="ck_logs_watched_where",
+        ),
+    )
+
+    op.execute("CREATE INDEX ix_logs_user_date_watched ON logs (user_id, date_watched DESC)")
+    op.execute(
+        "CREATE INDEX ix_logs_user_date_watched_created_at ON logs (user_id, date_watched DESC, created_at DESC)"
+    )
+    op.execute("CREATE INDEX ix_logs_user_movie ON logs (user_id, movie_id)")
+    op.execute("CREATE INDEX ix_logs_tmdb_date_watched ON logs (tmdb_id, date_watched DESC)")
+    op.execute("CREATE INDEX ix_logs_user_watched_where_created_at ON logs (user_id, watched_where, created_at)")
+
+
+def downgrade() -> None:
+    """Rollback the migration."""
+    op.drop_index("ix_logs_user_watched_where_created_at", table_name="logs")
+    op.drop_index("ix_logs_tmdb_date_watched", table_name="logs")
+    op.drop_index("ix_logs_user_movie", table_name="logs")
+    op.drop_index("ix_logs_user_date_watched_created_at", table_name="logs")
+    op.drop_index("ix_logs_user_date_watched", table_name="logs")
+    op.drop_table("logs")

--- a/app/dependencies/repository_dependency.py
+++ b/app/dependencies/repository_dependency.py
@@ -3,6 +3,7 @@
 from functools import lru_cache
 
 from app.db.postgres import is_postgres_required
+from app.repository.log_repository import LogRepository
 from app.repository.movie_rating_repository import MovieRatingRepository
 from app.repository.movie_repository import MovieRepository
 from app.repository.user_repository import UserRepository
@@ -71,3 +72,23 @@ def get_movie_rating_repository() -> MovieRatingRepository:
         )
 
     return MovieRatingRepository()
+
+
+@lru_cache
+def get_log_repository() -> LogRepository:
+    """Return the active log repository implementation.
+
+    LogRepository PostgreSQL activation is intentionally blocked in mixed mode
+    because log caching, service wiring, and UUID/ObjectId runtime assumptions
+    still require the later cutover work.
+    """
+
+    if is_postgres_required():
+        raise RepositoryActivationError(
+            "DB_BACKEND=postgres is not yet safe for LogRepository activation: "
+            "LogCacheRepository and downstream services still rely on Mongo-shaped log caching "
+            "and mixed UUID/ObjectId runtime assumptions. Keep DB_BACKEND=mongo until the "
+            "repository cutover work is complete."
+        )
+
+    return LogRepository()

--- a/app/dependencies/service_dependency.py
+++ b/app/dependencies/service_dependency.py
@@ -9,12 +9,12 @@ Tests can swap a whole service through
 from functools import lru_cache
 
 from app.dependencies.repository_dependency import (
+    get_log_repository,
     get_movie_rating_repository,
     get_movie_repository,
     get_user_repository,
 )
 from app.repository.log_cache_repository import LogCacheRepository
-from app.repository.log_repository import LogRepository
 from app.services.auth_rate_limit_service import AuthRateLimitService
 from app.services.auth_service import AuthService
 from app.services.log_service import LogService
@@ -55,7 +55,7 @@ def get_movie_rating_service() -> MovieRatingService:
 @lru_cache
 def get_log_service() -> LogService:
     return LogService(
-        log_repository=LogCacheRepository(LogRepository()),
+        log_repository=LogCacheRepository(get_log_repository()),
         movie_service=get_movie_service(),
         movie_repository=get_movie_repository(),
         movie_rating_repository=get_movie_rating_repository(),
@@ -66,7 +66,7 @@ def get_log_service() -> LogService:
 @lru_cache
 def get_stats_service() -> StatsService:
     return StatsService(
-        log_repository=LogCacheRepository(LogRepository()),
+        log_repository=LogCacheRepository(get_log_repository()),
         movie_rating_repository=get_movie_rating_repository(),
         movie_repository=get_movie_repository(),
     )

--- a/app/models/log_model.py
+++ b/app/models/log_model.py
@@ -1,0 +1,64 @@
+"""PostgreSQL log ORM model."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import CheckConstraint, DateTime, ForeignKey, Index, Integer, Text, text
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base_model import PostgresBaseEntity
+from app.types import WATCHED_WHERE_CHOICES
+
+
+class PostgresLog(PostgresBaseEntity):
+    """Viewing log record stored in PostgreSQL."""
+
+    __tablename__ = "logs"
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    user_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("users.id"),
+        nullable=False,
+    )
+    movie_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("movies.id"),
+        nullable=False,
+    )
+    tmdb_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    date_watched: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    viewing_notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    poster_path: Mapped[str | None] = mapped_column(Text, nullable=True)
+    watched_where: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+        server_default=text("'other'"),
+        default="other",
+    )
+
+    _watched_where_sql = ", ".join(f"'{choice}'" for choice in WATCHED_WHERE_CHOICES)
+
+    __table_args__ = (
+        CheckConstraint(
+            f"watched_where IN ({_watched_where_sql})",
+            name="ck_logs_watched_where",
+        ),
+        Index("ix_logs_user_date_watched", "user_id", text("date_watched DESC")),
+        Index(
+            "ix_logs_user_date_watched_created_at",
+            "user_id",
+            text("date_watched DESC"),
+            text("created_at DESC"),
+        ),
+        Index("ix_logs_user_movie", "user_id", "movie_id"),
+        Index("ix_logs_tmdb_date_watched", "tmdb_id", text("date_watched DESC")),
+        Index("ix_logs_user_watched_where_created_at", "user_id", "watched_where", "created_at"),
+    )

--- a/app/repository/log_repository.py
+++ b/app/repository/log_repository.py
@@ -10,6 +10,15 @@ from app.utils.object_id_utils import to_object_id
 
 
 class LogRepository:
+    """MongoDB log repository — active runtime implementation.
+
+    Pending replacement by ``PostgresLogRepository`` (in
+    ``app/repository/postgres_log_repository.py``) once runtime repository
+    cutover, log caching, and UUID/ObjectId mixed-mode concerns are resolved.
+    The PostgreSQL repository is intentionally unwired today — do not import
+    it from runtime code paths.
+    """
+
     async def create_log(self, user_id: PydanticObjectId, create_log_request: LogCreateRequest) -> Log:
         """
         Create a new log entry in the database.

--- a/app/repository/postgres_log_repository.py
+++ b/app/repository/postgres_log_repository.py
@@ -1,0 +1,220 @@
+"""PostgreSQL log repository implementation."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import ColumnElement, distinct, func, select
+
+from app.models.log_model import PostgresLog
+from app.repository.repository_base import RepositoryBase
+from app.schemas.log_schemas import LogCreateRequest, LogUpdateRequest
+from app.schemas.stats_schemas import LogDistributionEntry, LogStats
+from app.utils.datetime_utils import date_end_utc, date_start_utc, to_utc_datetime
+
+
+class PostgresLogRepository(RepositoryBase):
+    """Repository class for PostgreSQL log operations."""
+
+    async def create_log(self, user_id: UUID, create_log_request: LogCreateRequest) -> PostgresLog:
+        """Create a new viewing log in PostgreSQL."""
+
+        if create_log_request.movie_id is None:
+            raise ValueError("movie_id is required")
+
+        movie_id = UUID(create_log_request.movie_id)
+
+        async with self._session_provider() as session:
+            log = PostgresLog(
+                user_id=user_id,
+                movie_id=movie_id,
+                tmdb_id=create_log_request.tmdb_id,
+                date_watched=to_utc_datetime(create_log_request.date_watched),
+                viewing_notes=create_log_request.viewing_notes,
+                poster_path=create_log_request.poster_path,
+                watched_where=create_log_request.watched_where,
+            )
+            session.add(log)
+            await session.commit()
+            await session.refresh(log)
+            return log
+
+    async def find_log_by_id(self, log_id: UUID, user_id: UUID) -> PostgresLog | None:
+        """Find an active log by ID owned by the given user."""
+
+        async with self._session_provider() as session:
+            statement = select(PostgresLog).where(
+                PostgresLog.id == log_id,
+                PostgresLog.user_id == user_id,
+                PostgresLog.active(),
+            )
+            result = await session.execute(statement)
+            return result.scalar_one_or_none()
+
+    async def update_log(
+        self,
+        log_id: UUID,
+        user_id: UUID,
+        update_request: LogUpdateRequest,
+    ) -> PostgresLog | None:
+        """Update an active log owned by the given user."""
+
+        async with self._session_provider() as session:
+            statement = select(PostgresLog).where(
+                PostgresLog.id == log_id,
+                PostgresLog.user_id == user_id,
+                PostgresLog.active(),
+            )
+            result = await session.execute(statement)
+            log = result.scalar_one_or_none()
+            if log is None:
+                return None
+
+            update_data = update_request.model_dump(exclude_unset=True)
+            for field, value in update_data.items():
+                if field == "date_watched" and value is not None:
+                    value = to_utc_datetime(value)
+                setattr(log, field, value)
+
+            log.updated_at = datetime.now(UTC)
+            await session.commit()
+            await session.refresh(log)
+            return log
+
+    async def find_logs_by_user_id(
+        self,
+        user_id: UUID,
+        watched_where: str | None = None,
+        date_watched_from: date | None = None,
+        date_watched_to: date | None = None,
+        sort_by: str = "dateWatched",
+        sort_order: str = "desc",
+    ) -> list[PostgresLog]:
+        """Find active logs for a user with optional filters and sorting."""
+
+        async with self._session_provider() as session:
+            statement = select(PostgresLog).where(
+                PostgresLog.user_id == user_id,
+                PostgresLog.active(),
+            )
+
+            if watched_where is not None:
+                statement = statement.where(PostgresLog.watched_where == watched_where)
+            if date_watched_from is not None:
+                statement = statement.where(PostgresLog.date_watched >= date_start_utc(date_watched_from))
+            if date_watched_to is not None:
+                statement = statement.where(PostgresLog.date_watched <= date_end_utc(date_watched_to))
+
+            is_desc = sort_order == "desc"
+            order_by: tuple[ColumnElement[Any], ColumnElement[Any]]
+            if sort_by == "watchedWhere":
+                order_by = (
+                    PostgresLog.watched_where.desc() if is_desc else PostgresLog.watched_where.asc(),
+                    PostgresLog.created_at.desc() if is_desc else PostgresLog.created_at.asc(),
+                )
+            else:
+                order_by = (
+                    PostgresLog.date_watched.desc() if is_desc else PostgresLog.date_watched.asc(),
+                    PostgresLog.created_at.desc() if is_desc else PostgresLog.created_at.asc(),
+                )
+
+            result = await session.execute(statement.order_by(*order_by))
+            return list(result.scalars().all())
+
+    async def find_logs_by_movie_id(
+        self,
+        movie_id: UUID,
+        user_id: UUID | None = None,
+    ) -> list[PostgresLog]:
+        """Find active logs for a movie, optionally filtered by user."""
+
+        async with self._session_provider() as session:
+            statement = select(PostgresLog).where(
+                PostgresLog.movie_id == movie_id,
+                PostgresLog.active(),
+            )
+            if user_id is not None:
+                statement = statement.where(PostgresLog.user_id == user_id)
+
+            result = await session.execute(statement.order_by(PostgresLog.created_at.asc()))
+            return list(result.scalars().all())
+
+    async def delete_log(self, log_id: UUID, user_id: UUID) -> PostgresLog | None:
+        """Hard-delete an active log owned by the given user."""
+
+        async with self._session_provider() as session:
+            statement = select(PostgresLog).where(
+                PostgresLog.id == log_id,
+                PostgresLog.user_id == user_id,
+                PostgresLog.active(),
+            )
+            result = await session.execute(statement)
+            log = result.scalar_one_or_none()
+            if log is None:
+                return None
+
+            await session.delete(log)
+            await session.commit()
+            return log
+
+    async def get_log_stats(
+        self,
+        user_id: UUID,
+        date_from: date | None = None,
+        date_to: date | None = None,
+    ) -> LogStats:
+        """Compute active log statistics for a user."""
+
+        filters = [
+            PostgresLog.user_id == user_id,
+            PostgresLog.active(),
+        ]
+        if date_from is not None:
+            filters.append(PostgresLog.date_watched >= date_start_utc(date_from))
+        if date_to is not None:
+            filters.append(PostgresLog.date_watched <= date_end_utc(date_to))
+
+        filtered = (
+            select(
+                PostgresLog.id,
+                PostgresLog.movie_id,
+                PostgresLog.watched_where,
+            )
+            .where(*filters)
+            .cte("filtered_logs")
+        )
+
+        async with self._session_provider() as session:
+            summary_result = await session.execute(
+                select(
+                    func.count(filtered.c.id),
+                    func.count(distinct(filtered.c.movie_id)),
+                    func.array_agg(distinct(filtered.c.movie_id)),
+                )
+            )
+            total_watches, unique_titles, unique_movie_ids = summary_result.one()
+
+            if int(total_watches or 0) == 0:
+                return LogStats()
+
+            distribution_result = await session.execute(
+                select(
+                    filtered.c.watched_where,
+                    func.count(filtered.c.id),
+                )
+                .group_by(filtered.c.watched_where)
+                .order_by(filtered.c.watched_where.asc())
+            )
+            distribution = [
+                LogDistributionEntry(watched_where=watched_where, count=count)
+                for watched_where, count in distribution_result.all()
+            ]
+
+            return LogStats(
+                total_watches=int(total_watches or 0),
+                unique_titles=int(unique_titles or 0),
+                unique_movie_ids=list(unique_movie_ids or []),
+                distribution=distribution,
+            )

--- a/app/schemas/stats_schemas.py
+++ b/app/schemas/stats_schemas.py
@@ -1,4 +1,5 @@
 from typing import Literal
+from uuid import UUID
 
 from beanie import PydanticObjectId
 
@@ -53,5 +54,5 @@ class LogDistributionEntry(BaseSchema):
 class LogStats(BaseSchema):
     total_watches: int = 0
     unique_titles: int = 0
-    unique_movie_ids: list[PydanticObjectId] = []
+    unique_movie_ids: list[PydanticObjectId | UUID] = []
     distribution: list[LogDistributionEntry] = []

--- a/app/services/log_service.py
+++ b/app/services/log_service.py
@@ -1,6 +1,7 @@
 from beanie import PydanticObjectId
 
 from app.dependencies.repository_dependency import (
+    get_log_repository,
     get_movie_rating_repository,
     get_movie_repository,
     get_user_repository,
@@ -37,7 +38,7 @@ class LogService:
         stats_cache_service: StatsCacheService | None = None,
         user_repository: UserRepository | None = None,
     ):
-        self.log_repository = log_repository or LogCacheRepository()
+        self.log_repository = log_repository or LogCacheRepository(get_log_repository())
         resolved_movie_repository = movie_repository or get_movie_repository()
         if movie_service is None:
             movie_service = MovieService(resolved_movie_repository)

--- a/app/services/stats_service.py
+++ b/app/services/stats_service.py
@@ -1,9 +1,10 @@
 import asyncio
 from datetime import date
+from typing import cast
 
 from beanie import PydanticObjectId
 
-from app.dependencies.repository_dependency import get_movie_rating_repository, get_movie_repository
+from app.dependencies.repository_dependency import get_log_repository, get_movie_rating_repository, get_movie_repository
 from app.repository.log_cache_repository import LogCacheRepository
 from app.repository.movie_rating_repository import MovieRatingRepository
 from app.repository.movie_repository import MovieRepository
@@ -26,7 +27,7 @@ class StatsService:
         movie_repository: MovieRepository | None = None,
         stats_cache_service: StatsCacheService | None = None,
     ):
-        self.log_repository = log_repository or LogCacheRepository()
+        self.log_repository = log_repository or LogCacheRepository(get_log_repository())
         self.movie_rating_repository = movie_rating_repository or get_movie_rating_repository()
         self.movie_repository = movie_repository or get_movie_repository()
         self.stats_cache_service = stats_cache_service or StatsCacheService()
@@ -51,10 +52,11 @@ class StatsService:
         )
 
         movie_ids = set(log_stats.unique_movie_ids)
+        mongo_movie_ids = cast("set[PydanticObjectId]", movie_ids)
 
         movie_rating_stats, movie_stats = await asyncio.gather(
-            self.movie_rating_repository.get_user_movie_ratings_average(user_id, movie_ids),
-            self.movie_repository.get_movie_stats(movie_ids),
+            self.movie_rating_repository.get_user_movie_ratings_average(user_id, mongo_movie_ids),
+            self.movie_repository.get_movie_stats(mongo_movie_ids),
         )
 
         total_rewatches = max(0, log_stats.total_watches - log_stats.unique_titles)

--- a/db_migrations/m004_migrate_logs.py
+++ b/db_migrations/m004_migrate_logs.py
@@ -1,0 +1,249 @@
+"""Migrate logs data from MongoDB to PostgreSQL."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from typing import NamedTuple
+from uuid import UUID
+
+from sqlalchemy import delete, select
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.log_model import PostgresLog
+from app.models.movie_model import PostgresMovie
+from app.models.user_model import PostgresUser
+from app.types import WATCHED_WHERE_CHOICES
+from app.utils.datetime_utils import to_utc_datetime
+from app.utils.id_utils import mongo_id_to_uuid
+
+BATCH_SIZE = 100
+
+
+class BatchOutcome(NamedTuple):
+    inserted: int
+    skipped: int
+    warnings: int
+
+
+def _parse_date_watched(value: str | date | datetime | None) -> datetime | None:
+    if value is None:
+        return None
+
+    if isinstance(value, datetime):
+        return to_utc_datetime(value)
+
+    if isinstance(value, date):
+        return to_utc_datetime(value)
+
+    if not isinstance(value, str) or not value:
+        return None
+
+    try:
+        if "T" in value or " " in value:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+            return to_utc_datetime(parsed)
+        return to_utc_datetime(date.fromisoformat(value))
+    except ValueError:
+        return None
+
+
+def _normalize_watched_where(value: object) -> str:
+    if isinstance(value, str) and value in WATCHED_WHERE_CHOICES:
+        return value
+    return "other"
+
+
+def _normalize_log_doc(mongo_log: dict) -> dict:
+    mongo_user_id = mongo_log.get("userId")
+    mongo_movie_id = mongo_log.get("movieId")
+
+    return {
+        "id": mongo_id_to_uuid(str(mongo_log["_id"])),
+        "user_id": mongo_id_to_uuid(str(mongo_user_id)) if mongo_user_id is not None else None,
+        "movie_id": mongo_id_to_uuid(str(mongo_movie_id)) if mongo_movie_id is not None else None,
+        "tmdb_id": mongo_log.get("tmdbId"),
+        "date_watched": _parse_date_watched(mongo_log.get("dateWatched")),
+        "viewing_notes": mongo_log.get("viewingNotes"),
+        "poster_path": mongo_log.get("posterPath"),
+        "watched_where": _normalize_watched_where(mongo_log.get("watchedWhere")),
+        "deleted": bool(mongo_log.get("deleted", False)),
+        "deleted_at": mongo_log.get("deletedAt"),
+        "created_at": mongo_log.get("createdAt") or datetime.now(UTC),
+        "updated_at": mongo_log.get("updatedAt") or datetime.now(UTC),
+    }
+
+
+def _warn(values: dict, reason: str) -> None:
+    print(f"[logs-migration:warn] log_id={values['id']} {reason}")
+
+
+async def _validate_batch(
+    pg_session: AsyncSession,
+    batch: list[dict],
+) -> tuple[list[dict], int]:
+    """Filter out rows missing required values or foreign keys."""
+
+    prelim_valid: list[dict] = []
+    warnings = 0
+
+    for values in batch:
+        if values["user_id"] is None or values["movie_id"] is None or values["tmdb_id"] is None:
+            _warn(values, "missing required user_id, movie_id, or tmdb_id")
+            warnings += 1
+            continue
+        if values["date_watched"] is None:
+            _warn(values, "missing or invalid date_watched")
+            warnings += 1
+            continue
+        prelim_valid.append(values)
+
+    if not prelim_valid:
+        return [], warnings
+
+    user_ids = {values["user_id"] for values in prelim_valid}
+    movie_ids = {values["movie_id"] for values in prelim_valid}
+
+    user_result = await pg_session.execute(select(PostgresUser.id).where(PostgresUser.id.in_(user_ids)))
+    movie_result = await pg_session.execute(select(PostgresMovie.id).where(PostgresMovie.id.in_(movie_ids)))
+
+    existing_user_ids = set(user_result.scalars().all())
+    existing_movie_ids = set(movie_result.scalars().all())
+
+    valid: list[dict] = []
+    for values in prelim_valid:
+        missing_parts: list[str] = []
+        if values["user_id"] not in existing_user_ids:
+            missing_parts.append("user FK missing")
+        if values["movie_id"] not in existing_movie_ids:
+            missing_parts.append("movie FK missing")
+
+        if missing_parts:
+            _warn(values, ", ".join(missing_parts))
+            warnings += 1
+            continue
+
+        valid.append(values)
+
+    return valid, warnings
+
+
+async def _count_dry_run_insertable_logs(
+    pg_session: AsyncSession,
+    batch: list[dict],
+    projected_ids: set[UUID],
+) -> int:
+    """Count how many valid rows a dry-run batch would insert after ID conflicts."""
+
+    batch_ids = {values["id"] for values in batch}
+    result = await pg_session.execute(select(PostgresLog.id).where(PostgresLog.id.in_(batch_ids)))
+
+    occupied_ids = set(projected_ids)
+    occupied_ids.update(result.scalars().all())
+
+    insertable_ids: set[UUID] = set()
+    for values in batch:
+        log_id = values["id"]
+        if log_id in occupied_ids or log_id in insertable_ids:
+            continue
+        insertable_ids.add(log_id)
+
+    projected_ids.update(insertable_ids)
+    return len(insertable_ids)
+
+
+async def _flush_batch(
+    pg_session: AsyncSession,
+    batch: list[dict],
+    *,
+    dry_run: bool,
+    projected_ids: set[UUID] | None = None,
+) -> BatchOutcome:
+    """Insert a batch and return inserted/skipped/warning counts."""
+
+    if not batch:
+        return BatchOutcome(inserted=0, skipped=0, warnings=0)
+
+    valid_batch, warnings = await _validate_batch(pg_session, batch)
+    if not valid_batch:
+        return BatchOutcome(inserted=0, skipped=len(batch), warnings=warnings)
+
+    if dry_run:
+        inserted = await _count_dry_run_insertable_logs(
+            pg_session,
+            valid_batch,
+            projected_ids if projected_ids is not None else set(),
+        )
+        return BatchOutcome(inserted=inserted, skipped=len(batch) - inserted, warnings=warnings)
+
+    statement = (
+        insert(PostgresLog)
+        .values(valid_batch)
+        .on_conflict_do_nothing(index_elements=[PostgresLog.id])
+        .returning(PostgresLog.id)
+    )
+    result = await pg_session.execute(statement)
+    inserted = len(result.scalars().all())
+    return BatchOutcome(inserted=inserted, skipped=len(batch) - inserted, warnings=warnings)
+
+
+async def up(mongo_db, pg_session: AsyncSession, dry_run: bool = False) -> None:
+    """Migrate active logs from MongoDB into PostgreSQL in batches."""
+
+    cursor = mongo_db.logs.find({"deleted": {"$ne": True}}, batch_size=BATCH_SIZE)
+
+    total = 0
+    inserted = 0
+    skipped = 0
+    warnings = 0
+    batch: list[dict] = []
+    projected_ids: set[UUID] = set()
+
+    for mongo_log in cursor:
+        total += 1
+        batch.append(_normalize_log_doc(mongo_log))
+
+        if len(batch) >= BATCH_SIZE:
+            outcome = await _flush_batch(
+                pg_session,
+                batch,
+                dry_run=dry_run,
+                projected_ids=projected_ids,
+            )
+            inserted += outcome.inserted
+            skipped += outcome.skipped
+            warnings += outcome.warnings
+            batch = []
+
+    if batch:
+        outcome = await _flush_batch(
+            pg_session,
+            batch,
+            dry_run=dry_run,
+            projected_ids=projected_ids,
+        )
+        inserted += outcome.inserted
+        skipped += outcome.skipped
+        warnings += outcome.warnings
+
+    if not dry_run:
+        await pg_session.commit()
+
+    print(f"[logs-migration] total={total} inserted={inserted} skipped={skipped} warnings={warnings} dry_run={dry_run}")
+
+
+async def down(mongo_db, pg_session: AsyncSession) -> None:
+    """Rollback log migration by deleting only rows derived from Mongo."""
+
+    cursor = mongo_db.logs.find({}, batch_size=BATCH_SIZE)
+    derived_ids = [mongo_id_to_uuid(str(doc["_id"])) for doc in cursor]
+
+    deleted_count = 0
+    if derived_ids:
+        result = await pg_session.execute(
+            delete(PostgresLog).where(PostgresLog.id.in_(derived_ids)).returning(PostgresLog.id)
+        )
+        deleted_count = len(result.scalars().all())
+        await pg_session.commit()
+
+    print(f"[logs-migration:down] derived_ids={len(derived_ids)} deleted={deleted_count}")

--- a/docs/technical/postgres-migration.md
+++ b/docs/technical/postgres-migration.md
@@ -240,6 +240,77 @@ Migration rules:
 - Idempotent inserts via PostgreSQL `ON CONFLICT (user_id, tmdb_id) DO NOTHING`
 - Progress reporting (total / inserted / skipped / warnings)
 
+## Log Collection Migration
+
+`#129` adds PostgreSQL log persistence and migration scaffolding while Mongo remains active at runtime.
+
+### Repository split
+
+- Legacy Mongo implementation remains in `app/repository/log_repository.py` as `LogRepository` (deprecated during migration).
+- New PostgreSQL implementation lives in `app/repository/postgres_log_repository.py` as `PostgresLogRepository`.
+- Runtime activation is intentionally blocked by `get_log_repository()` until the later runtime cutover work is complete.
+
+### Table shape
+
+Alembic migration creates `logs` with canonical viewing-log fields plus shared lifecycle metadata:
+
+- `user_id UUID NOT NULL REFERENCES users(id)`
+- `movie_id UUID NOT NULL REFERENCES movies(id)`
+- `tmdb_id INTEGER NOT NULL`
+- `date_watched TIMESTAMPTZ NOT NULL`
+- `viewing_notes TEXT NULL`
+- `poster_path TEXT NULL`
+- `watched_where TEXT NOT NULL DEFAULT 'other'`
+
+`watched_where` is constrained to the same application-level choices:
+
+- `cinema`
+- `streaming`
+- `homeVideo`
+- `tv`
+- `other`
+
+### Hard-delete parity
+
+Unlike the other migrated repositories, logs preserve their current hard-delete behavior.
+
+- reads still filter with `active()` for parity and safety
+- `delete_log(...)` physically deletes the row instead of flipping `deleted=True`
+
+### Stats aggregation port
+
+`PostgresLogRepository.get_log_stats(...)` preserves the current Mongo response shape:
+
+- `total_watches`
+- `unique_titles`
+- `unique_movie_ids`
+- `distribution`
+
+Implementation uses a shared filtered CTE and two PostgreSQL aggregation queries:
+
+- summary query: `COUNT(*)`, `COUNT(DISTINCT movie_id)`, `array_agg(DISTINCT movie_id)`
+- distribution query: `GROUP BY watched_where`
+
+`LogStats.unique_movie_ids` is widened during the migration window so it can safely carry Mongo `PydanticObjectId` values today and PostgreSQL UUIDs after cutover.
+
+### Data migration script
+
+Use `db_migrations/m004_migrate_logs.py` with async session wiring:
+
+- `up(mongo_db, pg_session, dry_run=False)` migrates active (non-deleted) logs
+- `down(mongo_db, pg_session)` deletes only PostgreSQL rows whose UUIDs derive from the current Mongo `logs` collection
+
+Migration rules:
+
+- Skip `deleted=True` Mongo rows
+- Map Mongo `_id`, `userId`, and `movieId` -> Postgres UUID via `mongo_id_to_uuid(...)`
+- Validate that derived `user_id` and `movie_id` already exist in PostgreSQL before insert
+- Normalize invalid or missing `dateWatched` values into warnings/skips
+- Normalize invalid `watchedWhere` values to `other`
+- Preserve `tmdbId`, `viewingNotes`, `posterPath`, and timestamps
+- Idempotent inserts via PostgreSQL `ON CONFLICT (id) DO NOTHING`
+- Progress reporting (total / inserted / skipped / warnings)
+
 ## Activation Guardrails
 
 PostgreSQL movie activation is intentionally blocked in mixed mode while `LogRepository` and `MovieRatingRepository` still persist/query Mongo ObjectId movie references.
@@ -250,12 +321,14 @@ PostgreSQL user activation is also intentionally blocked in mixed mode while JWT
 
 PostgreSQL movie-rating activation is intentionally blocked in mixed mode while auth still emits ObjectId user IDs, `LogRepository` still consumes ObjectId movie IDs, and `MovieRepository` cutover remains blocked behind the earlier movie guard.
 
+PostgreSQL log activation is intentionally blocked in mixed mode while `LogCacheRepository`, service wiring, and runtime ID assumptions still require the later cutover work before PostgreSQL logs can safely back live requests.
+
 JWT `sub` values and public response IDs remain Mongo ObjectId strings until the core cutover is complete.
 
 ## Later Tickets
 
 Future migration tickets should add:
 
-- Log PostgreSQL repository migration
+- Runtime repository cutover and PostgreSQL-safe log caching
 - Safe full backend cutover once ID dependencies are resolved
 - Final MongoDB decommissioning

--- a/docs/technical/service-dependencies.md
+++ b/docs/technical/service-dependencies.md
@@ -11,11 +11,12 @@ Controllers receive services through FastAPI `Depends(...)`.
 
 ## Repository Provider Guardrails
 
-`get_movie_repository()`, `get_user_repository()`, and `get_movie_rating_repository()` are the runtime activation gates for mixed-mode persistence:
+`get_movie_repository()`, `get_user_repository()`, `get_movie_rating_repository()`, and `get_log_repository()` are the runtime activation gates for mixed-mode persistence:
 
 - `DB_BACKEND` unset or `mongo` -> returns Mongo-backed `MovieRepository`.
 - `DB_BACKEND` unset or `mongo` -> returns Mongo-backed `UserRepository`.
 - `DB_BACKEND` unset or `mongo` -> returns Mongo-backed `MovieRatingRepository`.
+- `DB_BACKEND` unset or `mongo` -> returns Mongo-backed `LogRepository`.
 - `DB_BACKEND=postgres` while mixed-mode is unsafe -> raises `RepositoryActivationError` (fail-fast).
 
 This prevents accidental cutover while:
@@ -23,6 +24,7 @@ This prevents accidental cutover while:
 - Mongo `LogRepository` and `MovieRatingRepository` still depend on ObjectId `movie_id` references.
 - JWT `sub` values, `auth_dependency`, profile ownership checks, and user-scoped cache keys still depend on ObjectId `user_id` references.
 - `MovieRatingService`, `LogService`, and `StatsService` still rely on mixed Mongo user/movie identifiers for rating lookups.
+- `LogService` and `StatsService` still wrap logs through `LogCacheRepository`, which remains Mongo-shaped until the later repository cutover.
 
 ## Service Providers
 

--- a/tests/units/db_migrations/test_migrate_logs.py
+++ b/tests/units/db_migrations/test_migrate_logs.py
@@ -1,0 +1,355 @@
+from __future__ import annotations
+
+import importlib.util
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+MIGRATION_FILE = Path(__file__).resolve().parents[3] / "db_migrations" / "m004_migrate_logs.py"
+spec = importlib.util.spec_from_file_location("migrate_logs_module", MIGRATION_FILE)
+assert spec is not None
+assert spec.loader is not None
+migrate_logs = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(migrate_logs)
+
+
+class _FakeMongoCollection:
+    def __init__(self, docs: list[dict]):
+        self._docs = docs
+        self.last_query: dict | None = None
+        self.last_batch_size: int | None = None
+
+    def find(self, query: dict, batch_size: int | None = None):
+        self.last_query = query
+        self.last_batch_size = batch_size
+        if query == {"deleted": {"$ne": True}}:
+            return iter(doc for doc in self._docs if doc.get("deleted") is not True)
+
+        return iter(self._docs)
+
+
+class _FakeMongoDB:
+    def __init__(self, docs: list[dict]):
+        self.logs = _FakeMongoCollection(docs)
+
+
+def _mock_scalar_result(values: list[object]) -> MagicMock:
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = values
+    return result
+
+
+@pytest.mark.asyncio
+async def test_migrate_logs_up_skips_deleted_missing_foreign_keys_and_invalid_dates(capsys):
+    from app.utils.id_utils import mongo_id_to_uuid
+
+    valid_user_id = mongo_id_to_uuid("507f1f77bcf86cd799439021")
+    valid_movie_id = mongo_id_to_uuid("507f1f77bcf86cd799439031")
+
+    mongo_db = _FakeMongoDB(
+        [
+            {
+                "_id": "507f1f77bcf86cd799439011",
+                "userId": "507f1f77bcf86cd799439021",
+                "movieId": "507f1f77bcf86cd799439031",
+                "tmdbId": 550,
+                "dateWatched": "2024-01-02",
+                "watchedWhere": "cinema",
+                "deleted": False,
+            },
+            {
+                "_id": "507f1f77bcf86cd799439012",
+                "userId": "507f1f77bcf86cd799439022",
+                "movieId": "507f1f77bcf86cd799439031",
+                "tmdbId": 551,
+                "dateWatched": "2024-01-03",
+                "deleted": False,
+            },
+            {
+                "_id": "507f1f77bcf86cd799439013",
+                "userId": "507f1f77bcf86cd799439021",
+                "movieId": "507f1f77bcf86cd799439031",
+                "tmdbId": 552,
+                "dateWatched": "not-a-date",
+                "deleted": False,
+            },
+            {
+                "_id": "507f1f77bcf86cd799439014",
+                "userId": "507f1f77bcf86cd799439021",
+                "movieId": "507f1f77bcf86cd799439031",
+                "tmdbId": 553,
+                "dateWatched": "2024-01-04",
+                "deleted": True,
+            },
+        ]
+    )
+
+    pg_session = AsyncMock()
+    pg_session.execute.side_effect = [
+        _mock_scalar_result([valid_user_id]),
+        _mock_scalar_result([valid_movie_id]),
+        _mock_scalar_result([mongo_id_to_uuid("507f1f77bcf86cd799439011")]),
+    ]
+
+    await migrate_logs.up(mongo_db, pg_session, dry_run=False)
+
+    assert mongo_db.logs.last_query == {"deleted": {"$ne": True}}
+    assert mongo_db.logs.last_batch_size == migrate_logs.BATCH_SIZE
+    assert pg_session.execute.await_count == 3
+    pg_session.commit.assert_awaited_once()
+
+    captured = capsys.readouterr().out
+    assert "total=3" in captured
+    assert "inserted=1" in captured
+    assert "skipped=2" in captured
+    assert "warnings=2" in captured
+
+
+@pytest.mark.asyncio
+async def test_migrate_logs_up_dry_run_reports_progress(capsys):
+    from app.utils.id_utils import mongo_id_to_uuid
+
+    mongo_db = _FakeMongoDB(
+        [
+            {
+                "_id": "507f1f77bcf86cd799439011",
+                "userId": "507f1f77bcf86cd799439021",
+                "movieId": "507f1f77bcf86cd799439031",
+                "tmdbId": 550,
+                "dateWatched": "2024-01-02",
+                "deleted": False,
+            }
+        ]
+    )
+    pg_session = AsyncMock()
+    pg_session.execute.side_effect = [
+        _mock_scalar_result([mongo_id_to_uuid("507f1f77bcf86cd799439021")]),
+        _mock_scalar_result([mongo_id_to_uuid("507f1f77bcf86cd799439031")]),
+        _mock_scalar_result([]),
+    ]
+
+    await migrate_logs.up(mongo_db, pg_session, dry_run=True)
+
+    assert pg_session.execute.await_count == 3
+    pg_session.commit.assert_not_awaited()
+
+    captured = capsys.readouterr().out
+    assert "dry_run=True" in captured
+    assert "inserted=1" in captured
+    assert "skipped=0" in captured
+    assert "warnings=0" in captured
+
+
+@pytest.mark.asyncio
+async def test_migrate_logs_up_dry_run_accounts_for_existing_and_prior_batch_conflicts(capsys, monkeypatch):
+    from app.utils.id_utils import mongo_id_to_uuid
+
+    monkeypatch.setattr(migrate_logs, "BATCH_SIZE", 2)
+    user_uuid = mongo_id_to_uuid("507f1f77bcf86cd799439021")
+    movie_uuid = mongo_id_to_uuid("507f1f77bcf86cd799439031")
+
+    mongo_db = _FakeMongoDB(
+        [
+            {
+                "_id": "507f1f77bcf86cd799439011",
+                "userId": "507f1f77bcf86cd799439021",
+                "movieId": "507f1f77bcf86cd799439031",
+                "tmdbId": 550,
+                "dateWatched": "2024-01-02",
+                "deleted": False,
+            },
+            {
+                "_id": "507f1f77bcf86cd799439012",
+                "userId": "507f1f77bcf86cd799439021",
+                "movieId": "507f1f77bcf86cd799439031",
+                "tmdbId": 551,
+                "dateWatched": "2024-01-03",
+                "deleted": False,
+            },
+            {
+                "_id": "507f1f77bcf86cd799439011",
+                "userId": "507f1f77bcf86cd799439021",
+                "movieId": "507f1f77bcf86cd799439031",
+                "tmdbId": 552,
+                "dateWatched": "2024-01-04",
+                "deleted": False,
+            },
+            {
+                "_id": "507f1f77bcf86cd799439013",
+                "userId": "507f1f77bcf86cd799439021",
+                "movieId": "507f1f77bcf86cd799439031",
+                "tmdbId": 553,
+                "dateWatched": "2024-01-05",
+                "deleted": False,
+            },
+        ]
+    )
+
+    pg_session = AsyncMock()
+    pg_session.execute.side_effect = [
+        _mock_scalar_result([user_uuid]),
+        _mock_scalar_result([movie_uuid]),
+        _mock_scalar_result([mongo_id_to_uuid("507f1f77bcf86cd799439012")]),
+        _mock_scalar_result([user_uuid]),
+        _mock_scalar_result([movie_uuid]),
+        _mock_scalar_result([]),
+    ]
+
+    await migrate_logs.up(mongo_db, pg_session, dry_run=True)
+
+    assert pg_session.execute.await_count == 6
+    pg_session.commit.assert_not_awaited()
+
+    captured = capsys.readouterr().out
+    assert "total=4" in captured
+    assert "inserted=2" in captured
+    assert "skipped=2" in captured
+    assert "warnings=0" in captured
+
+
+@pytest.mark.asyncio
+async def test_migrate_logs_up_preserves_fields_and_normalizes_invalid_watched_where():
+    from app.utils.id_utils import mongo_id_to_uuid
+
+    mongo_db = _FakeMongoDB(
+        [
+            {
+                "_id": "507f1f77bcf86cd799439011",
+                "userId": "507f1f77bcf86cd799439021",
+                "movieId": "507f1f77bcf86cd799439031",
+                "tmdbId": 550,
+                "dateWatched": "2024-01-03",
+                "viewingNotes": "Great notes",
+                "posterPath": "/poster.jpg",
+                "watchedWhere": "unsupported",
+                "createdAt": datetime(2024, 1, 3, 9, 0, tzinfo=UTC),
+                "updatedAt": datetime(2024, 1, 4, 9, 0, tzinfo=UTC),
+                "deleted": False,
+            }
+        ]
+    )
+
+    pg_session = AsyncMock()
+    pg_session.execute.side_effect = [
+        _mock_scalar_result([mongo_id_to_uuid("507f1f77bcf86cd799439021")]),
+        _mock_scalar_result([mongo_id_to_uuid("507f1f77bcf86cd799439031")]),
+        _mock_scalar_result([mongo_id_to_uuid("507f1f77bcf86cd799439011")]),
+    ]
+
+    await migrate_logs.up(mongo_db, pg_session, dry_run=False)
+
+    statement = pg_session.execute.await_args_list[2].args[0]
+    compiled_params = statement.compile().params
+    assert [value for key, value in compiled_params.items() if key.startswith("watched_where")] == ["other"]
+    assert [value for key, value in compiled_params.items() if key.startswith("viewing_notes")] == ["Great notes"]
+    assert [value for key, value in compiled_params.items() if key.startswith("poster_path")] == ["/poster.jpg"]
+    assert [value for key, value in compiled_params.items() if key.startswith("date_watched")] == [
+        datetime(2024, 1, 3, tzinfo=UTC)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_migrate_logs_up_flushes_in_batches(capsys, monkeypatch):
+    from app.utils.id_utils import mongo_id_to_uuid
+
+    monkeypatch.setattr(migrate_logs, "BATCH_SIZE", 2)
+    user_uuid = mongo_id_to_uuid("507f1f77bcf86cd799439021")
+    movie_uuid = mongo_id_to_uuid("507f1f77bcf86cd799439031")
+
+    mongo_db = _FakeMongoDB(
+        [
+            {
+                "_id": f"507f1f77bcf86cd79943901{i}",
+                "userId": "507f1f77bcf86cd799439021",
+                "movieId": "507f1f77bcf86cd799439031",
+                "tmdbId": 600 + i,
+                "dateWatched": "2024-01-02",
+                "deleted": False,
+            }
+            for i in range(5)
+        ]
+    )
+
+    pg_session = AsyncMock()
+    pg_session.execute.side_effect = [
+        _mock_scalar_result([user_uuid]),
+        _mock_scalar_result([movie_uuid]),
+        _mock_scalar_result(
+            [
+                mongo_id_to_uuid("507f1f77bcf86cd799439010"),
+                mongo_id_to_uuid("507f1f77bcf86cd799439011"),
+            ]
+        ),
+        _mock_scalar_result([user_uuid]),
+        _mock_scalar_result([movie_uuid]),
+        _mock_scalar_result(
+            [
+                mongo_id_to_uuid("507f1f77bcf86cd799439012"),
+                mongo_id_to_uuid("507f1f77bcf86cd799439013"),
+            ]
+        ),
+        _mock_scalar_result([user_uuid]),
+        _mock_scalar_result([movie_uuid]),
+        _mock_scalar_result([mongo_id_to_uuid("507f1f77bcf86cd799439014")]),
+    ]
+
+    await migrate_logs.up(mongo_db, pg_session, dry_run=False)
+
+    assert pg_session.execute.await_count == 9
+    pg_session.commit.assert_awaited_once()
+
+    captured = capsys.readouterr().out
+    assert "total=5" in captured
+    assert "inserted=5" in captured
+    assert "skipped=0" in captured
+    assert "warnings=0" in captured
+
+
+@pytest.mark.asyncio
+async def test_migrate_logs_down_is_noop_when_mongo_empty(capsys):
+    mongo_db = _FakeMongoDB([])
+    pg_session = AsyncMock()
+
+    await migrate_logs.down(mongo_db, pg_session)
+
+    pg_session.execute.assert_not_awaited()
+    pg_session.commit.assert_not_awaited()
+
+    captured = capsys.readouterr().out
+    assert "derived_ids=0" in captured
+    assert "deleted=0" in captured
+
+
+@pytest.mark.asyncio
+async def test_migrate_logs_down_deletes_only_derived_ids(capsys):
+    from app.utils.id_utils import mongo_id_to_uuid
+
+    mongo_db = _FakeMongoDB(
+        [
+            {"_id": "507f1f77bcf86cd799439011"},
+            {"_id": "507f1f77bcf86cd799439012"},
+        ]
+    )
+    pg_session = AsyncMock()
+    delete_result = MagicMock()
+    delete_result.scalars.return_value.all.return_value = [
+        mongo_id_to_uuid("507f1f77bcf86cd799439011"),
+        mongo_id_to_uuid("507f1f77bcf86cd799439012"),
+    ]
+    pg_session.execute.return_value = delete_result
+
+    await migrate_logs.down(mongo_db, pg_session)
+
+    pg_session.execute.assert_awaited_once()
+    pg_session.commit.assert_awaited_once()
+
+    statement = pg_session.execute.await_args.args[0]
+    sql = str(statement.compile(compile_kwargs={"literal_binds": True}))
+    assert mongo_id_to_uuid("507f1f77bcf86cd799439011").hex in sql
+    assert mongo_id_to_uuid("507f1f77bcf86cd799439012").hex in sql
+
+    captured = capsys.readouterr().out
+    assert "derived_ids=2" in captured
+    assert "deleted=2" in captured

--- a/tests/units/dependencies/test_repository_dependency.py
+++ b/tests/units/dependencies/test_repository_dependency.py
@@ -2,10 +2,12 @@ import pytest
 
 from app.dependencies.repository_dependency import (
     RepositoryActivationError,
+    get_log_repository,
     get_movie_rating_repository,
     get_movie_repository,
     get_user_repository,
 )
+from app.repository.log_repository import LogRepository
 from app.repository.movie_rating_repository import MovieRatingRepository
 from app.repository.movie_repository import MovieRepository
 from app.repository.user_repository import UserRepository
@@ -13,10 +15,12 @@ from app.repository.user_repository import UserRepository
 
 @pytest.fixture(autouse=True)
 def clear_repository_caches():
+    get_log_repository.cache_clear()
     get_movie_rating_repository.cache_clear()
     get_movie_repository.cache_clear()
     get_user_repository.cache_clear()
     yield
+    get_log_repository.cache_clear()
     get_movie_rating_repository.cache_clear()
     get_movie_repository.cache_clear()
     get_user_repository.cache_clear()
@@ -35,6 +39,21 @@ def test_get_movie_repository_raises_for_unsafe_postgres_activation(monkeypatch)
 
     with pytest.raises(RepositoryActivationError, match="not yet safe"):
         get_movie_repository()
+
+
+def test_get_log_repository_defaults_to_mongo(monkeypatch):
+    monkeypatch.delenv("DB_BACKEND", raising=False)
+
+    repository = get_log_repository()
+
+    assert isinstance(repository, LogRepository)
+
+
+def test_get_log_repository_raises_for_unsafe_postgres_activation(monkeypatch):
+    monkeypatch.setenv("DB_BACKEND", "postgres")
+
+    with pytest.raises(RepositoryActivationError, match="not yet safe"):
+        get_log_repository()
 
 
 def test_get_movie_rating_repository_defaults_to_mongo(monkeypatch):

--- a/tests/units/repository/test_postgres_log_repository.py
+++ b/tests/units/repository/test_postgres_log_repository.py
@@ -1,0 +1,475 @@
+"""Unit tests for ``PostgresLogRepository``."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from datetime import UTC, date, datetime
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from pytest_postgresql.janitor import DatabaseJanitor
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.models.base_model import Base
+from app.models.log_model import PostgresLog
+from app.models.movie_model import PostgresMovie
+from app.models.user_model import PostgresUser
+from app.repository.postgres_log_repository import PostgresLogRepository
+from app.schemas.log_schemas import LogCreateRequest, LogUpdateRequest
+from app.schemas.stats_schemas import LogStats
+
+
+def _async_url(pg, dbname: str) -> str:
+    return f"postgresql+asyncpg://{pg.user}:{pg.password}@{pg.host}:{pg.port}/{dbname}"
+
+
+@pytest_asyncio.fixture
+async def pg_engine(postgresql_proc):
+    """Create a fresh database per test and return an async SQLAlchemy engine."""
+    dbname = f"cinelog_log_test_{uuid4().hex[:8]}"
+
+    with DatabaseJanitor(
+        user=postgresql_proc.user,
+        host=postgresql_proc.host,
+        port=postgresql_proc.port,
+        dbname=dbname,
+        version=postgresql_proc.version,
+        password=postgresql_proc.password,
+    ):
+        engine = create_async_engine(_async_url(postgresql_proc, dbname))
+        async with engine.begin() as connection:
+            await connection.execute(text("CREATE EXTENSION IF NOT EXISTS pgcrypto"))
+            await connection.run_sync(Base.metadata.create_all)
+
+        try:
+            yield engine
+        finally:
+            await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def session_factory(pg_engine):
+    return async_sessionmaker(pg_engine, class_=AsyncSession, expire_on_commit=False)
+
+
+@pytest.fixture
+def repository(session_factory) -> PostgresLogRepository:
+    @asynccontextmanager
+    async def _provider():
+        async with session_factory() as session:
+            yield session
+
+    return PostgresLogRepository(session_provider=_provider)
+
+
+@pytest_asyncio.fixture
+async def seed_session(session_factory):
+    async with session_factory() as session:
+        yield session
+
+
+async def _add(seed_session: AsyncSession, *entities) -> None:
+    seed_session.add_all(entities)
+    await seed_session.commit()
+    for entity in entities:
+        await seed_session.refresh(entity)
+
+
+async def _seed_fk_entities(seed_session: AsyncSession) -> tuple[PostgresUser, PostgresMovie, PostgresMovie]:
+    user = PostgresUser(
+        email="logs@example.com",
+        handle="logs-user",
+        first_name="Logs",
+        last_name="User",
+        date_of_birth=date(1990, 1, 1),
+    )
+    movie_a = PostgresMovie(tmdb_id=550, title="Fight Club")
+    movie_b = PostgresMovie(tmdb_id=551, title="Alien")
+    await _add(seed_session, user, movie_a, movie_b)
+    return user, movie_a, movie_b
+
+
+def _create_request(
+    movie_id: str,
+    *,
+    tmdb_id: int,
+    date_watched: date = date(2024, 1, 2),
+    watched_where: str = "cinema",
+    viewing_notes: str | None = "Great watch",
+    poster_path: str | None = "/poster.jpg",
+) -> LogCreateRequest:
+    return LogCreateRequest(
+        movie_id=movie_id,
+        tmdb_id=tmdb_id,
+        date_watched=date_watched,
+        viewing_notes=viewing_notes,
+        poster_path=poster_path,
+        watched_where=watched_where,
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_log_persists_row(repository: PostgresLogRepository, seed_session: AsyncSession):
+    user, movie, _ = await _seed_fk_entities(seed_session)
+
+    log = await repository.create_log(
+        user.id,
+        _create_request(str(movie.id), tmdb_id=movie.tmdb_id),
+    )
+
+    assert log.id is not None
+    assert log.user_id == user.id
+    assert log.movie_id == movie.id
+    assert log.tmdb_id == movie.tmdb_id
+    assert log.date_watched == datetime(2024, 1, 2, tzinfo=UTC)
+    assert log.watched_where == "cinema"
+    assert log.deleted is False
+
+
+@pytest.mark.asyncio
+async def test_find_log_by_id_respects_owner_and_deleted_rows(
+    repository: PostgresLogRepository,
+    seed_session: AsyncSession,
+):
+    user, movie, _ = await _seed_fk_entities(seed_session)
+    other_user = PostgresUser(
+        email="other@example.com",
+        handle="other-user",
+        first_name="Other",
+        last_name="User",
+        date_of_birth=date(1991, 1, 1),
+    )
+    await _add(seed_session, other_user)
+
+    active = PostgresLog(
+        user_id=user.id,
+        movie_id=movie.id,
+        tmdb_id=movie.tmdb_id,
+        date_watched=datetime(2024, 1, 2, tzinfo=UTC),
+        watched_where="cinema",
+    )
+    deleted = PostgresLog(
+        user_id=user.id,
+        movie_id=movie.id,
+        tmdb_id=999,
+        date_watched=datetime(2024, 1, 3, tzinfo=UTC),
+        watched_where="streaming",
+        deleted=True,
+        deleted_at=datetime.now(UTC),
+    )
+    await _add(seed_session, active, deleted)
+
+    assert (await repository.find_log_by_id(active.id, user.id)) is not None
+    assert await repository.find_log_by_id(active.id, other_user.id) is None
+    assert await repository.find_log_by_id(deleted.id, user.id) is None
+
+
+@pytest.mark.asyncio
+async def test_update_log_applies_partial_updates_and_rejects_wrong_owner(
+    repository: PostgresLogRepository,
+    seed_session: AsyncSession,
+):
+    user, movie, _ = await _seed_fk_entities(seed_session)
+    other_user = PostgresUser(
+        email="update-other@example.com",
+        handle="update-other",
+        first_name="Update",
+        last_name="Other",
+        date_of_birth=date(1991, 2, 1),
+    )
+    await _add(seed_session, other_user)
+
+    log = PostgresLog(
+        user_id=user.id,
+        movie_id=movie.id,
+        tmdb_id=movie.tmdb_id,
+        date_watched=datetime(2024, 1, 2, tzinfo=UTC),
+        viewing_notes="Before",
+        watched_where="cinema",
+    )
+    await _add(seed_session, log)
+
+    updated = await repository.update_log(
+        log.id,
+        user.id,
+        LogUpdateRequest(
+            viewing_notes="After",
+            watched_where="streaming",
+            date_watched=date(2024, 1, 5),
+        ),
+    )
+
+    assert updated is not None
+    assert updated.viewing_notes == "After"
+    assert updated.watched_where == "streaming"
+    assert updated.date_watched == datetime(2024, 1, 5, tzinfo=UTC)
+
+    assert await repository.update_log(log.id, other_user.id, LogUpdateRequest(viewing_notes="Nope")) is None
+
+
+@pytest.mark.asyncio
+async def test_delete_log_hard_deletes_row(repository: PostgresLogRepository, seed_session: AsyncSession):
+    user, movie, _ = await _seed_fk_entities(seed_session)
+    other_user = PostgresUser(
+        email="delete-other@example.com",
+        handle="delete-other",
+        first_name="Delete",
+        last_name="Other",
+        date_of_birth=date(1992, 1, 1),
+    )
+    await _add(seed_session, other_user)
+    other_user_id = other_user.id
+
+    log = PostgresLog(
+        user_id=user.id,
+        movie_id=movie.id,
+        tmdb_id=movie.tmdb_id,
+        date_watched=datetime(2024, 1, 2, tzinfo=UTC),
+        watched_where="cinema",
+    )
+    await _add(seed_session, log)
+    log_id = log.id
+    user_id = user.id
+
+    deleted = await repository.delete_log(log_id, user_id)
+
+    assert deleted is not None
+    assert deleted.id == log_id
+    seed_session.expire_all()
+    assert await seed_session.get(PostgresLog, log_id) is None
+    assert await repository.delete_log(log_id, user_id) is None
+    assert await repository.delete_log(uuid4(), other_user_id) is None
+
+
+@pytest.mark.asyncio
+async def test_find_logs_by_user_id_filters_and_sorts(
+    repository: PostgresLogRepository,
+    seed_session: AsyncSession,
+):
+    user, movie_a, movie_b = await _seed_fk_entities(seed_session)
+    other_user = PostgresUser(
+        email="filters-other@example.com",
+        handle="filters-other",
+        first_name="Filters",
+        last_name="Other",
+        date_of_birth=date(1992, 2, 2),
+    )
+    await _add(seed_session, other_user)
+
+    older_streaming = PostgresLog(
+        user_id=user.id,
+        movie_id=movie_a.id,
+        tmdb_id=movie_a.tmdb_id,
+        date_watched=datetime(2024, 1, 2, tzinfo=UTC),
+        viewing_notes="Older",
+        watched_where="streaming",
+        created_at=datetime(2024, 1, 2, 8, 0, tzinfo=UTC),
+        updated_at=datetime(2024, 1, 2, 8, 0, tzinfo=UTC),
+    )
+    newer_streaming = PostgresLog(
+        user_id=user.id,
+        movie_id=movie_b.id,
+        tmdb_id=movie_b.tmdb_id,
+        date_watched=datetime(2024, 1, 3, tzinfo=UTC),
+        viewing_notes="Newer",
+        watched_where="streaming",
+        created_at=datetime(2024, 1, 2, 20, 0, tzinfo=UTC),
+        updated_at=datetime(2024, 1, 2, 20, 0, tzinfo=UTC),
+    )
+    cinema = PostgresLog(
+        user_id=user.id,
+        movie_id=movie_a.id,
+        tmdb_id=movie_a.tmdb_id,
+        date_watched=datetime(2024, 1, 4, tzinfo=UTC),
+        viewing_notes="Cinema",
+        watched_where="cinema",
+        created_at=datetime(2024, 1, 4, 9, 0, tzinfo=UTC),
+        updated_at=datetime(2024, 1, 4, 9, 0, tzinfo=UTC),
+    )
+    other_users_log = PostgresLog(
+        user_id=other_user.id,
+        movie_id=movie_b.id,
+        tmdb_id=movie_b.tmdb_id,
+        date_watched=datetime(2024, 1, 5, tzinfo=UTC),
+        watched_where="tv",
+    )
+    deleted = PostgresLog(
+        user_id=user.id,
+        movie_id=movie_b.id,
+        tmdb_id=999,
+        date_watched=datetime(2024, 1, 6, tzinfo=UTC),
+        watched_where="tv",
+        deleted=True,
+        deleted_at=datetime.now(UTC),
+    )
+    await _add(seed_session, older_streaming, newer_streaming, cinema, other_users_log, deleted)
+
+    no_filters = await repository.find_logs_by_user_id(user.id)
+    assert [log.id for log in no_filters] == [cinema.id, newer_streaming.id, older_streaming.id]
+
+    watched_where_only = await repository.find_logs_by_user_id(user.id, watched_where="streaming")
+    assert [log.id for log in watched_where_only] == [newer_streaming.id, older_streaming.id]
+
+    date_filtered = await repository.find_logs_by_user_id(
+        user.id,
+        date_watched_from=date(2024, 1, 3),
+        date_watched_to=date(2024, 1, 4),
+    )
+    assert [log.id for log in date_filtered] == [cinema.id, newer_streaming.id]
+
+    date_sort_asc = await repository.find_logs_by_user_id(user.id, sort_by="dateWatched", sort_order="asc")
+    assert [log.id for log in date_sort_asc] == [older_streaming.id, newer_streaming.id, cinema.id]
+
+    watched_where_sort_asc = await repository.find_logs_by_user_id(user.id, sort_by="watchedWhere", sort_order="asc")
+    assert [log.id for log in watched_where_sort_asc] == [cinema.id, older_streaming.id, newer_streaming.id]
+
+    watched_where_sort_desc = await repository.find_logs_by_user_id(
+        user.id,
+        sort_by="watchedWhere",
+        sort_order="desc",
+    )
+    assert [log.id for log in watched_where_sort_desc] == [newer_streaming.id, older_streaming.id, cinema.id]
+
+
+@pytest.mark.asyncio
+async def test_find_logs_by_movie_id_supports_optional_user_filter_and_created_order(
+    repository: PostgresLogRepository,
+    seed_session: AsyncSession,
+):
+    user, movie, _ = await _seed_fk_entities(seed_session)
+    other_user = PostgresUser(
+        email="movie-filter@example.com",
+        handle="movie-filter",
+        first_name="Movie",
+        last_name="Filter",
+        date_of_birth=date(1993, 3, 3),
+    )
+    await _add(seed_session, other_user)
+
+    first = PostgresLog(
+        user_id=user.id,
+        movie_id=movie.id,
+        tmdb_id=movie.tmdb_id,
+        date_watched=datetime(2024, 1, 2, tzinfo=UTC),
+        watched_where="cinema",
+        created_at=datetime(2024, 1, 2, 8, 0, tzinfo=UTC),
+        updated_at=datetime(2024, 1, 2, 8, 0, tzinfo=UTC),
+    )
+    second = PostgresLog(
+        user_id=user.id,
+        movie_id=movie.id,
+        tmdb_id=movie.tmdb_id,
+        date_watched=datetime(2024, 1, 3, tzinfo=UTC),
+        watched_where="streaming",
+        created_at=datetime(2024, 1, 2, 20, 0, tzinfo=UTC),
+        updated_at=datetime(2024, 1, 2, 20, 0, tzinfo=UTC),
+    )
+    other_users_log = PostgresLog(
+        user_id=other_user.id,
+        movie_id=movie.id,
+        tmdb_id=movie.tmdb_id,
+        date_watched=datetime(2024, 1, 4, tzinfo=UTC),
+        watched_where="tv",
+    )
+    await _add(seed_session, first, second, other_users_log)
+
+    all_logs = await repository.find_logs_by_movie_id(movie.id)
+    assert [log.id for log in all_logs] == [first.id, second.id, other_users_log.id]
+
+    user_logs = await repository.find_logs_by_movie_id(movie.id, user.id)
+    assert [log.id for log in user_logs] == [first.id, second.id]
+
+    assert await repository.find_logs_by_movie_id(uuid4()) == []
+
+
+@pytest.mark.asyncio
+async def test_get_log_stats_returns_summary_distribution_and_uuid_movie_ids(
+    repository: PostgresLogRepository,
+    seed_session: AsyncSession,
+):
+    user, movie_a, movie_b = await _seed_fk_entities(seed_session)
+    movie_c = PostgresMovie(tmdb_id=552, title="Movie C")
+    await _add(seed_session, movie_c)
+
+    active_one = PostgresLog(
+        user_id=user.id,
+        movie_id=movie_a.id,
+        tmdb_id=movie_a.tmdb_id,
+        date_watched=datetime(2024, 1, 2, tzinfo=UTC),
+        watched_where="cinema",
+    )
+    active_two = PostgresLog(
+        user_id=user.id,
+        movie_id=movie_a.id,
+        tmdb_id=movie_a.tmdb_id,
+        date_watched=datetime(2024, 1, 3, tzinfo=UTC),
+        watched_where="streaming",
+    )
+    active_three = PostgresLog(
+        user_id=user.id,
+        movie_id=movie_b.id,
+        tmdb_id=movie_b.tmdb_id,
+        date_watched=datetime(2024, 1, 4, tzinfo=UTC),
+        watched_where="streaming",
+    )
+    deleted = PostgresLog(
+        user_id=user.id,
+        movie_id=movie_c.id,
+        tmdb_id=movie_c.tmdb_id,
+        date_watched=datetime(2024, 1, 5, tzinfo=UTC),
+        watched_where="tv",
+        deleted=True,
+        deleted_at=datetime.now(UTC),
+    )
+    await _add(seed_session, active_one, active_two, active_three, deleted)
+
+    stats = await repository.get_log_stats(user.id)
+
+    assert stats.total_watches == 3
+    assert stats.unique_titles == 2
+    assert set(stats.unique_movie_ids) == {movie_a.id, movie_b.id}
+    assert {entry.watched_where: entry.count for entry in stats.distribution} == {
+        "cinema": 1,
+        "streaming": 2,
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_log_stats_supports_date_range_and_empty_result(
+    repository: PostgresLogRepository,
+    seed_session: AsyncSession,
+):
+    user, movie_a, movie_b = await _seed_fk_entities(seed_session)
+    first = PostgresLog(
+        user_id=user.id,
+        movie_id=movie_a.id,
+        tmdb_id=movie_a.tmdb_id,
+        date_watched=datetime(2024, 1, 2, tzinfo=UTC),
+        watched_where="cinema",
+    )
+    second = PostgresLog(
+        user_id=user.id,
+        movie_id=movie_b.id,
+        tmdb_id=movie_b.tmdb_id,
+        date_watched=datetime(2024, 2, 2, tzinfo=UTC),
+        watched_where="streaming",
+    )
+    await _add(seed_session, first, second)
+
+    january_stats = await repository.get_log_stats(
+        user.id,
+        date_from=date(2024, 1, 1),
+        date_to=date(2024, 1, 31),
+    )
+    assert january_stats.total_watches == 1
+    assert january_stats.unique_titles == 1
+    assert january_stats.unique_movie_ids == [movie_a.id]
+
+    empty_stats = await repository.get_log_stats(
+        user.id,
+        date_from=date(2024, 3, 1),
+        date_to=date(2024, 3, 31),
+    )
+    assert empty_stats == LogStats()

--- a/tests/units/services/test_stats_service.py
+++ b/tests/units/services/test_stats_service.py
@@ -1,5 +1,6 @@
 from datetime import date
-from unittest.mock import AsyncMock
+from unittest.mock import ANY, AsyncMock
+from uuid import uuid4
 
 import pytest
 from beanie import PydanticObjectId
@@ -181,6 +182,34 @@ class TestStatsService:
         assert result.distribution.by_method.home_video == 1
         assert result.distribution.by_method.tv == 1
         assert result.distribution.by_method.other == 2
+
+    @pytest.mark.asyncio
+    async def test_get_user_stats_accepts_uuid_movie_ids_during_migration(
+        self,
+        stats_service,
+        mock_log_repository,
+        mock_movie_rating_repository,
+        mock_movie_repository,
+    ):
+        movie_id_1 = uuid4()
+        movie_id_2 = uuid4()
+
+        mock_log_repository.get_log_stats.return_value = LogStats(
+            total_watches=2,
+            unique_titles=2,
+            unique_movie_ids=[movie_id_1, movie_id_2],
+            distribution=[],
+        )
+        mock_movie_rating_repository.get_user_movie_ratings_average.return_value = _empty_movie_rating_stats()
+        mock_movie_repository.get_movie_stats.return_value = _empty_movie_stats()
+
+        await stats_service.get_user_stats(PydanticObjectId())
+
+        mock_movie_rating_repository.get_user_movie_ratings_average.assert_awaited_once_with(
+            ANY,
+            {movie_id_1, movie_id_2},
+        )
+        mock_movie_repository.get_movie_stats.assert_awaited_once_with({movie_id_1, movie_id_2})
 
 
 def _sample_stats_response() -> StatsResponse:


### PR DESCRIPTION
## Summary
- add the PostgreSQL log model, repository, Alembic migration, and Mongo-to-Postgres data migration
- keep the Mongo log repository active and add `get_log_repository()` mixed-mode guard wiring through log/stats services
- document the migration path, widen `LogStats.unique_movie_ids` for the migration window, and add repository/migration/dependency coverage

## Verification
- make test-unit
- make lint
- make typecheck

## Follow-up
- Runtime cutover remains tracked in #167

Closes #129