### PR TITLE
fix(deploy): rename bundled Redis to avoid shared-network hostname collision

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -7,7 +7,7 @@ x-app-env: &app-env
     DB_BACKEND: postgres
     DATABASE_URL: ${DATABASE_URL:?Set DATABASE_URL to the external PostgreSQL database}
     MONGODB_URI: ${MONGODB_URI:?Set MONGODB_URI to the source MongoDB before production data migration}
-    REDIS_URL: redis://redis:6379/0
+    REDIS_URL: redis://cinelog-redis:6379/0
   networks:
     - default
     - coolify
@@ -33,7 +33,7 @@ services:
     depends_on:
       db-migrate:
         condition: service_completed_successfully
-      redis:
+      cinelog-redis:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:5009/')"]
@@ -43,7 +43,7 @@ services:
       start_period: 20s
     restart: unless-stopped
 
-  redis:
+  cinelog-redis:
     image: redis:7-alpine
     volumes:
       - redis_data:/data

--- a/docs/technical/postgres-migration.md
+++ b/docs/technical/postgres-migration.md
@@ -140,6 +140,8 @@ docker network ls
 
 If the declared external network does not exist on the host, Compose fails with `network <name> declared as external, but could not be found`.
 
+Because the `api` service then sits on both the project network and the shared external network, bare service hostnames can collide with other containers on the shared network. The bundled cache is therefore named `cinelog-redis` (not `redis`) so it can never resolve to an unrelated, password-protected Redis on the shared network. Keep `REDIS_URL` pointed at this project-unique hostname.
+
 Alternatively, if the database can be exposed publicly, set `DATABASE_URL` to its public connection string. This avoids the shared network but exposes the database to the internet, so protect it with the host firewall and a strong password.
 
 ## Deterministic IDs


### PR DESCRIPTION
## Summary

Regression from #178. Attaching `api` to the external shared network put it on two networks, so the bare hostname `redis` in `REDIS_URL` resolved to an unrelated, password-protected Redis on the shared network instead of the bundled cache. Startup then failed:

```
redis.exceptions.AuthenticationError: Authentication required.
RuntimeError: Redis is not reachable — cannot start the application
```

## Changes

- `docker-compose.prod.yml`: rename bundled cache service `redis` → `cinelog-redis` (project-unique hostname); update `REDIS_URL` and `depends_on` accordingly.
- `docs/technical/postgres-migration.md`: document the collision caveat.

## Deploy note

The cache container is recreated under the new name; bring the stack down and up so the `redis_data` volume reattaches:

```bash
docker compose -f docker-compose.prod.yml down
docker compose -f docker-compose.prod.yml up -d --build
```

Closes #179