### PR TITLE
fix(migration): normalize external postgres urls

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,7 +1,6 @@
 """Alembic environment for async PostgreSQL migrations."""
 
 import asyncio
-import os
 from logging.config import fileConfig
 from typing import Any
 
@@ -10,6 +9,7 @@ from sqlalchemy.engine import Connection
 from sqlalchemy.ext.asyncio import async_engine_from_config
 
 from alembic import context, util
+from app.db.postgres import get_database_url
 from app.models.base_model import Base
 from app.models.log_model import PostgresLog  # noqa: F401
 from app.models.movie_model import PostgresMovie  # noqa: F401
@@ -26,13 +26,13 @@ DATABASE_URL_ENV = "DATABASE_URL"
 
 
 def _get_alembic_database_url() -> str:
-    database_url = os.getenv(DATABASE_URL_ENV)
-    if database_url:
+    database_url = get_database_url(required=False)
+    if database_url is not None:
         return database_url
 
     raise util.CommandError(
         f"{DATABASE_URL_ENV} is required to run Alembic migrations. "
-        "Set it to a postgresql+asyncpg:// connection string before running Alembic."
+        "Set it to a PostgreSQL connection string before running Alembic."
     )
 
 

--- a/app/db/postgres.py
+++ b/app/db/postgres.py
@@ -9,6 +9,9 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
 DATABASE_URL_ENV = "DATABASE_URL"
 DB_BACKEND_ENV = "DB_BACKEND"
+ASYNC_POSTGRES_SCHEME = "postgresql+asyncpg://"
+POSTGRES_SCHEME = "postgres://"
+POSTGRESQL_SCHEME = "postgresql://"
 
 
 class PostgresConfigurationError(RuntimeError):
@@ -40,7 +43,7 @@ def get_database_url(*, required: bool = True) -> str | None:
     """Return the configured PostgreSQL database URL."""
     database_url = os.getenv(DATABASE_URL_ENV)
     if database_url:
-        return database_url
+        return normalize_database_url(database_url)
 
     if required:
         raise PostgresConfigurationError(
@@ -49,6 +52,20 @@ def get_database_url(*, required: bool = True) -> str | None:
         )
 
     return None
+
+
+def normalize_database_url(database_url: str) -> str:
+    """Normalize common hosted Postgres URLs for SQLAlchemy asyncpg."""
+    if database_url.startswith(ASYNC_POSTGRES_SCHEME):
+        return database_url
+
+    if database_url.startswith(POSTGRESQL_SCHEME):
+        return f"{ASYNC_POSTGRES_SCHEME}{database_url.removeprefix(POSTGRESQL_SCHEME)}"
+
+    if database_url.startswith(POSTGRES_SCHEME):
+        return f"{ASYNC_POSTGRES_SCHEME}{database_url.removeprefix(POSTGRES_SCHEME)}"
+
+    return database_url
 
 
 @overload

--- a/app/db/postgres.py
+++ b/app/db/postgres.py
@@ -4,6 +4,7 @@ import os
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Literal, cast, overload
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
 
@@ -57,15 +58,38 @@ def get_database_url(*, required: bool = True) -> str | None:
 def normalize_database_url(database_url: str) -> str:
     """Normalize common hosted Postgres URLs for SQLAlchemy asyncpg."""
     if database_url.startswith(ASYNC_POSTGRES_SCHEME):
-        return database_url
+        return _normalize_asyncpg_query(database_url)
 
     if database_url.startswith(POSTGRESQL_SCHEME):
-        return f"{ASYNC_POSTGRES_SCHEME}{database_url.removeprefix(POSTGRESQL_SCHEME)}"
+        normalized_url = f"{ASYNC_POSTGRES_SCHEME}{database_url.removeprefix(POSTGRESQL_SCHEME)}"
+        return _normalize_asyncpg_query(normalized_url)
 
     if database_url.startswith(POSTGRES_SCHEME):
-        return f"{ASYNC_POSTGRES_SCHEME}{database_url.removeprefix(POSTGRES_SCHEME)}"
+        normalized_url = f"{ASYNC_POSTGRES_SCHEME}{database_url.removeprefix(POSTGRES_SCHEME)}"
+        return _normalize_asyncpg_query(normalized_url)
 
     return database_url
+
+
+def _normalize_asyncpg_query(database_url: str) -> str:
+    """Translate common libpq query params to SQLAlchemy asyncpg params."""
+    parsed = urlsplit(database_url)
+    if not parsed.query:
+        return database_url
+
+    query_params = parse_qsl(parsed.query, keep_blank_values=True)
+    has_ssl = any(key == "ssl" for key, _ in query_params)
+    normalized_params: list[tuple[str, str]] = []
+
+    for key, value in query_params:
+        if key == "sslmode":
+            if not has_ssl:
+                normalized_params.append(("ssl", value))
+            continue
+        normalized_params.append((key, value))
+
+    normalized_query = urlencode(normalized_params)
+    return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, normalized_query, parsed.fragment))
 
 
 @overload

--- a/docs/technical/postgres-migration.md
+++ b/docs/technical/postgres-migration.md
@@ -19,7 +19,7 @@ Set `DATABASE_URL` when you want the app or Alembic to initialize PostgreSQL:
 DATABASE_URL=postgresql+asyncpg://cinelog:cinelog@localhost:5432/cinelog_db
 ```
 
-Production deployments may also provide hosted database URLs as `postgresql://...` or `postgres://...`; the app normalizes both forms to SQLAlchemy's asyncpg driver internally.
+Production deployments may also provide hosted database URLs as `postgresql://...` or `postgres://...`; the app normalizes both forms to SQLAlchemy's asyncpg driver internally. Hosted URLs that include `sslmode=require` are also translated to asyncpg's `ssl=require` query parameter.
 
 Repository activation is controlled through `DB_BACKEND`:
 

--- a/docs/technical/postgres-migration.md
+++ b/docs/technical/postgres-migration.md
@@ -19,6 +19,8 @@ Set `DATABASE_URL` when you want the app or Alembic to initialize PostgreSQL:
 DATABASE_URL=postgresql+asyncpg://cinelog:cinelog@localhost:5432/cinelog_db
 ```
 
+Production deployments may also provide hosted database URLs as `postgresql://...` or `postgres://...`; the app normalizes both forms to SQLAlchemy's asyncpg driver internally.
+
 Repository activation is controlled through `DB_BACKEND`:
 
 ```bash
@@ -110,7 +112,7 @@ Required production Compose settings:
 
 | Variable | Purpose |
 | --- | --- |
-| `DATABASE_URL` | External PostgreSQL database URL, required |
+| `DATABASE_URL` | External PostgreSQL database URL, required. Accepts `postgresql+asyncpg://...`, `postgresql://...`, or `postgres://...` |
 | `MONGODB_URI` | Source MongoDB URI for data migration, required |
 | `JWT_SECRET_KEY` | API auth signing secret |
 | `RATE_LIMIT_HMAC_SECRET` | HMAC secret for account-based rate-limit identifiers |

--- a/tests/units/db/test_postgres.py
+++ b/tests/units/db/test_postgres.py
@@ -67,6 +67,22 @@ async def test_get_async_session_yields_async_session(monkeypatch):
             "postgres://user:password@localhost:5432/cinelog_test",
             "postgresql+asyncpg://user:password@localhost:5432/cinelog_test",
         ),
+        (
+            "postgresql+asyncpg://user:password@localhost:5432/cinelog_test?sslmode=require",
+            "postgresql+asyncpg://user:password@localhost:5432/cinelog_test?ssl=require",
+        ),
+        (
+            "postgresql://user:password@localhost:5432/cinelog_test?sslmode=require",
+            "postgresql+asyncpg://user:password@localhost:5432/cinelog_test?ssl=require",
+        ),
+        (
+            "postgres://user:password@localhost:5432/cinelog_test?sslmode=require",
+            "postgresql+asyncpg://user:password@localhost:5432/cinelog_test?ssl=require",
+        ),
+        (
+            "postgresql+asyncpg://user:password@localhost:5432/cinelog_test?ssl=true&sslmode=require",
+            "postgresql+asyncpg://user:password@localhost:5432/cinelog_test?ssl=true",
+        ),
     ],
 )
 def test_get_database_url_normalizes_hosted_postgres_urls(monkeypatch, database_url, expected):

--- a/tests/units/db/test_postgres.py
+++ b/tests/units/db/test_postgres.py
@@ -50,3 +50,26 @@ async def test_get_async_session_yields_async_session(monkeypatch):
 
     async with postgres.get_async_session() as session:
         assert isinstance(session, AsyncSession)
+
+
+@pytest.mark.parametrize(
+    ("database_url", "expected"),
+    [
+        (
+            "postgresql+asyncpg://user:password@localhost:5432/cinelog_test",
+            "postgresql+asyncpg://user:password@localhost:5432/cinelog_test",
+        ),
+        (
+            "postgresql://user:password@localhost:5432/cinelog_test",
+            "postgresql+asyncpg://user:password@localhost:5432/cinelog_test",
+        ),
+        (
+            "postgres://user:password@localhost:5432/cinelog_test",
+            "postgresql+asyncpg://user:password@localhost:5432/cinelog_test",
+        ),
+    ],
+)
+def test_get_database_url_normalizes_hosted_postgres_urls(monkeypatch, database_url, expected):
+    monkeypatch.setenv("DATABASE_URL", database_url)
+
+    assert postgres.get_database_url(required=True) == expected


### PR DESCRIPTION
## Summary

- normalize hosted `DATABASE_URL` values from `postgres://...` and `postgresql://...` to `postgresql+asyncpg://...`
- translate hosted Postgres `sslmode=require` query params to asyncpg-compatible `ssl=require`
- make Alembic use the same database URL loader as runtime code
- document accepted external PostgreSQL URL forms
- add unit coverage for URL normalization

## Verification

- `make lint`
- `make typecheck`
- `make test-unit`
- `DATABASE_URL=postgresql://cinelog:cinelog@db.example:5432/cinelog_db MONGODB_URI=mongodb://source.example:27017/cinelog_db docker compose -f docker-compose.prod.yml config --quiet`
- `JWT_SECRET_KEY=test-jwt-secret-key-for-check RATE_LIMIT_HMAC_SECRET=test-rate-limit-secret DATABASE_URL=postgresql://cinelog:cinelog@db.example:5432/cinelog_db uv run alembic upgrade head --sql`
- `JWT_SECRET_KEY=test-jwt-secret-key-for-check RATE_LIMIT_HMAC_SECRET=test-rate-limit-secret DATABASE_URL='postgresql+asyncpg://cinelog:cinelog@db.example:5432/cinelog_db?sslmode=require' uv run alembic upgrade head --sql`

Closes #175
