### PR TITLE
feat(cutover): activate PostgreSQL repositories in services

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -74,6 +74,8 @@ jobs:
         run: |
           uv run alembic upgrade head
         env:
+          JWT_SECRET_KEY: test-jwt-secret-key-for-e2e-1234567890
+          RATE_LIMIT_HMAC_SECRET: test-rate-limit-hmac-secret
           DATABASE_URL: postgresql+asyncpg://cinelog:cinelog@localhost:5433/cinelog_e2e_db
 
       - name: Run E2E Tests

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      max-parallel: 2
       matrix:
         backend: [mongo, postgres]
 

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -9,8 +9,13 @@ on:
 
 jobs:
   e2e_tests:
+    name: E2E Tests (${{ matrix.backend }})
     runs-on: ubuntu-latest
-    
+    strategy:
+      fail-fast: false
+      matrix:
+        backend: [mongo, postgres]
+
     services:
       mongo:
         image: mongo:8
@@ -23,11 +28,25 @@ jobs:
           --health-retries=5
 
       redis:
-        image: redis:7
+        image: redis:7-alpine
         ports:
-          - 6379:6379
+          - 6380:6379
         options: >-
           --health-cmd="redis-cli ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+      postgres:
+        image: postgres:17-alpine
+        ports:
+          - 5433:5432
+        env:
+          POSTGRES_DB: cinelog_e2e_db
+          POSTGRES_USER: cinelog
+          POSTGRES_PASSWORD: cinelog
+        options: >-
+          --health-cmd="pg_isready -U cinelog -d cinelog_e2e_db"
           --health-interval=10s
           --health-timeout=5s
           --health-retries=5
@@ -49,12 +68,19 @@ jobs:
         run: |
           uv sync --frozen --group dev
 
+      - name: Prepare PostgreSQL schema
+        if: matrix.backend == 'postgres'
+        run: |
+          uv run alembic upgrade head
+        env:
+          DATABASE_URL: postgresql+asyncpg://cinelog:cinelog@localhost:5433/cinelog_e2e_db
+
       - name: Run E2E Tests
         run: |
           uv run pytest tests/e2e -v
         env:
-          MONGODB_HOST: localhost
-          MONGODB_PORT: 27018
-          MONGODB_DB: cinelog_e2e_db
-          REDIS_URL: redis://localhost:6379/0
+          E2E_BACKEND: ${{ matrix.backend }}
+          JWT_SECRET_KEY: test-jwt-secret-key-for-e2e-1234567890
+          RATE_LIMIT_HMAC_SECRET: test-rate-limit-hmac-secret
+          REDIS_URL: redis://localhost:6380/0
           TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,46 @@ test-unit:
 	uv run pytest tests/units/ --cov=app --cov-report=html
 
 test-e2e:
-	docker compose -f docker-compose.e2e.yml up -d
-	uv run pytest tests/e2e/ -v; status=$$?; docker compose -f docker-compose.e2e.yml down; exit $$status
+	backend="$${E2E_BACKEND:-mongo}"; \
+	status=0; \
+	if [ "$$backend" = "postgres" ]; then \
+		docker compose -f docker-compose.e2e.yml up -d redis_e2e postgres_e2e; \
+		ready=0; \
+		for i in $$(seq 1 30); do \
+			if docker compose -f docker-compose.e2e.yml exec -T postgres_e2e pg_isready -U cinelog -d cinelog_e2e_db >/dev/null 2>&1; then \
+				ready=1; \
+				break; \
+			fi; \
+			sleep 1; \
+		done; \
+		if [ "$$ready" -ne 1 ]; then \
+			status=1; \
+		fi; \
+		if [ "$$status" -eq 0 ]; then \
+			JWT_SECRET_KEY=test-jwt-secret-key-for-e2e-1234567890 \
+			RATE_LIMIT_HMAC_SECRET=test-rate-limit-hmac-secret \
+			DATABASE_URL=postgresql+asyncpg://cinelog:cinelog@localhost:5433/cinelog_e2e_db \
+			E2E_BACKEND=postgres \
+			uv run alembic upgrade head; \
+			status=$$?; \
+		fi; \
+		if [ "$$status" -eq 0 ]; then \
+			JWT_SECRET_KEY=test-jwt-secret-key-for-e2e-1234567890 \
+			RATE_LIMIT_HMAC_SECRET=test-rate-limit-hmac-secret \
+			DATABASE_URL=postgresql+asyncpg://cinelog:cinelog@localhost:5433/cinelog_e2e_db \
+			E2E_BACKEND=postgres \
+			uv run pytest tests/e2e/ -v; \
+			status=$$?; \
+		fi; \
+	else \
+		docker compose -f docker-compose.e2e.yml up -d redis_e2e mongo_e2e; \
+		JWT_SECRET_KEY=test-jwt-secret-key-for-e2e-1234567890 \
+		RATE_LIMIT_HMAC_SECRET=test-rate-limit-hmac-secret \
+		E2E_BACKEND=mongo uv run pytest tests/e2e/ -v; \
+		status=$$?; \
+	fi; \
+	docker compose -f docker-compose.e2e.yml down; \
+	exit $$status
 
 lint:
 	uv run ruff check .

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -9,11 +9,12 @@ from sqlalchemy import pool
 from sqlalchemy.engine import Connection
 from sqlalchemy.ext.asyncio import async_engine_from_config
 
-# Import all ORM modules so their tables register with ``Base.metadata`` before
-# ``--autogenerate`` snapshots it. Imports are side-effect only.
 from alembic import context, util
-from app.models import movie_model, user_model  # noqa: F401
 from app.models.base_model import Base
+from app.models.log_model import PostgresLog  # noqa: F401
+from app.models.movie_model import PostgresMovie  # noqa: F401
+from app.models.movie_rating_model import PostgresMovieRating  # noqa: F401
+from app.models.user_model import PostgresUser  # noqa: F401
 
 config = context.config
 

--- a/app/controllers/log_controller.py
+++ b/app/controllers/log_controller.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from beanie import PydanticObjectId
 from fastapi import APIRouter, Depends, Request, Response, status
 
@@ -22,7 +24,7 @@ async def create_log(
     request: Request,
     response: Response,
     request_body: LogCreateRequest,
-    user_id: PydanticObjectId = Depends(auth_dependency),
+    user_id: PydanticObjectId | UUID = Depends(auth_dependency),
     log_service: LogService = Depends(get_log_service),
 ) -> LogCreateResponse:
     """
@@ -38,9 +40,9 @@ async def create_log(
 async def update_log(
     request: Request,
     response: Response,
-    log_id: PydanticObjectId,
+    log_id: PydanticObjectId | UUID,
     request_body: LogUpdateRequest,
-    user_id: PydanticObjectId = Depends(auth_dependency),
+    user_id: PydanticObjectId | UUID = Depends(auth_dependency),
     log_service: LogService = Depends(get_log_service),
 ) -> LogCreateResponse:
     """
@@ -61,8 +63,8 @@ async def update_log(
 async def delete_log(
     request: Request,
     response: Response,
-    log_id: PydanticObjectId,
-    user_id: PydanticObjectId = Depends(auth_dependency),
+    log_id: PydanticObjectId | UUID,
+    user_id: PydanticObjectId | UUID = Depends(auth_dependency),
     log_service: LogService = Depends(get_log_service),
 ) -> None:
     """
@@ -79,7 +81,7 @@ async def get_logs_by_handle(
     handle: str,
     request: Request,
     list_request: LogListRequest = Depends(),
-    user_id: PydanticObjectId = Depends(auth_dependency),
+    user_id: PydanticObjectId | UUID = Depends(auth_dependency),
     log_service: LogService = Depends(get_log_service),
 ) -> LogListResponse:
     """

--- a/app/controllers/movie_rating_controller.py
+++ b/app/controllers/movie_rating_controller.py
@@ -1,4 +1,5 @@
 from typing import Annotated
+from uuid import UUID
 
 from beanie import PydanticObjectId
 from fastapi import APIRouter, Depends, Request, Response, status
@@ -18,7 +19,7 @@ router = APIRouter()
 async def create_movie_rating(
     request_body: MovieRatingCreateUpdateRequest,
     request: Request,
-    user_id: Annotated[PydanticObjectId, Depends(auth_dependency)],
+    user_id: Annotated[PydanticObjectId | UUID, Depends(auth_dependency)],
     movie_rating_service: Annotated[MovieRatingService, Depends(get_movie_rating_service)],
 ) -> MovieRatingResponse:
     """
@@ -37,7 +38,7 @@ async def create_movie_rating(
 @router.get("/{tmdb_id}", response_model=None)
 async def get_movie_rating(
     tmdb_id: int,
-    current_user_id: Annotated[PydanticObjectId, Depends(auth_dependency)],
+    current_user_id: Annotated[PydanticObjectId | UUID, Depends(auth_dependency)],
     movie_rating_service: Annotated[MovieRatingService, Depends(get_movie_rating_service)],
 ) -> MovieRatingResponse | Response:
     """

--- a/app/controllers/stats_controller.py
+++ b/app/controllers/stats_controller.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from beanie import PydanticObjectId
 from fastapi import APIRouter, Depends, HTTPException, Request
 
@@ -14,7 +16,7 @@ router = APIRouter()
 async def get_my_stats(
     request: Request,
     stats_request: StatsRequest = Depends(),
-    user_id: PydanticObjectId = Depends(auth_dependency),
+    user_id: PydanticObjectId | UUID = Depends(auth_dependency),
     stats_service: StatsService = Depends(get_stats_service),
 ) -> StatsResponse:
     """

--- a/app/controllers/user_controller.py
+++ b/app/controllers/user_controller.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from beanie import PydanticObjectId
 from fastapi import APIRouter, Depends, Request
 
@@ -18,7 +20,7 @@ router = APIRouter()
 @router.get("/info", response_model=UserResponse)
 async def get_user_info(
     request: Request,
-    user_id: PydanticObjectId = Depends(auth_dependency),
+    user_id: PydanticObjectId | UUID = Depends(auth_dependency),
     user_service: UserService = Depends(get_user_service),
 ) -> UserResponse:
     return await user_service.get_user_info(user_id)
@@ -28,7 +30,7 @@ async def get_user_info(
 async def get_public_profile(
     handle: str,
     request: Request,
-    user_id: PydanticObjectId = Depends(auth_dependency),
+    user_id: PydanticObjectId | UUID = Depends(auth_dependency),
     user_service: UserService = Depends(get_user_service),
 ) -> UserProfileResponse:
     return await user_service.get_visible_profile(handle=handle, requester_id=user_id)
@@ -38,7 +40,7 @@ async def get_public_profile(
 async def update_profile(
     request_body: UpdateProfileRequest,
     request: Request,
-    user_id: PydanticObjectId = Depends(auth_dependency),
+    user_id: PydanticObjectId | UUID = Depends(auth_dependency),
     user_service: UserService = Depends(get_user_service),
 ) -> UserResponse:
     return await user_service.update_profile(user_id, request_body)
@@ -48,7 +50,7 @@ async def update_profile(
 async def change_password(
     request_body: ChangePasswordRequest,
     request: Request,
-    user_id: PydanticObjectId = Depends(auth_dependency),
+    user_id: PydanticObjectId | UUID = Depends(auth_dependency),
     user_service: UserService = Depends(get_user_service),
 ) -> ChangePasswordResponse:
     return await user_service.change_password(

--- a/app/dependencies/auth_dependency.py
+++ b/app/dependencies/auth_dependency.py
@@ -1,11 +1,14 @@
+from uuid import UUID
+
 from beanie import PydanticObjectId
 from fastapi import HTTPException, Request
 
 from app.services.token_service import TokenService
 from app.utils.auth_utils import ACCESS_TOKEN_COOKIE
+from app.utils.id_utils import is_valid_uuid
 
 
-def auth_dependency(request: Request) -> PydanticObjectId:
+def auth_dependency(request: Request) -> PydanticObjectId | UUID:
     """
     Auth dependency check if the user is authenticated via local JWT cookie.
     Returns the user_id (sub) from the token.
@@ -25,6 +28,11 @@ def auth_dependency(request: Request) -> PydanticObjectId:
             raise HTTPException(status_code=401, detail="Invalid token payload")
 
         request.state.user_id = user_id
+
+        print(f"Authenticated user_id: {user_id} from token in auth_dependency")
+
+        if is_valid_uuid(user_id):
+            return UUID(user_id)
 
         return PydanticObjectId(user_id)
 

--- a/app/dependencies/auth_dependency.py
+++ b/app/dependencies/auth_dependency.py
@@ -3,6 +3,7 @@ from uuid import UUID
 from beanie import PydanticObjectId
 from fastapi import HTTPException, Request
 
+from app.db.postgres import is_postgres_required
 from app.services.token_service import TokenService
 from app.utils.auth_utils import ACCESS_TOKEN_COOKIE
 from app.utils.id_utils import is_valid_uuid
@@ -29,10 +30,14 @@ def auth_dependency(request: Request) -> PydanticObjectId | UUID:
 
         request.state.user_id = user_id
 
-        print(f"Authenticated user_id: {user_id} from token in auth_dependency")
-
         if is_valid_uuid(user_id):
             return UUID(user_id)
+
+        # Under the PostgreSQL backend, user IDs are UUIDs. A non-UUID ``sub``
+        # is a stale pre-cutover (Mongo ObjectId) token, so reject it cleanly
+        # instead of letting an ObjectId reach a UUID-typed query.
+        if is_postgres_required():
+            raise HTTPException(status_code=401, detail="Unauthorized")
 
         return PydanticObjectId(user_id)
 

--- a/app/dependencies/repository_dependency.py
+++ b/app/dependencies/repository_dependency.py
@@ -6,7 +6,9 @@ from app.db.postgres import is_postgres_required
 from app.repository.log_repository import LogRepository
 from app.repository.movie_rating_repository import MovieRatingRepository
 from app.repository.movie_repository import MovieRepository
+from app.repository.postgres_user_repository import PostgresUserRepository
 from app.repository.user_repository import UserRepository
+from app.repository.user_repository_protocol import UserRepositoryProtocol
 
 
 class RepositoryActivationError(RuntimeError):
@@ -33,7 +35,7 @@ def get_movie_repository() -> MovieRepository:
 
 
 @lru_cache
-def get_user_repository() -> UserRepository:
+def get_user_repository() -> UserRepositoryProtocol:
     """Return the active user repository implementation.
 
     UserRepository PostgreSQL activation is intentionally blocked in mixed mode
@@ -43,12 +45,7 @@ def get_user_repository() -> UserRepository:
     """
 
     if is_postgres_required():
-        raise RepositoryActivationError(
-            "DB_BACKEND=postgres is not yet safe for UserRepository activation: "
-            "JWT subjects, auth dependency parsing, caches, and still-active Mongo repositories "
-            "depend on Mongo ObjectId user references. Keep DB_BACKEND=mongo until related "
-            "repositories and ID adapters are migrated."
-        )
+        return PostgresUserRepository()
 
     return UserRepository()
 

--- a/app/dependencies/repository_dependency.py
+++ b/app/dependencies/repository_dependency.py
@@ -1,12 +1,16 @@
-"""Repository dependency providers and backend activation guardrails."""
+"""Repository dependency providers and backend selection."""
 
 from functools import lru_cache
 
 from app.db.postgres import is_postgres_required
 from app.repository.log_repository import LogRepository
+from app.repository.log_repository_protocol import LogRepositoryProtocol
 from app.repository.movie_rating_repository import MovieRatingRepository
+from app.repository.movie_rating_repository_protocol import MovieRatingRepositoryProtocol
 from app.repository.movie_repository import MovieRepository
 from app.repository.movie_repository_protocol import MovieRepositoryProtocol
+from app.repository.postgres_log_repository import PostgresLogRepository
+from app.repository.postgres_movie_rating_repository import PostgresMovieRatingRepository
 from app.repository.postgres_movie_repository import PostgresMovieRepository
 from app.repository.postgres_user_repository import PostgresUserRepository
 from app.repository.user_repository import UserRepository
@@ -21,9 +25,8 @@ class RepositoryActivationError(RuntimeError):
 def get_movie_repository() -> MovieRepositoryProtocol:
     """Return the active movie repository implementation.
 
-    MovieRepository PostgreSQL activation is intentionally blocked in mixed mode
-    because LogRepository and MovieRatingRepository still persist/query Mongo
-    ObjectId-based movie references.
+    ``DB_BACKEND=postgres`` selects ``PostgresMovieRepository`` during the
+    migration window; otherwise the legacy Mongo implementation stays active.
     """
 
     if is_postgres_required():
@@ -36,10 +39,8 @@ def get_movie_repository() -> MovieRepositoryProtocol:
 def get_user_repository() -> UserRepositoryProtocol:
     """Return the active user repository implementation.
 
-    UserRepository PostgreSQL activation is intentionally blocked in mixed mode
-    because JWT ``sub`` values, auth dependency parsing, user-owned resource
-    checks, Redis keys, and Mongo repositories still depend on ObjectId user
-    identifiers.
+    ``DB_BACKEND=postgres`` selects ``PostgresUserRepository`` during the
+    migration window; otherwise the legacy Mongo implementation stays active.
     """
 
     if is_postgres_required():
@@ -49,41 +50,29 @@ def get_user_repository() -> UserRepositoryProtocol:
 
 
 @lru_cache
-def get_movie_rating_repository() -> MovieRatingRepository:
+def get_movie_rating_repository() -> MovieRatingRepositoryProtocol:
     """Return the active movie-rating repository implementation.
 
-    MovieRatingRepository PostgreSQL activation is intentionally blocked in
-    mixed mode because auth still provides Mongo ObjectId user identifiers,
-    LogRepository still consumes ObjectId movie references, and MovieRepository
-    activation remains blocked until later cutover work.
+    ``DB_BACKEND=postgres`` selects ``PostgresMovieRatingRepository`` during
+    the migration window; otherwise the legacy Mongo implementation stays
+    active.
     """
 
     if is_postgres_required():
-        raise RepositoryActivationError(
-            "DB_BACKEND=postgres is not yet safe for MovieRatingRepository activation: "
-            "auth still provides Mongo ObjectId user IDs, LogRepository still depends on "
-            "Mongo ObjectId movie references, and MovieRepository cutover remains blocked. "
-            "Keep DB_BACKEND=mongo until related repositories and ID adapters are migrated."
-        )
+        return PostgresMovieRatingRepository()
 
     return MovieRatingRepository()
 
 
 @lru_cache
-def get_log_repository() -> LogRepository:
+def get_log_repository() -> LogRepositoryProtocol:
     """Return the active log repository implementation.
 
-    LogRepository PostgreSQL activation is intentionally blocked in mixed mode
-    because log caching, service wiring, and UUID/ObjectId runtime assumptions
-    still require the later cutover work.
+    ``DB_BACKEND=postgres`` selects ``PostgresLogRepository`` during the
+    migration window; otherwise the legacy Mongo implementation stays active.
     """
 
     if is_postgres_required():
-        raise RepositoryActivationError(
-            "DB_BACKEND=postgres is not yet safe for LogRepository activation: "
-            "LogCacheRepository and downstream services still rely on Mongo-shaped log caching "
-            "and mixed UUID/ObjectId runtime assumptions. Keep DB_BACKEND=mongo until the "
-            "repository cutover work is complete."
-        )
+        return PostgresLogRepository()
 
     return LogRepository()

--- a/app/dependencies/repository_dependency.py
+++ b/app/dependencies/repository_dependency.py
@@ -6,6 +6,8 @@ from app.db.postgres import is_postgres_required
 from app.repository.log_repository import LogRepository
 from app.repository.movie_rating_repository import MovieRatingRepository
 from app.repository.movie_repository import MovieRepository
+from app.repository.movie_repository_protocol import MovieRepositoryProtocol
+from app.repository.postgres_movie_repository import PostgresMovieRepository
 from app.repository.postgres_user_repository import PostgresUserRepository
 from app.repository.user_repository import UserRepository
 from app.repository.user_repository_protocol import UserRepositoryProtocol
@@ -16,7 +18,7 @@ class RepositoryActivationError(RuntimeError):
 
 
 @lru_cache
-def get_movie_repository() -> MovieRepository:
+def get_movie_repository() -> MovieRepositoryProtocol:
     """Return the active movie repository implementation.
 
     MovieRepository PostgreSQL activation is intentionally blocked in mixed mode
@@ -25,11 +27,7 @@ def get_movie_repository() -> MovieRepository:
     """
 
     if is_postgres_required():
-        raise RepositoryActivationError(
-            "DB_BACKEND=postgres is not yet safe for MovieRepository activation: "
-            "LogRepository and MovieRatingRepository still depend on Mongo ObjectId movie references. "
-            "Keep DB_BACKEND=mongo until related repositories are migrated or a compatibility adapter exists."
-        )
+        return PostgresMovieRepository()
 
     return MovieRepository()
 

--- a/app/dependencies/service_dependency.py
+++ b/app/dependencies/service_dependency.py
@@ -8,6 +8,7 @@ Tests can swap a whole service through
 
 from functools import lru_cache
 
+from app.db.postgres import is_postgres_required
 from app.dependencies.repository_dependency import (
     get_log_repository,
     get_movie_rating_repository,
@@ -22,6 +23,13 @@ from app.services.movie_rating_service import MovieRatingService
 from app.services.movie_service import MovieService
 from app.services.stats_service import StatsService
 from app.services.user_service import UserService
+
+
+def _get_runtime_log_repository():
+    log_repository = get_log_repository()
+    if is_postgres_required():
+        return log_repository
+    return LogCacheRepository(log_repository)
 
 
 @lru_cache
@@ -55,7 +63,7 @@ def get_movie_rating_service() -> MovieRatingService:
 @lru_cache
 def get_log_service() -> LogService:
     return LogService(
-        log_repository=LogCacheRepository(get_log_repository()),
+        log_repository=_get_runtime_log_repository(),
         movie_service=get_movie_service(),
         movie_repository=get_movie_repository(),
         movie_rating_repository=get_movie_rating_repository(),
@@ -66,7 +74,7 @@ def get_log_service() -> LogService:
 @lru_cache
 def get_stats_service() -> StatsService:
     return StatsService(
-        log_repository=LogCacheRepository(get_log_repository()),
+        log_repository=_get_runtime_log_repository(),
         movie_rating_repository=get_movie_rating_repository(),
         movie_repository=get_movie_repository(),
     )

--- a/app/repository/log_cache_repository.py
+++ b/app/repository/log_cache_repository.py
@@ -7,6 +7,7 @@ from beanie import PydanticObjectId
 
 from app.models.log import Log
 from app.repository.log_repository import LogRepository
+from app.repository.log_repository_protocol import LogRepositoryProtocol
 from app.schemas.log_schemas import LogCreateRequest, LogUpdateRequest
 from app.schemas.stats_schemas import LogStats
 from app.services.cache_service import CacheService
@@ -19,7 +20,10 @@ LOG_CACHE_TTL = int(os.getenv("LOG_CACHE_TTL", "86400"))
 class LogCacheRepository:
     """Redis-backed decorator for raw log repository lookups."""
 
-    def __init__(self, repository: LogRepository | None = None):
+    def __init__(
+        self,
+        repository: LogRepositoryProtocol | None = None,
+    ):
         self.repository = repository or LogRepository()
 
     @property
@@ -198,6 +202,7 @@ class LogCacheRepository:
             sort_by=sort_by,
             sort_order=sort_order,
         )
+        logs = list(logs)
         await self._set_logs(key, logs)
         return logs
 
@@ -212,6 +217,7 @@ class LogCacheRepository:
             return cached
 
         logs = await self.repository.find_logs_by_movie_id(movie_id, user_id)
+        logs = list(logs)
         await self._set_logs(key, logs)
         return logs
 

--- a/app/repository/log_repository.py
+++ b/app/repository/log_repository.py
@@ -10,13 +10,12 @@ from app.utils.object_id_utils import to_object_id
 
 
 class LogRepository:
-    """MongoDB log repository — active runtime implementation.
+    """MongoDB log repository.
 
-    Pending replacement by ``PostgresLogRepository`` (in
-    ``app/repository/postgres_log_repository.py``) once runtime repository
-    cutover, log caching, and UUID/ObjectId mixed-mode concerns are resolved.
-    The PostgreSQL repository is intentionally unwired today — do not import
-    it from runtime code paths.
+    Selected at runtime when ``DB_BACKEND`` is unset or ``mongo``. Under
+    ``DB_BACKEND=postgres`` the dependency layer activates
+    ``PostgresLogRepository`` (in ``app/repository/postgres_log_repository.py``)
+    instead. PostgreSQL log caching is still pending (tracked in #170).
     """
 
     async def create_log(self, user_id: PydanticObjectId, create_log_request: LogCreateRequest) -> Log:

--- a/app/repository/log_repository_protocol.py
+++ b/app/repository/log_repository_protocol.py
@@ -1,0 +1,56 @@
+from collections.abc import Sequence
+from datetime import date
+from typing import Protocol, TypeVar
+
+from app.schemas.log_schemas import LogCreateRequest, LogUpdateRequest
+from app.schemas.stats_schemas import LogStats
+
+IdType = TypeVar("IdType", contravariant=True)
+LogType = TypeVar("LogType", covariant=True)
+
+
+class LogRepositoryProtocol(Protocol[IdType, LogType]):
+    """Protocol for log repository implementations."""
+
+    async def create_log(self, user_id: IdType, create_log_request: LogCreateRequest) -> LogType:
+        """Create a new viewing log."""
+
+    async def find_log_by_id(self, log_id: IdType, user_id: IdType) -> LogType | None:
+        """Find a log entry by ID, scoped to the owning user."""
+
+    async def update_log(
+        self,
+        log_id: IdType,
+        user_id: IdType,
+        update_request: LogUpdateRequest,
+    ) -> LogType | None:
+        """Update a log entry by ID, scoped to the owning user."""
+
+    async def find_logs_by_user_id(
+        self,
+        user_id: IdType,
+        watched_where: str | None = None,
+        date_watched_from: date | None = None,
+        date_watched_to: date | None = None,
+        sort_by: str = "dateWatched",
+        sort_order: str = "desc",
+    ) -> Sequence[LogType]:
+        """Find logs for a specific user with optional filtering and sorting."""
+
+    async def find_logs_by_movie_id(
+        self,
+        movie_id: IdType,
+        user_id: IdType | None = None,
+    ) -> Sequence[LogType]:
+        """Find logs for a movie, optionally filtered by user."""
+
+    async def delete_log(self, log_id: IdType, user_id: IdType) -> LogType | None:
+        """Delete a log entry by ID, scoped to the owning user."""
+
+    async def get_log_stats(
+        self,
+        user_id: IdType,
+        date_from: date | None = None,
+        date_to: date | None = None,
+    ) -> LogStats:
+        """Compute aggregate log statistics for a user."""

--- a/app/repository/movie_rating_repository.py
+++ b/app/repository/movie_rating_repository.py
@@ -1,3 +1,5 @@
+from collections.abc import Iterable, Sequence
+
 from beanie import PydanticObjectId
 
 from app.models.movie_rating import MovieRating
@@ -77,8 +79,8 @@ class MovieRatingRepository:
     async def find_movie_ratings_by_user_and_movie_ids(
         self,
         user_id: PydanticObjectId,
-        movie_ids: set[PydanticObjectId],
-    ) -> list[MovieRating]:
+        movie_ids: Iterable[PydanticObjectId],
+    ) -> Sequence[MovieRating]:
         """
         Find all movie ratings for a specific user and a set of movie IDs.
         """
@@ -92,7 +94,7 @@ class MovieRatingRepository:
     async def get_user_movie_ratings_average(
         self,
         user_id: PydanticObjectId,
-        movie_ids: set[PydanticObjectId],
+        movie_ids: Iterable[PydanticObjectId],
     ) -> MovieRatingStats:
         pipeline = [
             {

--- a/app/repository/movie_rating_repository_protocol.py
+++ b/app/repository/movie_rating_repository_protocol.py
@@ -1,0 +1,34 @@
+from collections.abc import Iterable, Sequence
+from typing import Protocol, TypeVar
+
+from app.schemas.movie_rating_schemas import MovieRatingStats
+
+IdType = TypeVar("IdType", contravariant=True)
+
+MovieRatingType = TypeVar("MovieRatingType", covariant=True)
+
+
+class MovieRatingRepositoryProtocol(Protocol[IdType, MovieRatingType]):
+    async def find_movie_rating_by_user_and_movie(self, user_id: IdType, movie_id: IdType) -> MovieRatingType | None:
+        """Find a movie rating by user ID and movie ID."""
+
+    async def find_movie_rating_by_user_and_tmdb(self, user_id: IdType, tmdb_id: int) -> MovieRatingType | None:
+        """Find a movie rating by user ID and TMDB ID."""
+
+    async def create_update_movie_rating(
+        self,
+        user_id: IdType,
+        movie_id: IdType,
+        rating: int,
+        comment: str | None,
+        tmdb_id: int,
+    ) -> MovieRatingType:
+        """Create or update a movie rating for a specific user and movie."""
+
+    async def find_movie_ratings_by_user_and_movie_ids(
+        self, user_id: IdType, movie_ids: Iterable[IdType]
+    ) -> Sequence[MovieRatingType]:
+        """Find all movie ratings for a list of movie IDs."""
+
+    async def get_user_movie_ratings_average(self, user_id: IdType, movie_ids: Iterable[IdType]) -> MovieRatingStats:
+        """Get the average rating for a movie by a specific user."""

--- a/app/repository/movie_repository.py
+++ b/app/repository/movie_repository.py
@@ -1,5 +1,6 @@
 """MongoDB movie repository implementation."""
 
+from collections.abc import Iterable
 from datetime import UTC, datetime
 
 from beanie import PydanticObjectId
@@ -77,11 +78,11 @@ class MovieRepository:
                 raise
             return existing_movie
 
-    async def find_movies_by_ids(self, movie_ids: set[PydanticObjectId]) -> list[Movie]:
+    async def find_movies_by_ids(self, movie_ids: Iterable[PydanticObjectId]) -> list[Movie]:
         """Find multiple movies by their IDs."""
         return await Movie.find(Movie.active_filter({"_id": {"$in": list(movie_ids)}})).to_list()
 
-    async def get_movie_stats(self, movie_ids: set[PydanticObjectId]) -> MovieStats:
+    async def get_movie_stats(self, movie_ids: Iterable[PydanticObjectId]) -> MovieStats:
         """Compute movie aggregates for a set of IDs."""
         pipeline = [
             {"$match": {"_id": {"$in": list(movie_ids)}}},

--- a/app/repository/movie_repository_protocol.py
+++ b/app/repository/movie_repository_protocol.py
@@ -1,0 +1,33 @@
+from collections.abc import Iterable, Sequence
+from typing import Protocol, TypeVar
+
+from app.schemas.movie_schemas import MovieCreateRequest, MovieStats, MovieUpdateRequest
+from app.schemas.tmdb_schemas import TMDBMovieDetails
+
+IdType = TypeVar("IdType", contravariant=True)
+MovieType = TypeVar("MovieType", covariant=True)
+
+
+class MovieRepositoryProtocol(Protocol[IdType, MovieType]):
+    """Protocol for movie repository implementations."""
+
+    async def create_movie(self, request: MovieCreateRequest) -> MovieType:
+        """Create a new movie in the database."""
+
+    async def update_movie(self, movie_id: IdType, request: MovieUpdateRequest) -> None:
+        """Update an existing movie in the database."""
+
+    async def find_movie_by_id(self, movie_id: IdType) -> MovieType | None:
+        """Find a movie by its unique identifier."""
+
+    async def find_movie_by_tmdb_id(self, tmdb_id: int) -> MovieType | None:
+        """Find a movie by its TMDB ID."""
+
+    async def create_from_tmdb_data(self, tmdb_data: TMDBMovieDetails) -> MovieType:
+        """Create a movie from TMDB details or return existing row on duplicate TMDB ID."""
+
+    async def find_movies_by_ids(self, movie_ids: Iterable[IdType]) -> Sequence[MovieType]:
+        """Find multiple movies by a set of unique identifiers."""
+
+    async def get_movie_stats(self, movie_id: Iterable[IdType]) -> MovieStats:
+        """Get aggregated stats for a movie (e.g. average rating, total ratings)."""

--- a/app/repository/postgres_movie_rating_repository.py
+++ b/app/repository/postgres_movie_rating_repository.py
@@ -98,6 +98,7 @@ class PostgresMovieRatingRepository(RepositoryBase):
     ) -> Sequence[PostgresMovieRating]:
         """Find active movie ratings for a user across movie IDs."""
 
+        movie_ids = list(movie_ids)
         if not movie_ids:
             return []
 
@@ -117,6 +118,7 @@ class PostgresMovieRatingRepository(RepositoryBase):
     ) -> MovieRatingStats:
         """Compute average movie rating and count for the user's active ratings."""
 
+        movie_ids = list(movie_ids)
         if not movie_ids:
             return MovieRatingStats(average_rating=0.0, total_ratings=0)
 

--- a/app/repository/postgres_movie_rating_repository.py
+++ b/app/repository/postgres_movie_rating_repository.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable, Sequence
 from uuid import UUID
 
 from sqlalchemy import func, select
@@ -93,8 +94,8 @@ class PostgresMovieRatingRepository(RepositoryBase):
     async def find_movie_ratings_by_user_and_movie_ids(
         self,
         user_id: UUID,
-        movie_ids: set[UUID],
-    ) -> list[PostgresMovieRating]:
+        movie_ids: Iterable[UUID],
+    ) -> Sequence[PostgresMovieRating]:
         """Find active movie ratings for a user across movie IDs."""
 
         if not movie_ids:
@@ -112,7 +113,7 @@ class PostgresMovieRatingRepository(RepositoryBase):
     async def get_user_movie_ratings_average(
         self,
         user_id: UUID,
-        movie_ids: set[UUID],
+        movie_ids: Iterable[UUID],
     ) -> MovieRatingStats:
         """Compute average movie rating and count for the user's active ratings."""
 

--- a/app/repository/postgres_movie_repository.py
+++ b/app/repository/postgres_movie_repository.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from datetime import UTC, datetime
 from uuid import UUID
 
@@ -106,7 +107,7 @@ class PostgresMovieRepository(RepositoryBase):
                     raise
                 return existing_movie
 
-    async def find_movies_by_ids(self, movie_ids: set[UUID]) -> list[PostgresMovie]:
+    async def find_movies_by_ids(self, movie_ids: Iterable[UUID]) -> list[PostgresMovie]:
         """Find active movies by UUID set."""
 
         if not movie_ids:
@@ -120,7 +121,7 @@ class PostgresMovieRepository(RepositoryBase):
             result = await session.execute(statement)
             return list(result.scalars().all())
 
-    async def get_movie_stats(self, movie_ids: set[UUID]) -> MovieStats:
+    async def get_movie_stats(self, movie_ids: Iterable[UUID]) -> MovieStats:
         """Compute runtime stats for active movies in PostgreSQL."""
 
         if not movie_ids:

--- a/app/repository/postgres_movie_repository.py
+++ b/app/repository/postgres_movie_repository.py
@@ -110,6 +110,7 @@ class PostgresMovieRepository(RepositoryBase):
     async def find_movies_by_ids(self, movie_ids: Iterable[UUID]) -> list[PostgresMovie]:
         """Find active movies by UUID set."""
 
+        movie_ids = list(movie_ids)
         if not movie_ids:
             return []
 
@@ -124,6 +125,7 @@ class PostgresMovieRepository(RepositoryBase):
     async def get_movie_stats(self, movie_ids: Iterable[UUID]) -> MovieStats:
         """Compute runtime stats for active movies in PostgreSQL."""
 
+        movie_ids = list(movie_ids)
         if not movie_ids:
             return MovieStats(total_runtime=0)
 

--- a/app/repository/user_repository_protocol.py
+++ b/app/repository/user_repository_protocol.py
@@ -1,12 +1,10 @@
 from datetime import datetime
-from typing import Protocol, TypeVar
-
-from alembic.environment import Any
+from typing import Any, Protocol, TypeVar
 
 from app.schemas.user_schemas import UserCreateRequest
 
 IdType = TypeVar("IdType", contravariant=True)
-UserType = TypeVar("UserType", covariant=True)
+UserType = TypeVar("UserType")
 
 
 class UserRepositoryProtocol(Protocol[IdType, UserType]):
@@ -33,13 +31,13 @@ class UserRepositoryProtocol(Protocol[IdType, UserType]):
     async def delete_user_oblivion(self, user_id: IdType) -> bool:
         """Obscure all the user information and delete the user logically."""
 
-    async def update_password(self, user_id: IdType, new_password_hash: str):
+    async def update_password(self, user: UserType, new_password_hash: str) -> UserType:
         """Update a user's password hash."""
 
-    async def set_reset_password_code(self, user_id: IdType, code: str, expires_at: datetime) -> UserType:
+    async def set_reset_password_code(self, user: UserType, code: str, expires_at: datetime) -> UserType:
         """Set reset password code and expiration for a user."""
 
-    async def clear_reset_password_code(self, user_id: IdType) -> UserType:
+    async def clear_reset_password_code(self, user: UserType) -> UserType:
         """Clear reset password code and expiration for a user."""
 
     async def update_user_profile(self, user_id: IdType, update_data: dict[str, Any]) -> UserType | None:

--- a/app/repository/user_repository_protocol.py
+++ b/app/repository/user_repository_protocol.py
@@ -1,0 +1,46 @@
+from datetime import datetime
+from typing import Protocol, TypeVar
+
+from alembic.environment import Any
+
+from app.schemas.user_schemas import UserCreateRequest
+
+IdType = TypeVar("IdType", contravariant=True)
+UserType = TypeVar("UserType", covariant=True)
+
+class UserRepositoryProtocol(Protocol[IdType, UserType]):
+    """Protocol for user repository implementations."""
+
+    async def create_user(self, request: UserCreateRequest) -> UserType:
+        """Create a new user in the database."""
+
+    async def find_user_by_email(self, email: str) -> UserType | None:
+        """Find a user by email (case-insensitive)."""
+
+    async def find_user_by_handle(self, handle: str) -> UserType | None:
+        """Find a user by handle."""
+
+    async def find_user_by_email_or_handle(self, email_or_handle: str) -> UserType | None:
+        """Find a user by email or handle."""
+
+    async def find_user_by_id(self, id: IdType) -> UserType | None:
+        """Find a user by ID."""
+
+    async def delete_user(self, id: IdType) -> bool:
+        """Delete a user logically by ID."""
+
+    async def delete_user_oblivion(self, user_id: IdType) -> bool:
+        """Obscure all the user information and delete the user logically."""
+
+    async def update_password(self, user_id: IdType, new_password_hash: str):
+        """Update a user's password hash."""
+
+    async def set_reset_password_code(self, user_id: IdType, code: str, expires_at: datetime) -> UserType:
+        """Set reset password code and expiration for a user."""
+
+    async def clear_reset_password_code(self, user_id: IdType) -> UserType:
+        """Clear reset password code and expiration for a user."""
+
+    async def update_user_profile(self, user_id: IdType, update_data: dict[str, Any]) -> UserType | None:
+        """Update user profile fields."""
+

--- a/app/repository/user_repository_protocol.py
+++ b/app/repository/user_repository_protocol.py
@@ -8,6 +8,7 @@ from app.schemas.user_schemas import UserCreateRequest
 IdType = TypeVar("IdType", contravariant=True)
 UserType = TypeVar("UserType", covariant=True)
 
+
 class UserRepositoryProtocol(Protocol[IdType, UserType]):
     """Protocol for user repository implementations."""
 
@@ -23,10 +24,10 @@ class UserRepositoryProtocol(Protocol[IdType, UserType]):
     async def find_user_by_email_or_handle(self, email_or_handle: str) -> UserType | None:
         """Find a user by email or handle."""
 
-    async def find_user_by_id(self, id: IdType) -> UserType | None:
+    async def find_user_by_id(self, user_id: IdType) -> UserType | None:
         """Find a user by ID."""
 
-    async def delete_user(self, id: IdType) -> bool:
+    async def delete_user(self, user_id: IdType) -> bool:
         """Delete a user logically by ID."""
 
     async def delete_user_oblivion(self, user_id: IdType) -> bool:
@@ -43,4 +44,3 @@ class UserRepositoryProtocol(Protocol[IdType, UserType]):
 
     async def update_user_profile(self, user_id: IdType, update_data: dict[str, Any]) -> UserType | None:
         """Update user profile fields."""
-

--- a/app/schemas/log_schemas.py
+++ b/app/schemas/log_schemas.py
@@ -1,4 +1,5 @@
 from datetime import date
+from uuid import UUID
 
 from beanie import PydanticObjectId
 from pydantic import Field, field_validator, model_validator
@@ -49,8 +50,8 @@ class LogUpdateRequest(BaseSchema):
 
 
 class LogListItem(BaseSchema):
-    id: PydanticObjectId = Field(..., description="Unique identifier of the log entry")
-    movie_id: PydanticObjectId = Field(..., description="Unique identifier of the movie")
+    id: PydanticObjectId | UUID = Field(..., description="Unique identifier of the log entry")
+    movie_id: PydanticObjectId | UUID = Field(..., description="Unique identifier of the movie")
     movie: MovieResponse | None = Field(None, description="Details of the movie")
     tmdb_id: int = Field(..., description="TMDB ID of the movie")
     date_watched: date = Field(..., description="Date when the movie was watched")

--- a/app/schemas/movie_schemas.py
+++ b/app/schemas/movie_schemas.py
@@ -1,4 +1,5 @@
 from datetime import date, datetime
+from uuid import UUID
 
 from beanie import PydanticObjectId
 from pydantic import Field
@@ -16,7 +17,7 @@ class MovieUpdateRequest(BaseSchema):
 
 
 class MovieResponse(BaseSchema):
-    id: PydanticObjectId = Field(..., description="Unique identifier of the movie")
+    id: PydanticObjectId | UUID = Field(..., description="Unique identifier of the movie")
     title: str = Field(..., min_length=1, max_length=100, description="Title of the movie")
     tmdb_id: int = Field(..., description="TMDB ID of the movie")
     poster_path: str | None = Field(None, description="Path to the movie poster image")

--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -1,7 +1,7 @@
 import secrets
 from datetime import UTC, datetime, timedelta
 
-from app.repository.user_repository import UserRepository
+from app.repository.user_repository_protocol import UserRepositoryProtocol
 from app.schemas.auth_schemas import (
     RegisterRequest,
     RegisterResponse,
@@ -14,12 +14,12 @@ from app.utils.exceptions_utils import AppException
 
 
 class AuthService:
-    user_repository: UserRepository
+    user_repository: UserRepositoryProtocol
     email_service: EmailService
 
     def __init__(
         self,
-        user_repository: UserRepository,
+        user_repository: UserRepositoryProtocol,
         email_service: EmailService | None = None,
     ):
         self.user_repository = user_repository

--- a/app/services/log_service.py
+++ b/app/services/log_service.py
@@ -9,7 +9,7 @@ from app.dependencies.repository_dependency import (
 from app.models.movie import Movie
 from app.repository.log_cache_repository import LogCacheRepository
 from app.repository.movie_rating_repository import MovieRatingRepository
-from app.repository.movie_repository import MovieRepository
+from app.repository.movie_repository_protocol import MovieRepositoryProtocol
 from app.repository.user_repository_protocol import UserRepositoryProtocol
 from app.schemas.log_schemas import (
     LogCreateRequest,
@@ -33,7 +33,7 @@ class LogService:
         self,
         log_repository: LogCacheRepository | None = None,
         movie_service: MovieService | None = None,
-        movie_repository: MovieRepository | None = None,
+        movie_repository: MovieRepositoryProtocol | None = None,
         movie_rating_repository: MovieRatingRepository | None = None,
         stats_cache_service: StatsCacheService | None = None,
         user_repository: UserRepositoryProtocol | None = None,

--- a/app/services/log_service.py
+++ b/app/services/log_service.py
@@ -10,7 +10,7 @@ from app.models.movie import Movie
 from app.repository.log_cache_repository import LogCacheRepository
 from app.repository.movie_rating_repository import MovieRatingRepository
 from app.repository.movie_repository import MovieRepository
-from app.repository.user_repository import UserRepository
+from app.repository.user_repository_protocol import UserRepositoryProtocol
 from app.schemas.log_schemas import (
     LogCreateRequest,
     LogCreateResponse,
@@ -36,7 +36,7 @@ class LogService:
         movie_repository: MovieRepository | None = None,
         movie_rating_repository: MovieRatingRepository | None = None,
         stats_cache_service: StatsCacheService | None = None,
-        user_repository: UserRepository | None = None,
+        user_repository: UserRepositoryProtocol | None = None,
     ):
         self.log_repository = log_repository or LogCacheRepository(get_log_repository())
         resolved_movie_repository = movie_repository or get_movie_repository()

--- a/app/services/log_service.py
+++ b/app/services/log_service.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from beanie import PydanticObjectId
 
 from app.dependencies.repository_dependency import (
@@ -28,6 +30,12 @@ from app.utils.exceptions_utils import AppException
 
 class LogService:
     """Service layer for log operations."""
+
+    @staticmethod
+    def _matches_backend_id_family(user_id: PydanticObjectId | UUID, log_id: PydanticObjectId | UUID) -> bool:
+        if isinstance(user_id, UUID):
+            return isinstance(log_id, UUID)
+        return isinstance(log_id, PydanticObjectId)
 
     def __init__(
         self,
@@ -64,7 +72,7 @@ class LogService:
             updated_at=movie.updated_at,
         )
 
-    async def create_log(self, user_id: PydanticObjectId, request: LogCreateRequest) -> LogCreateResponse:
+    async def create_log(self, user_id: PydanticObjectId | UUID, request: LogCreateRequest) -> LogCreateResponse:
         """
         Create a new viewing log entry.
 
@@ -95,11 +103,14 @@ class LogService:
 
     async def update_log(
         self,
-        user_id: PydanticObjectId,
-        log_id: PydanticObjectId,
+        user_id: PydanticObjectId | UUID,
+        log_id: PydanticObjectId | UUID,
         request: LogUpdateRequest,
     ) -> LogCreateResponse:
         """Update an existing log entry."""
+        if not self._matches_backend_id_family(user_id, log_id):
+            raise AppException(ErrorCodes.LOG_NOT_FOUND)
+
         log = await self.log_repository.update_log(log_id=log_id, user_id=user_id, update_request=request)
 
         if not log:
@@ -122,15 +133,18 @@ class LogService:
             watched_where=log.watched_where,
         )
 
-    async def delete_log(self, user_id: PydanticObjectId, log_id: PydanticObjectId) -> None:
+    async def delete_log(self, user_id: PydanticObjectId | UUID, log_id: PydanticObjectId | UUID) -> None:
         """Delete a viewing log entry owned by the given user."""
+        if not self._matches_backend_id_family(user_id, log_id):
+            raise AppException(ErrorCodes.LOG_NOT_FOUND)
+
         deleted_log = await self.log_repository.delete_log(log_id=log_id, user_id=user_id)
         if deleted_log is None:
             raise AppException(ErrorCodes.LOG_NOT_FOUND)
 
         await self.stats_cache_service.invalidate_user_stats(user_id)
 
-    async def get_user_logs(self, user_id: PydanticObjectId, request: LogListRequest) -> LogListResponse:
+    async def get_user_logs(self, user_id: PydanticObjectId | UUID, request: LogListRequest) -> LogListResponse:
         """Get list of user's viewing logs with optional filtering and sorting."""
 
         logs_data = await self.log_repository.find_logs_by_user_id(
@@ -178,7 +192,7 @@ class LogService:
     async def get_user_logs_by_handle(
         self,
         handle: str,
-        requester_id: PydanticObjectId,
+        requester_id: PydanticObjectId | UUID,
         request: LogListRequest,
     ) -> LogListResponse:
         user = await self.user_repository.find_user_by_handle(handle.strip())

--- a/app/services/log_service.py
+++ b/app/services/log_service.py
@@ -7,8 +7,8 @@ from app.dependencies.repository_dependency import (
     get_user_repository,
 )
 from app.models.movie import Movie
-from app.repository.log_cache_repository import LogCacheRepository
-from app.repository.movie_rating_repository import MovieRatingRepository
+from app.repository.log_repository_protocol import LogRepositoryProtocol
+from app.repository.movie_rating_repository_protocol import MovieRatingRepositoryProtocol
 from app.repository.movie_repository_protocol import MovieRepositoryProtocol
 from app.repository.user_repository_protocol import UserRepositoryProtocol
 from app.schemas.log_schemas import (
@@ -31,14 +31,14 @@ class LogService:
 
     def __init__(
         self,
-        log_repository: LogCacheRepository | None = None,
+        log_repository: LogRepositoryProtocol | None = None,
         movie_service: MovieService | None = None,
         movie_repository: MovieRepositoryProtocol | None = None,
-        movie_rating_repository: MovieRatingRepository | None = None,
+        movie_rating_repository: MovieRatingRepositoryProtocol | None = None,
         stats_cache_service: StatsCacheService | None = None,
         user_repository: UserRepositoryProtocol | None = None,
     ):
-        self.log_repository = log_repository or LogCacheRepository(get_log_repository())
+        self.log_repository = log_repository or get_log_repository()
         resolved_movie_repository = movie_repository or get_movie_repository()
         if movie_service is None:
             movie_service = MovieService(resolved_movie_repository)

--- a/app/services/movie_rating_service.py
+++ b/app/services/movie_rating_service.py
@@ -1,6 +1,7 @@
+from uuid import UUID
+
 from beanie import PydanticObjectId
 
-from app.models.movie_rating import MovieRating
 from app.repository.movie_rating_repository_protocol import MovieRatingRepositoryProtocol
 from app.schemas.movie_rating_schemas import MovieRatingResponse
 from app.services.movie_service import MovieService
@@ -12,7 +13,7 @@ from app.utils.exceptions_utils import AppException
 class MovieRatingService:
     def __init__(
         self,
-        movie_rating_repository: MovieRatingRepositoryProtocol[PydanticObjectId, MovieRating],
+        movie_rating_repository: MovieRatingRepositoryProtocol,
         movie_service: MovieService,
         stats_cache_service: StatsCacheService | None = None,
     ):
@@ -22,7 +23,7 @@ class MovieRatingService:
 
     async def create_update_movie_rating(
         self,
-        user_id: PydanticObjectId,
+        user_id: PydanticObjectId | UUID,
         tmdb_id: int,
         rating: int,
         comment: str | None = None,
@@ -46,7 +47,7 @@ class MovieRatingService:
         return self._get_movie_rating_response(movie_rating)
 
     async def get_movie_rating(
-        self, user_id: PydanticObjectId, movie_id: PydanticObjectId
+        self, user_id: PydanticObjectId | UUID, movie_id: PydanticObjectId | UUID
     ) -> MovieRatingResponse | None:
         """
         Get a movie rating for a specific user and movie.
@@ -73,7 +74,9 @@ class MovieRatingService:
             updated_at=movie_rating.updated_at,
         )
 
-    async def get_movie_ratings_by_tmdb_id(self, tmdb_id: int, user_id: PydanticObjectId) -> MovieRatingResponse | None:
+    async def get_movie_ratings_by_tmdb_id(
+        self, tmdb_id: int, user_id: PydanticObjectId | UUID
+    ) -> MovieRatingResponse | None:
         """
         Get the caller's rating for a specific TMDB ID. Returns None if no rating exists.
         """
@@ -87,7 +90,7 @@ class MovieRatingService:
 
         return self._get_movie_rating_response(movie_rating)
 
-    def _get_movie_rating_response(self, movie_rating: MovieRating) -> MovieRatingResponse:
+    def _get_movie_rating_response(self, movie_rating) -> MovieRatingResponse:
         if movie_rating.rating is None:
             raise AppException(ErrorCodes.MOVIE_RATING_VALUE_REQUIRED)
 

--- a/app/services/movie_rating_service.py
+++ b/app/services/movie_rating_service.py
@@ -1,7 +1,7 @@
 from beanie import PydanticObjectId
 
 from app.models.movie_rating import MovieRating
-from app.repository.movie_rating_repository import MovieRatingRepository
+from app.repository.movie_rating_repository_protocol import MovieRatingRepositoryProtocol
 from app.schemas.movie_rating_schemas import MovieRatingResponse
 from app.services.movie_service import MovieService
 from app.services.stats_cache_service import StatsCacheService
@@ -12,7 +12,7 @@ from app.utils.exceptions_utils import AppException
 class MovieRatingService:
     def __init__(
         self,
-        movie_rating_repository: MovieRatingRepository,
+        movie_rating_repository: MovieRatingRepositoryProtocol[PydanticObjectId, MovieRating],
         movie_service: MovieService,
         stats_cache_service: StatsCacheService | None = None,
     ):

--- a/app/services/movie_service.py
+++ b/app/services/movie_service.py
@@ -1,12 +1,16 @@
 from beanie import PydanticObjectId
 
 from app.models.movie import Movie
-from app.repository.movie_repository import MovieRepository
+from app.repository.movie_repository_protocol import MovieRepositoryProtocol
 from app.services.tmdb_service import TMDBService
 
 
 class MovieService:
-    def __init__(self, movie_repository: MovieRepository, tmdb_service: TMDBService | None = None):
+    def __init__(
+        self,
+        movie_repository: MovieRepositoryProtocol[PydanticObjectId, Movie],
+        tmdb_service: TMDBService | None = None,
+    ):
         self.movie_repository = movie_repository
         self.tmdb_service = tmdb_service or TMDBService.get_instance()
 

--- a/app/services/movie_service.py
+++ b/app/services/movie_service.py
@@ -1,6 +1,7 @@
+from uuid import UUID
+
 from beanie import PydanticObjectId
 
-from app.models.movie import Movie
 from app.repository.movie_repository_protocol import MovieRepositoryProtocol
 from app.services.tmdb_service import TMDBService
 
@@ -8,21 +9,21 @@ from app.services.tmdb_service import TMDBService
 class MovieService:
     def __init__(
         self,
-        movie_repository: MovieRepositoryProtocol[PydanticObjectId, Movie],
+        movie_repository: MovieRepositoryProtocol,
         tmdb_service: TMDBService | None = None,
     ):
         self.movie_repository = movie_repository
         self.tmdb_service = tmdb_service or TMDBService.get_instance()
 
-    async def get_movie_by_id(self, movie_id: PydanticObjectId) -> Movie | None:
+    async def get_movie_by_id(self, movie_id: PydanticObjectId | UUID):
         """Find a movie by its ID."""
         return await self.movie_repository.find_movie_by_id(movie_id)
 
-    async def get_movie_by_tmdb_id(self, tmdb_id: int) -> Movie | None:
+    async def get_movie_by_tmdb_id(self, tmdb_id: int):
         """Find a movie by its TMDB ID."""
         return await self.movie_repository.find_movie_by_tmdb_id(tmdb_id)
 
-    async def find_or_create_movie(self, tmdb_id: int) -> Movie:
+    async def find_or_create_movie(self, tmdb_id: int):
         """Find a movie by TMDB ID, or create it if it doesn't exist."""
 
         movie = await self.movie_repository.find_movie_by_tmdb_id(tmdb_id)

--- a/app/services/stats_cache_service.py
+++ b/app/services/stats_cache_service.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from uuid import UUID
 
 from beanie import PydanticObjectId
 
@@ -18,7 +19,7 @@ class StatsCacheService:
 
     @staticmethod
     def build_key(
-        user_id: PydanticObjectId,
+        user_id: PydanticObjectId | UUID,
         year_from: int | None = None,
         year_to: int | None = None,
     ) -> str:
@@ -30,7 +31,7 @@ class StatsCacheService:
 
     async def get_stats(
         self,
-        user_id: PydanticObjectId,
+        user_id: PydanticObjectId | UUID,
         year_from: int | None = None,
         year_to: int | None = None,
     ) -> StatsResponse | None:
@@ -44,7 +45,7 @@ class StatsCacheService:
 
     async def set_stats(
         self,
-        user_id: PydanticObjectId,
+        user_id: PydanticObjectId | UUID,
         year_from: int | None = None,
         year_to: int | None = None,
         *,
@@ -54,6 +55,6 @@ class StatsCacheService:
         await self._cache.set(key, stats.model_dump(mode="json"), ttl=STATS_CACHE_TTL)
         logger.debug("Cache set for key=%s", key)
 
-    async def invalidate_user_stats(self, user_id: PydanticObjectId) -> None:
+    async def invalidate_user_stats(self, user_id: PydanticObjectId | UUID) -> None:
         await self._cache.invalidate_pattern(f"cinelog:stats:{user_id}:*")
         logger.info("Cache invalidated for user_id=%s", user_id)

--- a/app/services/stats_service.py
+++ b/app/services/stats_service.py
@@ -1,12 +1,11 @@
 import asyncio
 from datetime import date
-from typing import cast
 
 from beanie import PydanticObjectId
 
 from app.dependencies.repository_dependency import get_log_repository, get_movie_rating_repository, get_movie_repository
-from app.repository.log_cache_repository import LogCacheRepository
-from app.repository.movie_rating_repository import MovieRatingRepository
+from app.repository.log_repository_protocol import LogRepositoryProtocol
+from app.repository.movie_rating_repository_protocol import MovieRatingRepositoryProtocol
 from app.repository.movie_repository_protocol import MovieRepositoryProtocol
 from app.schemas.stats_schemas import (
     LogStats,
@@ -22,12 +21,12 @@ from app.services.stats_cache_service import StatsCacheService
 class StatsService:
     def __init__(
         self,
-        log_repository: LogCacheRepository | None = None,
-        movie_rating_repository: MovieRatingRepository | None = None,
+        log_repository: LogRepositoryProtocol | None = None,
+        movie_rating_repository: MovieRatingRepositoryProtocol | None = None,
         movie_repository: MovieRepositoryProtocol | None = None,
         stats_cache_service: StatsCacheService | None = None,
     ):
-        self.log_repository = log_repository or LogCacheRepository(get_log_repository())
+        self.log_repository = log_repository or get_log_repository()
         self.movie_rating_repository = movie_rating_repository or get_movie_rating_repository()
         self.movie_repository = movie_repository or get_movie_repository()
         self.stats_cache_service = stats_cache_service or StatsCacheService()
@@ -52,11 +51,10 @@ class StatsService:
         )
 
         movie_ids = set(log_stats.unique_movie_ids)
-        mongo_movie_ids = cast("set[PydanticObjectId]", movie_ids)
 
         movie_rating_stats, movie_stats = await asyncio.gather(
-            self.movie_rating_repository.get_user_movie_ratings_average(user_id, mongo_movie_ids),
-            self.movie_repository.get_movie_stats(mongo_movie_ids),
+            self.movie_rating_repository.get_user_movie_ratings_average(user_id, movie_ids),
+            self.movie_repository.get_movie_stats(movie_ids),
         )
 
         total_rewatches = max(0, log_stats.total_watches - log_stats.unique_titles)

--- a/app/services/stats_service.py
+++ b/app/services/stats_service.py
@@ -7,7 +7,7 @@ from beanie import PydanticObjectId
 from app.dependencies.repository_dependency import get_log_repository, get_movie_rating_repository, get_movie_repository
 from app.repository.log_cache_repository import LogCacheRepository
 from app.repository.movie_rating_repository import MovieRatingRepository
-from app.repository.movie_repository import MovieRepository
+from app.repository.movie_repository_protocol import MovieRepositoryProtocol
 from app.schemas.stats_schemas import (
     LogStats,
     StatsByMethod,
@@ -24,7 +24,7 @@ class StatsService:
         self,
         log_repository: LogCacheRepository | None = None,
         movie_rating_repository: MovieRatingRepository | None = None,
-        movie_repository: MovieRepository | None = None,
+        movie_repository: MovieRepositoryProtocol | None = None,
         stats_cache_service: StatsCacheService | None = None,
     ):
         self.log_repository = log_repository or LogCacheRepository(get_log_repository())

--- a/app/services/stats_service.py
+++ b/app/services/stats_service.py
@@ -1,5 +1,6 @@
 import asyncio
 from datetime import date
+from uuid import UUID
 
 from beanie import PydanticObjectId
 
@@ -33,7 +34,7 @@ class StatsService:
 
     async def get_user_stats(
         self,
-        user_id: PydanticObjectId,
+        user_id: PydanticObjectId | UUID,
         year_from: int | None = None,
         year_to: int | None = None,
     ) -> StatsResponse:

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -20,7 +20,7 @@ class UserService:
 
     def __init__(
         self,
-        user_repository: UserRepositoryProtocol,
+        user_repository: UserRepositoryProtocol[PydanticObjectId, UserResponse],
     ):
         self.user_repository = user_repository
 
@@ -28,7 +28,7 @@ class UserService:
         """
         Get user information from MongoDB.
         """
-        if(isinstance(self.user_repository, PostgresUserRepository)):
+        if isinstance(self.user_repository, PostgresUserRepository):
             print("Using PostgresUserRepository in UserService.get_user_info")
 
         user = await self.user_repository.find_user_by_id(user_id)

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -2,7 +2,8 @@ from datetime import datetime
 
 from beanie import PydanticObjectId
 
-from app.repository.user_repository import UserRepository
+from app.repository.postgres_user_repository import PostgresUserRepository
+from app.repository.user_repository_protocol import UserRepositoryProtocol
 from app.schemas.user_schemas import (
     ChangePasswordResponse,
     UpdateProfileRequest,
@@ -15,11 +16,11 @@ from app.utils.exceptions_utils import AppException
 
 
 class UserService:
-    user_repository: UserRepository
+    user_repository: UserRepositoryProtocol
 
     def __init__(
         self,
-        user_repository: UserRepository,
+        user_repository: UserRepositoryProtocol,
     ):
         self.user_repository = user_repository
 
@@ -27,6 +28,9 @@ class UserService:
         """
         Get user information from MongoDB.
         """
+        if(isinstance(self.user_repository, PostgresUserRepository)):
+            print("Using PostgresUserRepository in UserService.get_user_info")
+
         user = await self.user_repository.find_user_by_id(user_id)
         if not user:
             raise AppException(ErrorCodes.USER_NOT_FOUND)

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -1,8 +1,8 @@
 from datetime import datetime
+from uuid import UUID
 
 from beanie import PydanticObjectId
 
-from app.repository.postgres_user_repository import PostgresUserRepository
 from app.repository.user_repository_protocol import UserRepositoryProtocol
 from app.schemas.user_schemas import (
     ChangePasswordResponse,
@@ -20,17 +20,14 @@ class UserService:
 
     def __init__(
         self,
-        user_repository: UserRepositoryProtocol[PydanticObjectId, UserResponse],
+        user_repository: UserRepositoryProtocol,
     ):
         self.user_repository = user_repository
 
-    async def get_user_info(self, user_id: PydanticObjectId) -> UserResponse:
+    async def get_user_info(self, user_id: PydanticObjectId | UUID) -> UserResponse:
         """
         Get user information from MongoDB.
         """
-        if isinstance(self.user_repository, PostgresUserRepository):
-            print("Using PostgresUserRepository in UserService.get_user_info")
-
         user = await self.user_repository.find_user_by_id(user_id)
         if not user:
             raise AppException(ErrorCodes.USER_NOT_FOUND)
@@ -48,7 +45,7 @@ class UserService:
             profile_visibility=user.profile_visibility,
         )
 
-    async def get_visible_profile(self, handle: str, requester_id: PydanticObjectId) -> UserProfileResponse:
+    async def get_visible_profile(self, handle: str, requester_id: PydanticObjectId | UUID) -> UserProfileResponse:
         user = await self.user_repository.find_user_by_handle(handle.strip())
         if not user:
             raise AppException(ErrorCodes.USER_NOT_FOUND)
@@ -77,7 +74,7 @@ class UserService:
             date_of_birth=None,
         )
 
-    async def update_profile(self, user_id: PydanticObjectId, request: UpdateProfileRequest) -> UserResponse:
+    async def update_profile(self, user_id: PydanticObjectId | UUID, request: UpdateProfileRequest) -> UserResponse:
         """
         Update user profile fields.
         """
@@ -104,7 +101,7 @@ class UserService:
 
     async def change_password(
         self,
-        user_id: PydanticObjectId,
+        user_id: PydanticObjectId | UUID,
         current_password: str,
         new_password: str,
     ) -> ChangePasswordResponse:

--- a/app/utils/id_utils.py
+++ b/app/utils/id_utils.py
@@ -8,3 +8,12 @@ from beanie import PydanticObjectId
 def mongo_id_to_uuid(mongo_id: str | PydanticObjectId) -> UUID:
     """Derive a stable PostgreSQL UUID from a MongoDB ObjectId value."""
     return uuid5(NAMESPACE_URL, str(mongo_id))
+
+
+def is_valid_uuid(id_str: str) -> bool:
+    """Check if a string is a valid UUID."""
+    try:
+        UUID(id_str)
+        return True
+    except ValueError:
+        return False

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,7 +49,7 @@ Developer-facing documentation covering infrastructure, implementation details, 
 | `make dev` | Install runtime + development dependencies and configure git hooks |
 | `make hooks` | Configure git pre-commit hooks (lint, format, typecheck) |
 | `make test-unit` | Run unit tests with coverage report |
-| `make test-e2e` | Start e2e MongoDB, run e2e tests, then stop e2e MongoDB |
+| `make test-e2e` | Run e2e tests against Mongo by default, or Postgres with `E2E_BACKEND=postgres` |
 | `make migrate` | Run pending database migrations with confirmation |
 | `make migrate-dry-run` | Preview pending migrations without applying changes |
 | `make db-data-migrate` | Run pending PostgreSQL data migrations from `db_migrations/` |

--- a/docs/technical/e2e-testing.md
+++ b/docs/technical/e2e-testing.md
@@ -91,6 +91,8 @@ It uses a backend matrix so every PR now gets two separate e2e checks:
 - `E2E Tests (mongo)`
 - `E2E Tests (postgres)`
 
+The workflow allows both matrix entries to run in parallel, so Mongo and PostgreSQL e2e coverage do not block each other serially on the same pull request.
+
 The PostgreSQL job runs `uv run alembic upgrade head` before pytest so the schema is created from the same Alembic revisions used in development.
 
 **Required secrets:**

--- a/docs/technical/e2e-testing.md
+++ b/docs/technical/e2e-testing.md
@@ -4,7 +4,7 @@ This guide walks through setting up and running end-to-end tests locally.
 
 ## Prerequisites
 
-- **Docker** - For running MongoDB
+- **Docker** - For running MongoDB, PostgreSQL, and Redis
 - **Python 3.12+** - With `uv` installed
 - **.env file** - With `TMDB_API_KEY` configured
 
@@ -14,8 +14,11 @@ This guide walks through setting up and running end-to-end tests locally.
 # 0. Sync dependencies
 uv sync --group dev
 
-# 1. Run e2e tests with Docker MongoDB lifecycle managed automatically
+# 1. Run e2e tests against Mongo (default)
 make test-e2e
+
+# 2. Run the same suite against PostgreSQL
+E2E_BACKEND=postgres make test-e2e
 ```
 
 ## Infrastructure Components
@@ -23,6 +26,8 @@ make test-e2e
 | Service | Container | Port | Purpose |
 |---------|-----------|------|---------|
 | MongoDB | `cinelog_mongo_e2e` | 27018 | Test database |
+| PostgreSQL | `cinelog_postgres_e2e` | 5433 | Test database |
+| Redis | `cinelog_redis_e2e` | 6380 | Rate-limit and cache backend |
 
 ## Configuration Files
 
@@ -34,12 +39,17 @@ make test-e2e
 
 ## Environment Variables
 
-The e2e tests automatically configure these (via `conftest.py`):
+The e2e tests automatically configure these (via `conftest.py`), depending on `E2E_BACKEND`:
 
 ```bash
+# Mongo mode
 MONGODB_HOST=localhost
 MONGODB_PORT=27018
 MONGODB_DB=cinelog_e2e_db
+
+# PostgreSQL mode
+DATABASE_URL=postgresql+asyncpg://cinelog:cinelog@localhost:5433/cinelog_e2e_db
+DB_BACKEND=postgres
 ```
 
 **Note:** `TMDB_API_KEY` is loaded from `.env` for log tests that fetch movie data.
@@ -48,8 +58,9 @@ MONGODB_DB=cinelog_e2e_db
 
 ```
 tests/e2e/
-├── conftest.py          # Fixtures (MongoDB, Firebase, cleanup)
+├── conftest.py          # Backend-aware fixtures and cleanup
 ├── test_auth_e2e.py     # Registration tests
+├── test_movie_rating_e2e.py # Movie rating tests
 ├── test_user_e2e.py     # User info & logs tests
 └── test_log_e2e.py      # Log CRUD tests
 ```
@@ -59,6 +70,11 @@ tests/e2e/
 ### Connect to MongoDB
 ```bash
 mongosh --port 27018
+```
+
+### Connect to PostgreSQL
+```bash
+docker exec -it cinelog_postgres_e2e psql -U cinelog -d cinelog_e2e_db
 ```
 
 ### Run specific test

--- a/docs/technical/e2e-testing.md
+++ b/docs/technical/e2e-testing.md
@@ -84,7 +84,14 @@ uv run pytest tests/e2e/test_auth_e2e.py::TestAuthE2E::test_register_success -v
 
 ## CI/CD
 
-The GitHub workflow (`.github/workflows/e2e_tests.yml`) runs e2e tests automatically.
+The GitHub workflow (`.github/workflows/e2e_tests.yml`) runs e2e tests automatically on pull requests and pushes to `main`.
+
+It uses a backend matrix so every PR now gets two separate e2e checks:
+
+- `E2E Tests (mongo)`
+- `E2E Tests (postgres)`
+
+The PostgreSQL job runs `uv run alembic upgrade head` before pytest so the schema is created from the same Alembic revisions used in development.
 
 **Required secrets:**
 - `TMDB_API_KEY` - For movie data fetching

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ target-version = "py312"
 line-length = 120
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I", "N", "UP", "S", "B", "A", "C4", "PT"]
+select = ["E", "F", "W", "I", "N", "UP", "S", "B", "A", "C4", "PT", "T20"]
 ignore = [
     # FastAPI dependency injection intentionally uses function calls in defaults.
     "B008",
@@ -62,6 +62,10 @@ known-first-party = ["app"]
     "PT011",
     "S101",
 ]
+# The dev email fallback and the CLI migration scripts print progress to stdout by design.
+"app/services/email_service.py" = ["T20"]
+"db_migrations/**/*.py" = ["T20"]
+"migrations/**/*.py" = ["T20"]
 
 [tool.bandit]
 exclude_dirs = ["tests"]

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,19 +1,28 @@
 """
 E2E test fixtures for the cinelog_server application.
-Uses httpx ASGITransport for direct FastAPI testing.
+Uses httpx ASGITransport for direct FastAPI testing against the selected backend.
 """
 
 import os
 
+E2E_BACKEND = os.environ.get("E2E_BACKEND", "mongo").strip().lower()
+if E2E_BACKEND not in {"mongo", "postgres"}:
+    raise RuntimeError(f"Unsupported E2E_BACKEND={E2E_BACKEND!r}. Expected 'mongo' or 'postgres'.")
+
 # Set e2e environment variables BEFORE load_dotenv and any app imports.
 # app.config.rate_limiter reads REDIS_URL at import time, so the override
 # must be in place before any app module is imported.
-os.environ["MONGODB_HOST"] = "localhost"
-os.environ["MONGODB_PORT"] = "27018"
-os.environ["MONGODB_DB"] = "cinelog_e2e_db"
-os.environ["DB_BACKEND"] = "mongo"
 os.environ.setdefault("REDIS_URL", "redis://localhost:6380/0")
 os.environ.setdefault("RATE_LIMIT_HMAC_SECRET", "test-rate-limit-hmac-secret")
+
+if E2E_BACKEND == "postgres":
+    os.environ["DB_BACKEND"] = "postgres"
+    os.environ["DATABASE_URL"] = "postgresql+asyncpg://cinelog:cinelog@localhost:5433/cinelog_e2e_db"
+else:
+    os.environ["MONGODB_HOST"] = "localhost"
+    os.environ["MONGODB_PORT"] = "27018"
+    os.environ["MONGODB_DB"] = "cinelog_e2e_db"
+    os.environ["DB_BACKEND"] = "mongo"
 
 import asyncio  # noqa: E402
 from unittest.mock import patch  # noqa: E402
@@ -25,7 +34,9 @@ import redis.asyncio as aioredis  # noqa: E402
 from beanie import init_beanie  # noqa: E402
 from dotenv import load_dotenv  # noqa: E402
 from pymongo import AsyncMongoClient  # noqa: E402
+from sqlalchemy import text  # noqa: E402
 
+from app.db.postgres import close_postgres_engine, init_postgres_engine  # noqa: E402
 from app.models.log import Log  # noqa: E402
 from app.models.movie import Movie  # noqa: E402
 from app.models.movie_rating import MovieRating  # noqa: E402
@@ -35,21 +46,48 @@ from app.services.cache_service import CacheService  # noqa: E402
 from app.services.tmdb_service import TMDBService  # noqa: E402
 
 # Load .env file for remaining env vars (e.g. TMDB_API_KEY, JWT_SECRET_KEY).
-# RATE_LIMIT_HMAC_SECRET is set above so auth rate-limit keys stay deterministic.
-# os.environ takes precedence over .env values because load_dotenv does NOT
-# overwrite existing variables by default.
+# The values set above take precedence because load_dotenv does not overwrite
+# existing environment variables by default.
 load_dotenv()
 
 MONGO_DB = "cinelog_e2e_db"
+POSTGRES_TABLES = ("logs", "movie_ratings", "movies", "users")
+
+
+def _clear_dependency_caches() -> None:
+    from app.dependencies.repository_dependency import (
+        get_log_repository,
+        get_movie_rating_repository,
+        get_movie_repository,
+        get_user_repository,
+    )
+    from app.dependencies.service_dependency import (
+        get_auth_service,
+        get_log_service,
+        get_movie_rating_service,
+        get_movie_service,
+        get_stats_service,
+        get_user_service,
+    )
+
+    for provider in (
+        get_auth_service,
+        get_log_service,
+        get_movie_rating_service,
+        get_movie_service,
+        get_stats_service,
+        get_user_service,
+        get_log_repository,
+        get_movie_rating_repository,
+        get_movie_repository,
+        get_user_repository,
+    ):
+        provider.cache_clear()
 
 
 @pytest_asyncio.fixture(autouse=True)
 async def flush_redis():
-    """Flush Redis before each test to reset rate limit and cache state.
-
-    Flushing before (not after) guarantees a clean slate even if a
-    previous test run was interrupted before teardown completed.
-    """
+    """Flush Redis before each test to reset rate limit and cache state."""
     client = aioredis.from_url(os.environ["REDIS_URL"])
     await client.flushdb()
     await client.aclose()
@@ -58,11 +96,14 @@ async def flush_redis():
 
 @pytest_asyncio.fixture
 async def mongo_client():
+    if E2E_BACKEND != "mongo":
+        yield None
+        return
+
     client: AsyncMongoClient = AsyncMongoClient(
         f"mongodb://{os.environ['MONGODB_HOST']}:{os.environ['MONGODB_PORT']}",
         uuidRepresentation="standard",
     )
-    # Wait briefly for the MongoDB container to become ready.
     for _ in range(30):
         try:
             await client.admin.command("ping")
@@ -77,36 +118,70 @@ async def mongo_client():
 
 
 @pytest_asyncio.fixture
-async def async_client(mongo_client):
-    """Async HTTP client using ASGITransport for direct app testing.
+async def postgres_engine():
+    if E2E_BACKEND != "postgres":
+        yield None
+        return
 
-    ASGITransport does not send lifespan events, so the app's startup
-    handler (app/__init__.py) never runs. We initialize Beanie and
-    CacheService explicitly here instead.
-    """
+    engine = init_postgres_engine(required=True)
+    if engine is None:
+        raise RuntimeError("PostgreSQL engine failed to initialize for e2e tests.")
+
+    for _ in range(30):
+        try:
+            async with engine.connect() as connection:
+                await connection.execute(text("SELECT 1"))
+            break
+        except Exception:
+            await asyncio.sleep(0.25)
+    else:
+        raise RuntimeError("PostgreSQL for E2E tests is not reachable on port 5433")
+
+    yield engine
+    await close_postgres_engine()
+
+
+@pytest_asyncio.fixture
+async def async_client(mongo_client, postgres_engine):
+    """Async HTTP client using ASGITransport for direct app testing."""
     from app import app
     from app.config.redis import get_redis_config
 
-    await init_beanie(
-        database=mongo_client[MONGO_DB],
-        document_models=[User, Log, Movie, MovieRating],
-    )
+    _clear_dependency_caches()
+
+    if E2E_BACKEND == "mongo":
+        await init_beanie(
+            database=mongo_client[MONGO_DB],
+            document_models=[User, Log, Movie, MovieRating],
+        )
+    else:
+        init_postgres_engine(required=True)
+
     CacheService.initialize(get_redis_config())
 
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url="https://test") as client:
         yield client
+
+    _clear_dependency_caches()
     await CacheService.aclose_all()
     await TMDBService.aclose_all()
 
 
 @pytest_asyncio.fixture(autouse=True)
-async def clean_db(mongo_client):
-    """Clean all collections before each test."""
-    db = mongo_client[MONGO_DB]
-    collection_names = await db.list_collection_names()
-    for collection_name in collection_names:
-        await db.drop_collection(collection_name)
+async def clean_db(mongo_client, postgres_engine):
+    """Clean the active database before each test."""
+    if E2E_BACKEND == "mongo":
+        db = mongo_client[MONGO_DB]
+        collection_names = await db.list_collection_names()
+        for collection_name in collection_names:
+            await db.drop_collection(collection_name)
+    else:
+        async with postgres_engine.begin() as connection:
+            await connection.execute(
+                text(f"TRUNCATE TABLE {', '.join(POSTGRES_TABLES)} RESTART IDENTITY CASCADE")
+            )
+
     yield
 
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -178,9 +178,7 @@ async def clean_db(mongo_client, postgres_engine):
             await db.drop_collection(collection_name)
     else:
         async with postgres_engine.begin() as connection:
-            await connection.execute(
-                text(f"TRUNCATE TABLE {', '.join(POSTGRES_TABLES)} RESTART IDENTITY CASCADE")
-            )
+            await connection.execute(text(f"TRUNCATE TABLE {', '.join(POSTGRES_TABLES)} RESTART IDENTITY CASCADE"))
 
     yield
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -11,6 +11,7 @@ import os
 os.environ["MONGODB_HOST"] = "localhost"
 os.environ["MONGODB_PORT"] = "27018"
 os.environ["MONGODB_DB"] = "cinelog_e2e_db"
+os.environ["DB_BACKEND"] = "mongo"
 os.environ.setdefault("REDIS_URL", "redis://localhost:6380/0")
 os.environ.setdefault("RATE_LIMIT_HMAC_SECRET", "test-rate-limit-hmac-secret")
 

--- a/tests/e2e/test_auth_e2e.py
+++ b/tests/e2e/test_auth_e2e.py
@@ -1,6 +1,6 @@
 """
 E2E tests for authentication endpoints.
-Tests the full stack: FastAPI -> AuthService -> Firebase + MongoDB.
+Tests the full stack against the selected e2e backend.
 """
 
 from datetime import timedelta
@@ -270,10 +270,11 @@ class TestAuthE2E:
         forgot_resp = await async_client.post("/v1/auth/forgot-password", json={"email": "reset@example.com"})
         assert forgot_resp.status_code == 200
 
-        # Fetch the reset code directly from DB since it was mocked via email
-        from app.models.user import User
+        # Fetch the reset code through the active repository so the test
+        # works for both Mongo and PostgreSQL e2e backends.
+        from app.dependencies.repository_dependency import get_user_repository
 
-        user: User | None = await User.find_one(User.email == "reset@example.com")
+        user = await get_user_repository().find_user_by_email("reset@example.com")
         assert user is not None
         code = user.reset_password_code
 

--- a/tests/e2e/test_log_e2e.py
+++ b/tests/e2e/test_log_e2e.py
@@ -1,6 +1,6 @@
 """
 E2E tests for log controller endpoints.
-Tests the full stack: FastAPI -> LogService -> MongoDB.
+Tests the full stack against the selected e2e backend.
 """
 
 from app.utils.error_codes_utils import ErrorCodes

--- a/tests/e2e/test_movie_rating_e2e.py
+++ b/tests/e2e/test_movie_rating_e2e.py
@@ -1,6 +1,6 @@
 """
 E2E tests for movie rating controller endpoints.
-Tests the full stack: FastAPI -> MovieRatingService -> MongoDB.
+Tests the full stack against the selected e2e backend.
 """
 
 from tests.e2e.conftest import register_and_login

--- a/tests/e2e/test_user_e2e.py
+++ b/tests/e2e/test_user_e2e.py
@@ -1,6 +1,6 @@
 """
 E2E tests for user controller endpoints.
-Tests the full stack: FastAPI -> UserService -> MongoDB.
+Tests the full stack against the selected e2e backend.
 """
 
 from tests.e2e.conftest import register_and_login

--- a/tests/units/db_migrations/test_migrate_movie_ratings.py
+++ b/tests/units/db_migrations/test_migrate_movie_ratings.py
@@ -143,9 +143,7 @@ async def test_migrate_movie_ratings_up_dry_run_reports_progress(capsys):
 
 
 @pytest.mark.asyncio
-async def test_migrate_movie_ratings_up_dry_run_accounts_for_existing_and_prior_batch_conflicts(
-    capsys, monkeypatch
-):
+async def test_migrate_movie_ratings_up_dry_run_accounts_for_existing_and_prior_batch_conflicts(capsys, monkeypatch):
     from app.utils.id_utils import mongo_id_to_uuid
 
     monkeypatch.setattr(migrate_movie_ratings, "BATCH_SIZE", 2)

--- a/tests/units/dependencies/test_auth_dependency.py
+++ b/tests/units/dependencies/test_auth_dependency.py
@@ -1,5 +1,5 @@
-from uuid import UUID
 from unittest.mock import Mock, patch
+from uuid import UUID
 
 import pytest
 from beanie import PydanticObjectId

--- a/tests/units/dependencies/test_auth_dependency.py
+++ b/tests/units/dependencies/test_auth_dependency.py
@@ -1,3 +1,4 @@
+from uuid import UUID
 from unittest.mock import Mock, patch
 
 import pytest
@@ -25,6 +26,22 @@ class TestAuthDependency:
             result = auth_dependency(mock_request)
 
             assert result == PydanticObjectId(user_id_str)
+            mock_decode.assert_called_once_with("valid_token")
+
+    def test_when_cookie_contains_uuid_sub_returns_uuid(self):
+        """Test that auth_dependency returns UUID when JWT sub is a UUID string."""
+        mock_request = Mock()
+        mock_request.cookies = {"__Host-access_token": "valid_token"}
+        mock_request.headers = {}
+        user_id_str = "3f6f4d8c-c729-4c09-93aa-fbffcd2d1c4f"
+
+        with patch("app.dependencies.auth_dependency.TokenService.decode_token") as mock_decode:
+            mock_decode.return_value = {"sub": user_id_str, "type": "access"}
+
+            result = auth_dependency(mock_request)
+
+            assert result == UUID(user_id_str)
+            assert mock_request.state.user_id == user_id_str
             mock_decode.assert_called_once_with("valid_token")
 
     def test_when_cookie_is_missing(self):

--- a/tests/units/dependencies/test_repository_dependency.py
+++ b/tests/units/dependencies/test_repository_dependency.py
@@ -10,6 +10,8 @@ from app.dependencies.repository_dependency import (
 from app.repository.log_repository import LogRepository
 from app.repository.movie_rating_repository import MovieRatingRepository
 from app.repository.movie_repository import MovieRepository
+from app.repository.postgres_movie_repository import PostgresMovieRepository
+from app.repository.postgres_user_repository import PostgresUserRepository
 from app.repository.user_repository import UserRepository
 
 
@@ -34,11 +36,12 @@ def test_get_movie_repository_defaults_to_mongo(monkeypatch):
     assert isinstance(repository, MovieRepository)
 
 
-def test_get_movie_repository_raises_for_unsafe_postgres_activation(monkeypatch):
+def test_get_movie_repository_returns_postgres_when_backend_is_postgres(monkeypatch):
     monkeypatch.setenv("DB_BACKEND", "postgres")
 
-    with pytest.raises(RepositoryActivationError, match="not yet safe"):
-        get_movie_repository()
+    repository = get_movie_repository()
+
+    assert isinstance(repository, PostgresMovieRepository)
 
 
 def test_get_log_repository_defaults_to_mongo(monkeypatch):
@@ -79,8 +82,9 @@ def test_get_user_repository_defaults_to_mongo(monkeypatch):
     assert isinstance(repository, UserRepository)
 
 
-def test_get_user_repository_raises_for_unsafe_postgres_activation(monkeypatch):
+def test_get_user_repository_returns_postgres_when_backend_is_postgres(monkeypatch):
     monkeypatch.setenv("DB_BACKEND", "postgres")
 
-    with pytest.raises(RepositoryActivationError, match="not yet safe"):
-        get_user_repository()
+    repository = get_user_repository()
+
+    assert isinstance(repository, PostgresUserRepository)

--- a/tests/units/dependencies/test_repository_dependency.py
+++ b/tests/units/dependencies/test_repository_dependency.py
@@ -1,7 +1,6 @@
 import pytest
 
 from app.dependencies.repository_dependency import (
-    RepositoryActivationError,
     get_log_repository,
     get_movie_rating_repository,
     get_movie_repository,
@@ -10,6 +9,8 @@ from app.dependencies.repository_dependency import (
 from app.repository.log_repository import LogRepository
 from app.repository.movie_rating_repository import MovieRatingRepository
 from app.repository.movie_repository import MovieRepository
+from app.repository.postgres_log_repository import PostgresLogRepository
+from app.repository.postgres_movie_rating_repository import PostgresMovieRatingRepository
 from app.repository.postgres_movie_repository import PostgresMovieRepository
 from app.repository.postgres_user_repository import PostgresUserRepository
 from app.repository.user_repository import UserRepository
@@ -52,11 +53,12 @@ def test_get_log_repository_defaults_to_mongo(monkeypatch):
     assert isinstance(repository, LogRepository)
 
 
-def test_get_log_repository_raises_for_unsafe_postgres_activation(monkeypatch):
+def test_get_log_repository_returns_postgres_when_backend_is_postgres(monkeypatch):
     monkeypatch.setenv("DB_BACKEND", "postgres")
 
-    with pytest.raises(RepositoryActivationError, match="not yet safe"):
-        get_log_repository()
+    repository = get_log_repository()
+
+    assert isinstance(repository, PostgresLogRepository)
 
 
 def test_get_movie_rating_repository_defaults_to_mongo(monkeypatch):
@@ -67,11 +69,12 @@ def test_get_movie_rating_repository_defaults_to_mongo(monkeypatch):
     assert isinstance(repository, MovieRatingRepository)
 
 
-def test_get_movie_rating_repository_raises_for_unsafe_postgres_activation(monkeypatch):
+def test_get_movie_rating_repository_returns_postgres_when_backend_is_postgres(monkeypatch):
     monkeypatch.setenv("DB_BACKEND", "postgres")
 
-    with pytest.raises(RepositoryActivationError, match="not yet safe"):
-        get_movie_rating_repository()
+    repository = get_movie_rating_repository()
+
+    assert isinstance(repository, PostgresMovieRatingRepository)
 
 
 def test_get_user_repository_defaults_to_mongo(monkeypatch):

--- a/tests/units/dependencies/test_service_dependency.py
+++ b/tests/units/dependencies/test_service_dependency.py
@@ -1,0 +1,33 @@
+from app.dependencies.repository_dependency import get_log_repository
+from app.dependencies.service_dependency import _get_runtime_log_repository
+from app.repository.log_cache_repository import LogCacheRepository
+from app.repository.log_repository import LogRepository
+from app.repository.postgres_log_repository import PostgresLogRepository
+
+
+def clear_caches() -> None:
+    get_log_repository.cache_clear()
+
+
+def test_get_runtime_log_repository_uses_cache_wrapper_for_mongo(monkeypatch):
+    clear_caches()
+    monkeypatch.delenv("DB_BACKEND", raising=False)
+
+    repository = _get_runtime_log_repository()
+
+    assert isinstance(repository, LogCacheRepository)
+    assert isinstance(repository.repository, LogRepository)
+
+    clear_caches()
+
+
+def test_get_runtime_log_repository_skips_cache_wrapper_for_postgres(monkeypatch):
+    clear_caches()
+    monkeypatch.setenv("DB_BACKEND", "postgres")
+
+    repository = _get_runtime_log_repository()
+
+    assert isinstance(repository, PostgresLogRepository)
+    assert not isinstance(repository, LogCacheRepository)
+
+    clear_caches()

--- a/tests/units/repository/test_movie_repository.py
+++ b/tests/units/repository/test_movie_repository.py
@@ -1,9 +1,12 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 from beanie import PydanticObjectId
 
 from app.models.movie import Movie
 from app.repository.movie_repository import MovieRepository
-from app.schemas.movie_schemas import MovieCreateRequest, MovieUpdateRequest
+from app.schemas.movie_schemas import MovieCreateRequest, MovieStats, MovieUpdateRequest
+from app.schemas.tmdb_schemas import TMDBMovieDetails
 
 
 @pytest.fixture
@@ -107,7 +110,6 @@ async def test_find_movie_filters_soft_deleted(beanie_test_db, movie_create_requ
 
 @pytest.mark.asyncio
 async def test_create_from_tmdb_data(beanie_test_db):
-    from app.schemas.tmdb_schemas import TMDBMovieDetails
 
     repository = MovieRepository()
     tmdb_data = TMDBMovieDetails(
@@ -148,7 +150,6 @@ async def test_create_from_tmdb_data(beanie_test_db):
 
 @pytest.mark.asyncio
 async def test_create_from_tmdb_data_without_release_date(beanie_test_db):
-    from app.schemas.tmdb_schemas import TMDBMovieDetails
 
     repository = MovieRepository()
     tmdb_data = TMDBMovieDetails(
@@ -183,7 +184,6 @@ async def test_create_from_tmdb_data_without_release_date(beanie_test_db):
 
 @pytest.mark.asyncio
 async def test_create_from_tmdb_data_with_invalid_date(beanie_test_db):
-    from app.schemas.tmdb_schemas import TMDBMovieDetails
 
     repository = MovieRepository()
     tmdb_data = TMDBMovieDetails(
@@ -218,7 +218,6 @@ async def test_create_from_tmdb_data_with_invalid_date(beanie_test_db):
 
 @pytest.mark.asyncio
 async def test_create_from_tmdb_data_duplicate_key_returns_existing(beanie_test_db):
-    from app.schemas.tmdb_schemas import TMDBMovieDetails
 
     repository = MovieRepository()
     existing = await repository.create_movie(MovieCreateRequest(title="Existing Movie", tmdb_id=98765))
@@ -250,3 +249,31 @@ async def test_create_from_tmdb_data_duplicate_key_returns_existing(beanie_test_
 
     assert returned.id == existing.id
     assert returned.tmdb_id == existing.tmdb_id
+
+
+@pytest.mark.asyncio
+async def test_find_movies_by_ids_accepts_iterable(beanie_test_db):
+    repository = MovieRepository()
+    first = await repository.create_movie(MovieCreateRequest(title="First", tmdb_id=200001))
+    second = await repository.create_movie(MovieCreateRequest(title="Second", tmdb_id=200002))
+
+    found = await repository.find_movies_by_ids([first.id, second.id])
+
+    assert {movie.id for movie in found} == {first.id, second.id}
+
+
+@pytest.mark.asyncio
+async def test_get_movie_stats_accepts_iterable(beanie_test_db):
+    repository = MovieRepository()
+    first_id = PydanticObjectId()
+    second_id = PydanticObjectId()
+    aggregate_result = MagicMock()
+    aggregate_result.to_list = AsyncMock(return_value=[MovieStats(total_runtime=180)])
+
+    with patch.object(Movie, "aggregate", return_value=aggregate_result) as aggregate:
+        stats = await repository.get_movie_stats((first_id, second_id))
+
+    pipeline = aggregate.call_args.args[0]
+    assert pipeline[0]["$match"]["_id"]["$in"] == [first_id, second_id]
+
+    assert stats.total_runtime == 180

--- a/tests/units/repository/test_postgres_movie_repository.py
+++ b/tests/units/repository/test_postgres_movie_repository.py
@@ -249,6 +249,17 @@ async def test_find_movies_by_ids_with_empty_set_short_circuits(repository: Post
 
 
 @pytest.mark.asyncio
+async def test_find_movies_by_ids_accepts_iterable(repository: PostgresMovieRepository, seed_session: AsyncSession):
+    first = PostgresMovie(tmdb_id=804, title="First")
+    second = PostgresMovie(tmdb_id=805, title="Second")
+    await _add(seed_session, first, second)
+
+    found = await repository.find_movies_by_ids([first.id, second.id])
+
+    assert {movie.id for movie in found} == {first.id, second.id}
+
+
+@pytest.mark.asyncio
 async def test_get_movie_stats_sums_runtime_excluding_deleted(
     repository: PostgresMovieRepository, seed_session: AsyncSession
 ):
@@ -261,6 +272,17 @@ async def test_get_movie_stats_sums_runtime_excluding_deleted(
     stats = await repository.get_movie_stats({a.id, b.id, deleted.id, null_runtime.id})
 
     assert stats.total_runtime == 210
+
+
+@pytest.mark.asyncio
+async def test_get_movie_stats_accepts_iterable(repository: PostgresMovieRepository, seed_session: AsyncSession):
+    first = PostgresMovie(tmdb_id=905, title="First", runtime=100)
+    second = PostgresMovie(tmdb_id=906, title="Second", runtime=80)
+    await _add(seed_session, first, second)
+
+    stats = await repository.get_movie_stats((first.id, second.id))
+
+    assert stats.total_runtime == 180
 
 
 @pytest.mark.asyncio

--- a/tests/units/services/test_log_service.py
+++ b/tests/units/services/test_log_service.py
@@ -261,6 +261,16 @@ class TestLogService:
             await log_service.update_log("user123", PydanticObjectId(), request)
 
     @pytest.mark.asyncio
+    async def test_update_log_rejects_mismatched_id_family(self, log_service, mock_log_repository):
+        request = LogUpdateRequest(viewing_notes="Updated notes")
+
+        with pytest.raises(AppException) as exc_info:
+            await log_service.update_log(uuid4(), PydanticObjectId(), request)
+
+        assert exc_info.value.error.error_code == ErrorCodes.LOG_NOT_FOUND.error_code
+        mock_log_repository.update_log.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_delete_log_success(self, log_service, mock_log_repository, mock_stats_cache_service):
         """Test successful log deletion invalidates the stats cache."""
         user_id = PydanticObjectId()
@@ -282,6 +292,20 @@ class TestLogService:
             await log_service.delete_log(user_id=user_id, log_id=PydanticObjectId())
 
         assert exc_info.value.error.error_code == ErrorCodes.LOG_NOT_FOUND.error_code
+        mock_stats_cache_service.invalidate_user_stats.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_delete_log_rejects_mismatched_id_family(
+        self,
+        log_service,
+        mock_log_repository,
+        mock_stats_cache_service,
+    ):
+        with pytest.raises(AppException) as exc_info:
+            await log_service.delete_log(uuid4(), PydanticObjectId())
+
+        assert exc_info.value.error.error_code == ErrorCodes.LOG_NOT_FOUND.error_code
+        mock_log_repository.delete_log.assert_not_awaited()
         mock_stats_cache_service.invalidate_user_stats.assert_not_called()
 
     @pytest.mark.asyncio

--- a/tests/units/services/test_log_service.py
+++ b/tests/units/services/test_log_service.py
@@ -1,5 +1,6 @@
 from datetime import date
 from unittest.mock import AsyncMock, MagicMock, Mock
+from uuid import uuid4
 
 import pytest
 from beanie import PydanticObjectId
@@ -368,6 +369,55 @@ class TestGetUserLogsByHandle:
 
         assert len(result.logs) == 1
         mock_user_repository.find_user_by_handle.assert_awaited_once_with("johndoe")
+
+    @pytest.mark.asyncio
+    async def test_public_profile_allows_access_with_uuid_backed_logs(self, log_service, mock_user_repository):
+        user_id = uuid4()
+        movie_id = uuid4()
+        log_id = uuid4()
+
+        mock_user = self._create_mock_user(user_id=user_id, handle="johndoe", profile_visibility="public")
+        mock_user_repository.find_user_by_handle.return_value = mock_user
+
+        mock_movie = Mock()
+        mock_movie.id = movie_id
+        mock_movie.title = "Test Movie"
+        mock_movie.tmdb_id = 550
+        mock_movie.poster_path = "/poster.jpg"
+        mock_movie.release_date = None
+        mock_movie.overview = None
+        mock_movie.vote_average = None
+        mock_movie.runtime = None
+        mock_movie.original_language = "en"
+        mock_movie.created_at = None
+        mock_movie.updated_at = None
+
+        mock_rating = Mock()
+        mock_rating.movie_id = movie_id
+        mock_rating.rating = 8
+
+        mock_log = Mock()
+        mock_log.id = log_id
+        mock_log.movie_id = movie_id
+        mock_log.tmdb_id = 550
+        mock_log.date_watched = date(2024, 1, 15)
+        mock_log.viewing_notes = "Great!"
+        mock_log.poster_path = "/poster.jpg"
+        mock_log.watched_where = "cinema"
+
+        log_service.log_repository.find_logs_by_user_id = AsyncMock(return_value=[mock_log])
+        log_service.movie_repository.find_movies_by_ids = AsyncMock(return_value=[mock_movie])
+        log_service.movie_rating_repository.find_movie_ratings_by_user_and_movie_ids = AsyncMock(
+            return_value=[mock_rating]
+        )
+
+        request = LogListRequest()
+        result = await log_service.get_user_logs_by_handle(handle="johndoe", requester_id=uuid4(), request=request)
+
+        assert len(result.logs) == 1
+        assert result.logs[0].id == log_id
+        assert result.logs[0].movie_id == movie_id
+        assert result.logs[0].movie_rating == 8
 
     @pytest.mark.asyncio
     async def test_own_profile_allows_access(self, log_service, mock_user_repository):

--- a/tests/units/utils/test_id_utils.py
+++ b/tests/units/utils/test_id_utils.py
@@ -1,8 +1,9 @@
 from uuid import UUID
 
+import pytest
 from beanie import PydanticObjectId
 
-from app.utils.id_utils import mongo_id_to_uuid
+from app.utils.id_utils import is_valid_uuid, mongo_id_to_uuid
 
 
 def test_mongo_id_to_uuid_is_deterministic():
@@ -41,3 +42,15 @@ def test_mongo_id_to_uuid_accepts_pydantic_object_id():
     mongo_id = PydanticObjectId("507f1f77bcf86cd799439011")
 
     assert mongo_id_to_uuid(mongo_id) == UUID("e340c5bd-a268-5cb5-9e3c-2413648520da")
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("e340c5bd-a268-5cb5-9e3c-2413648520da", True),
+        ("not-a-uuid", False),
+        ("507f1f77bcf86cd799439011", False),
+    ],
+)
+def test_is_valid_uuid(value: str, expected: bool):
+    assert is_valid_uuid(value) is expected


### PR DESCRIPTION
## Summary
- activate PostgreSQL repositories in the service/dependency runtime paths
- add repository protocols and align services with backend-neutral repository contracts
- add PostgreSQL-backed log repository, log migration support, and UUID-safe runtime handling
- add dual-backend e2e support so the same suite runs on Mongo by default and on Postgres with `E2E_BACKEND=postgres`
- add a dedicated PR e2e workflow matrix for both `mongo` and `postgres`

## Testing
- make test-unit
- make lint
- make typecheck
- make test-e2e
- E2E_BACKEND=postgres make test-e2e

## Follow-up
- PostgreSQL log cache restoration is tracked in #170; runtime currently bypasses the Mongo-shaped log cache under `DB_BACKEND=postgres`

Refs #167