### PR TITLE
fix(deploy): attach prod compose services to external network for managed PostgreSQL

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -8,6 +8,9 @@ x-app-env: &app-env
     DATABASE_URL: ${DATABASE_URL:?Set DATABASE_URL to the external PostgreSQL database}
     MONGODB_URI: ${MONGODB_URI:?Set MONGODB_URI to the source MongoDB before production data migration}
     REDIS_URL: redis://redis:6379/0
+  networks:
+    - default
+    - coolify
 
 services:
   db-migrate:
@@ -53,3 +56,8 @@ services:
 
 volumes:
   redis_data:
+
+networks:
+  default:
+  coolify:
+    external: true

--- a/docs/technical/postgres-migration.md
+++ b/docs/technical/postgres-migration.md
@@ -124,6 +124,24 @@ make docker-prod-up
 
 The `db-migrate` service is idempotent: Alembic skips already-applied schema revisions, and `db_migrations.runner` skips data migrations recorded in `data_migration_versions`.
 
+### Reaching a managed PostgreSQL on an external Docker network
+
+Some managed PostgreSQL setups expose the database only through an internal container hostname (for example `dddkln2s1wv5ouou7sobil35ob4`) that is **resolvable solely on the platform's shared Docker network**. Running the prod stack on its own isolated bridge network then causes the migration to fail with:
+
+```
+socket.gaierror: [Errno -3] Temporary failure in name resolution
+```
+
+`docker-compose.prod.yml` therefore attaches the `db-migrate` and `api` services to an external network (while keeping `redis` reachable on `default`). Confirm the network name on the host before deploying and update the `networks:` block to match it:
+
+```bash
+docker network ls
+```
+
+If the declared external network does not exist on the host, Compose fails with `network <name> declared as external, but could not be found`.
+
+Alternatively, if the database can be exposed publicly, set `DATABASE_URL` to its public connection string. This avoids the shared network but exposes the database to the internet, so protect it with the host firewall and a strong password.
+
 ## Deterministic IDs
 
 During migration, PostgreSQL IDs derived from MongoDB documents must use the shared helper:


### PR DESCRIPTION
## Summary

The production migration (`db-migrate` in `docker-compose.prod.yml`) failed against a managed PostgreSQL whose `DATABASE_URL` host is an internal container name resolvable only on the platform's shared Docker network:

```
socket.gaierror: [Errno -3] Temporary failure in name resolution
```

The prod stack ran on its own isolated bridge network, so `db-migrate` and `api` could not resolve the database hostname. This attaches both services to the external network so the internal host resolves, while keeping `redis` on `default`.

## Changes

- `docker-compose.prod.yml`: attach `db-migrate` and `api` to an external network (`default` + external); declare the external network. `redis` stays on `default`, and `api` bridges both so it still reaches `redis` by service name. Database stays private — no public exposure required.
- `docs/technical/postgres-migration.md`: document the external-network requirement, how to verify the network name, and the public-URL alternative.

## Verification

- Pre-commit checks pass (Ruff lint, Ruff format, mypy).
- Diff vs `main` limited to the compose network wiring and docs.

Closes #177