### PR TITLE
feat(migration): add production postgres migration job

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,9 @@ MONGODB_DB=cinelog_db
 
 # PostgreSQL Configuration (optional until PostgreSQL repositories are activated)
 DATABASE_URL=postgresql+asyncpg://cinelog:cinelog@localhost:5432/cinelog_db
+POSTGRES_DB=cinelog_db
+POSTGRES_USER=cinelog
+POSTGRES_PASSWORD=CHANGE_THIS_IN_PRODUCTION_POSTGRES_PASSWORD
 
 # CORS Configuration
 # CORS_ORIGINS=https://cinelog.app,https://www.cinelog.app

--- a/.env.example
+++ b/.env.example
@@ -11,9 +11,6 @@ MONGODB_DB=cinelog_db
 
 # PostgreSQL Configuration (optional until PostgreSQL repositories are activated)
 DATABASE_URL=postgresql+asyncpg://cinelog:cinelog@localhost:5432/cinelog_db
-POSTGRES_DB=cinelog_db
-POSTGRES_USER=cinelog
-POSTGRES_PASSWORD=CHANGE_THIS_IN_PRODUCTION_POSTGRES_PASSWORD
 
 # CORS Configuration
 # CORS_ORIGINS=https://cinelog.app,https://www.cinelog.app

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -19,6 +19,9 @@ WORKDIR /app
 COPY --from=builder /app/.venv /app/.venv
 
 COPY app/ ./app/
+COPY alembic/ ./alembic/
+COPY db_migrations/ ./db_migrations/
+COPY alembic.ini ./
 COPY main.py ./
 
 RUN chown -R appuser:appuser /app

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install dev hooks test-unit test-e2e lint format format-check typecheck security dependency-audit run docker-up docker-down docker-build-prod docker-prod-up docker-prod-down migrate migrate-dry-run db-data-migrate db-data-migrate-dry-run migrate-all migrate-all-dry-run db-schema-migrate db-schema-migrate-dry-run db-schema-rollback
+.PHONY: install dev hooks test-unit test-e2e lint format format-check typecheck security dependency-audit run docker-up docker-down docker-build-prod docker-prod-up docker-prod-down migrate migrate-dry-run db-data-migrate db-data-migrate-dry-run postgres-migrate-all postgres-migrate-all-dry-run migrate-all migrate-all-dry-run db-schema-migrate db-schema-migrate-dry-run db-schema-rollback
 
 install:
 	uv sync
@@ -102,6 +102,14 @@ db-data-migrate:
 	uv run python -m db_migrations.runner --yes
 
 db-data-migrate-dry-run:
+	uv run python -m db_migrations.runner --dry-run
+
+postgres-migrate-all:
+	uv run alembic upgrade head
+	uv run python -m db_migrations.runner --yes
+
+postgres-migrate-all-dry-run:
+	uv run alembic upgrade head --sql
 	uv run python -m db_migrations.runner --dry-run
 
 migrate-all:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -5,26 +5,11 @@ x-app-env: &app-env
     - .env
   environment:
     DB_BACKEND: postgres
-    DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-cinelog}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD for production Compose}@postgres:5432/${POSTGRES_DB:-cinelog_db}
+    DATABASE_URL: ${DATABASE_URL:?Set DATABASE_URL to the external PostgreSQL database}
     MONGODB_URI: ${MONGODB_URI:?Set MONGODB_URI to the source MongoDB before production data migration}
     REDIS_URL: redis://redis:6379/0
 
 services:
-  postgres:
-    image: postgres:17-alpine
-    environment:
-      POSTGRES_DB: ${POSTGRES_DB:-cinelog_db}
-      POSTGRES_USER: ${POSTGRES_USER:-cinelog}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD for production Compose}
-    volumes:
-      - postgres_data:/var/lib/postgresql/data
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-cinelog} -d ${POSTGRES_DB:-cinelog_db}"]
-      interval: 5s
-      timeout: 5s
-      retries: 10
-    restart: unless-stopped
-
   db-migrate:
     <<: *app-env
     build:
@@ -33,9 +18,6 @@ services:
     command: >
       sh -c "alembic upgrade head &&
       python -m db_migrations.runner --yes"
-    depends_on:
-      postgres:
-        condition: service_healthy
     restart: "no"
 
   api:
@@ -48,8 +30,6 @@ services:
     depends_on:
       db-migrate:
         condition: service_completed_successfully
-      postgres:
-        condition: service_healthy
       redis:
         condition: service_healthy
     healthcheck:
@@ -72,5 +52,4 @@ services:
     restart: unless-stopped
 
 volumes:
-  postgres_data:
   redis_data:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,15 +1,55 @@
 name: cinelog-prod
 
+x-app-env: &app-env
+  env_file:
+    - .env
+  environment:
+    DB_BACKEND: postgres
+    DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-cinelog}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD for production Compose}@postgres:5432/${POSTGRES_DB:-cinelog_db}
+    MONGODB_URI: ${MONGODB_URI:?Set MONGODB_URI to the source MongoDB before production data migration}
+    REDIS_URL: redis://redis:6379/0
+
 services:
+  postgres:
+    image: postgres:17-alpine
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-cinelog_db}
+      POSTGRES_USER: ${POSTGRES_USER:-cinelog}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD for production Compose}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-cinelog} -d ${POSTGRES_DB:-cinelog_db}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  db-migrate:
+    <<: *app-env
+    build:
+      context: .
+      dockerfile: Dockerfile.prod
+    command: >
+      sh -c "alembic upgrade head &&
+      python -m db_migrations.runner --yes"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: "no"
+
   api:
+    <<: *app-env
     build:
       context: .
       dockerfile: Dockerfile.prod
     ports:
       - "5009:5009"
-    environment:
-      - REDIS_URL=redis://redis:6379/0
     depends_on:
+      db-migrate:
+        condition: service_completed_successfully
+      postgres:
+        condition: service_healthy
       redis:
         condition: service_healthy
     healthcheck:
@@ -32,4 +72,5 @@ services:
     restart: unless-stopped
 
 volumes:
+  postgres_data:
   redis_data:

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,6 +54,8 @@ Developer-facing documentation covering infrastructure, implementation details, 
 | `make migrate-dry-run` | Preview pending migrations without applying changes |
 | `make db-data-migrate` | Run pending PostgreSQL data migrations from `db_migrations/` |
 | `make db-data-migrate-dry-run` | Preview pending PostgreSQL data migrations without applying changes |
+| `make postgres-migrate-all` | Run PostgreSQL schema migrations, then PostgreSQL data migrations |
+| `make postgres-migrate-all-dry-run` | Preview the PostgreSQL schema/data migration path |
 | `make migrate-all` | Run all pending Mongo migrations, PostgreSQL schema migrations, and PostgreSQL data migrations |
 | `make migrate-all-dry-run` | Preview all pending migration systems without applying changes |
 | `make db-schema-migrate` | Run Alembic schema migrations against `DATABASE_URL` |
@@ -67,3 +69,5 @@ Developer-facing documentation covering infrastructure, implementation details, 
 | `make run` | Run API locally via `python main.py` |
 | `make docker-up` | Start local Docker stack (`docker-compose.local.yml`) |
 | `make docker-down` | Stop local Docker stack (`docker-compose.local.yml`) |
+| `make docker-prod-up` | Build and start the production Docker stack (`docker-compose.prod.yml`) |
+| `make docker-prod-down` | Stop the production Docker stack (`docker-compose.prod.yml`) |

--- a/docs/technical/deployment-options.md
+++ b/docs/technical/deployment-options.md
@@ -4,7 +4,7 @@
 
 Cinelog Server is a FastAPI application that can run anywhere an ASGI Python service can run. The repository does not require a specific hosting provider.
 
-The recommended production path is a generic VPS or container host where the backend, Redis, and MongoDB connectivity can be managed explicitly. Vercel is also a valid option for developers who want a free or low-friction deployment, but it is optional and self-managed.
+The recommended production path is a generic VPS or container host where the backend, PostgreSQL, Redis, and source MongoDB connectivity can be managed explicitly during the cutover. Vercel is also a valid option for developers who want a free or low-friction deployment, but it is optional and self-managed.
 
 ## Generic VPS
 
@@ -15,10 +15,19 @@ Typical setup:
 - Build and run the API with `Dockerfile.prod`
 - Start the stack with `docker-compose.prod.yml`
 - Provide production environment variables through the host or deployment system
-- Point `MONGODB_URI` at a managed MongoDB instance or an externally managed MongoDB server
+- Point `MONGODB_URI` at the source MongoDB instance until data migration and MongoDB removal are complete
+- Set `POSTGRES_PASSWORD` and optionally `POSTGRES_DB` / `POSTGRES_USER` for the production PostgreSQL service
 - Run Redis either as a container in the stack or as a managed Redis service
 - Put a reverse proxy such as Nginx, Caddy, or a cloud load balancer in front of the API
 - Terminate TLS at the reverse proxy or load balancer
+
+On `docker-compose.prod.yml` startup, Compose runs the `db-migrate` one-shot service before the API:
+
+```bash
+alembic upgrade head && python -m db_migrations.runner --yes
+```
+
+The API waits for that service to complete successfully, so failed PostgreSQL schema or data migrations block startup instead of allowing a partially migrated deployment.
 
 The production container starts Uvicorn directly with the FastAPI app:
 
@@ -65,6 +74,7 @@ Production deployments should configure:
 - `RATE_LIMIT_HMAC_SECRET`
 - `TMDB_API_KEY`
 - `MONGODB_URI`
+- `POSTGRES_PASSWORD`
 - `REDIS_URL`
 - `CORS_ORIGINS`
 - `CORS_ALLOW_CREDENTIALS`
@@ -74,8 +84,14 @@ Optional Redis tuning:
 
 - `REDIS_DEFAULT_TTL`
 
+Optional PostgreSQL settings:
+
+- `POSTGRES_DB`
+- `POSTGRES_USER`
+
 ## See Also
 
 - [CORS Configuration](cors-configuration.md)
+- [Postgres Migration](postgres-migration.md)
 - [Redis Caching](redis-caching.md)
 - [Migrations](migrations.md)

--- a/docs/technical/deployment-options.md
+++ b/docs/technical/deployment-options.md
@@ -4,7 +4,7 @@
 
 Cinelog Server is a FastAPI application that can run anywhere an ASGI Python service can run. The repository does not require a specific hosting provider.
 
-The recommended production path is a generic VPS or container host where the backend, PostgreSQL, Redis, and source MongoDB connectivity can be managed explicitly during the cutover. Vercel is also a valid option for developers who want a free or low-friction deployment, but it is optional and self-managed.
+The recommended production path is a generic VPS or container host where the backend, Redis, external PostgreSQL, and source MongoDB connectivity can be managed explicitly during the cutover. Vercel is also a valid option for developers who want a free or low-friction deployment, but it is optional and self-managed.
 
 ## Generic VPS
 
@@ -16,7 +16,7 @@ Typical setup:
 - Start the stack with `docker-compose.prod.yml`
 - Provide production environment variables through the host or deployment system
 - Point `MONGODB_URI` at the source MongoDB instance until data migration and MongoDB removal are complete
-- Set `POSTGRES_PASSWORD` and optionally `POSTGRES_DB` / `POSTGRES_USER` for the production PostgreSQL service
+- Point `DATABASE_URL` at the external PostgreSQL database
 - Run Redis either as a container in the stack or as a managed Redis service
 - Put a reverse proxy such as Nginx, Caddy, or a cloud load balancer in front of the API
 - Terminate TLS at the reverse proxy or load balancer
@@ -74,7 +74,7 @@ Production deployments should configure:
 - `RATE_LIMIT_HMAC_SECRET`
 - `TMDB_API_KEY`
 - `MONGODB_URI`
-- `POSTGRES_PASSWORD`
+- `DATABASE_URL`
 - `REDIS_URL`
 - `CORS_ORIGINS`
 - `CORS_ALLOW_CREDENTIALS`
@@ -83,11 +83,6 @@ Production deployments should configure:
 Optional Redis tuning:
 
 - `REDIS_DEFAULT_TTL`
-
-Optional PostgreSQL settings:
-
-- `POSTGRES_DB`
-- `POSTGRES_USER`
 
 ## See Also
 

--- a/docs/technical/postgres-migration.md
+++ b/docs/technical/postgres-migration.md
@@ -88,6 +88,44 @@ Run all pending migration systems (Mongo custom runner + Alembic schema + Postgr
 make migrate-all
 ```
 
+Run only the PostgreSQL cutover path, with schema migrations before data migrations:
+
+```bash
+make postgres-migrate-all
+```
+
+This target is the same migration order used by production Compose.
+
+## Production Compose Migration
+
+`docker-compose.prod.yml` includes a one-shot `db-migrate` service that runs before the API starts:
+
+```bash
+alembic upgrade head && python -m db_migrations.runner --yes
+```
+
+The production order is intentionally PostgreSQL schema first, then MongoDB-to-PostgreSQL data migrations. The API service depends on `db-migrate` with `service_completed_successfully`, so a failed schema or data migration prevents the API container from starting.
+
+Required production Compose settings:
+
+| Variable | Purpose |
+| --- | --- |
+| `POSTGRES_DB` | PostgreSQL database name, defaults to `cinelog_db` |
+| `POSTGRES_USER` | PostgreSQL user, defaults to `cinelog` |
+| `POSTGRES_PASSWORD` | PostgreSQL password, required |
+| `MONGODB_URI` | Source MongoDB URI for data migration, required |
+| `JWT_SECRET_KEY` | API auth signing secret |
+| `RATE_LIMIT_HMAC_SECRET` | HMAC secret for account-based rate-limit identifiers |
+| `TMDB_API_KEY` | TMDB API key |
+
+Start production Compose after the required variables are present in the host environment or `.env`:
+
+```bash
+make docker-prod-up
+```
+
+The `db-migrate` service is idempotent: Alembic skips already-applied schema revisions, and `db_migrations.runner` skips data migrations recorded in `data_migration_versions`.
+
 ## Deterministic IDs
 
 During migration, PostgreSQL IDs derived from MongoDB documents must use the shared helper:

--- a/docs/technical/postgres-migration.md
+++ b/docs/technical/postgres-migration.md
@@ -110,9 +110,7 @@ Required production Compose settings:
 
 | Variable | Purpose |
 | --- | --- |
-| `POSTGRES_DB` | PostgreSQL database name, defaults to `cinelog_db` |
-| `POSTGRES_USER` | PostgreSQL user, defaults to `cinelog` |
-| `POSTGRES_PASSWORD` | PostgreSQL password, required |
+| `DATABASE_URL` | External PostgreSQL database URL, required |
 | `MONGODB_URI` | Source MongoDB URI for data migration, required |
 | `JWT_SECRET_KEY` | API auth signing secret |
 | `RATE_LIMIT_HMAC_SECRET` | HMAC secret for account-based rate-limit identifiers |

--- a/tests/units/config/test_prod_compose.py
+++ b/tests/units/config/test_prod_compose.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PROD_COMPOSE_FILE = REPO_ROOT / "docker-compose.prod.yml"
+
+
+def test_prod_compose_runs_schema_before_data_migration():
+    compose = PROD_COMPOSE_FILE.read_text()
+
+    schema_index = compose.index("alembic upgrade head")
+    data_index = compose.index("python -m db_migrations.runner --yes")
+
+    assert "db-migrate:" in compose
+    assert schema_index < data_index
+    assert "make migrate-all" not in compose
+
+
+def test_prod_api_waits_for_successful_migration_job():
+    compose = PROD_COMPOSE_FILE.read_text()
+
+    assert "db-migrate:" in compose
+    assert "condition: service_completed_successfully" in compose
+    assert "DB_BACKEND: postgres" in compose
+    assert "pg_isready" in compose

--- a/tests/units/config/test_prod_compose.py
+++ b/tests/units/config/test_prod_compose.py
@@ -21,4 +21,6 @@ def test_prod_api_waits_for_successful_migration_job():
     assert "db-migrate:" in compose
     assert "condition: service_completed_successfully" in compose
     assert "DB_BACKEND: postgres" in compose
-    assert "pg_isready" in compose
+    assert "DATABASE_URL: ${DATABASE_URL:?Set DATABASE_URL to the external PostgreSQL database}" in compose
+    assert "image: postgres" not in compose
+    assert "postgres_data:" not in compose


### PR DESCRIPTION
## Summary

- add a production PostgreSQL service and one-shot `db-migrate` job to `docker-compose.prod.yml`
- run Alembic schema migrations before PostgreSQL data migrations, then start the API only after migration success
- include migration files in the production image and document the production migration flow
- add static unit coverage for production Compose migration order and API dependency behavior

## Verification

- `make lint`
- `make typecheck`
- `make test-unit`
- `POSTGRES_PASSWORD=cinelog MONGODB_URI=mongodb://source.example:27017/cinelog_db docker compose -f docker-compose.prod.yml config --quiet`

Closes #173
