### PR TITLE
refactor(logs): type LogCreateRequest.movie_id as UUID

### DIFF
--- a/app/repository/postgres_log_repository.py
+++ b/app/repository/postgres_log_repository.py
@@ -24,12 +24,10 @@ class PostgresLogRepository(RepositoryBase):
         if create_log_request.movie_id is None:
             raise ValueError("movie_id is required")
 
-        movie_id = UUID(create_log_request.movie_id)
-
         async with self._session_provider() as session:
             log = PostgresLog(
                 user_id=user_id,
-                movie_id=movie_id,
+                movie_id=create_log_request.movie_id,
                 tmdb_id=create_log_request.tmdb_id,
                 date_watched=to_utc_datetime(create_log_request.date_watched),
                 viewing_notes=create_log_request.viewing_notes,

--- a/app/schemas/log_schemas.py
+++ b/app/schemas/log_schemas.py
@@ -9,7 +9,7 @@ from app.types import WatchedWhereStr
 
 
 class LogCreateRequest(BaseSchema):
-    movie_id: str | None = Field(None, description="Unique identifier of the movie (auto-generated from tmdbId)")
+    movie_id: UUID | None = Field(None, description="Unique identifier of the movie (auto-generated from tmdbId)")
     tmdb_id: int = Field(..., description="TMDB ID of the movie")
     date_watched: date = Field(..., description="Date when the movie was watched")
     viewing_notes: str | None = Field(None, description="Optional notes about this viewing")

--- a/app/services/log_service.py
+++ b/app/services/log_service.py
@@ -73,7 +73,7 @@ class LogService:
         """
         movie: PostgresMovie = await self.movie_service.find_or_create_movie(tmdb_id=request.tmdb_id)
 
-        request.movie_id = str(movie.id)
+        request.movie_id = movie.id
 
         if not request.poster_path and movie.poster_path:
             request.poster_path = movie.poster_path

--- a/tests/units/repository/test_log_cache_repository.py
+++ b/tests/units/repository/test_log_cache_repository.py
@@ -242,7 +242,7 @@ async def test_create_log_invalidates_user_and_movie_lists():
     inner_repository.create_log.return_value = log
     repository = LogCacheRepository(inner_repository)
     request = LogCreateRequest(
-        movie_id=str(log.movie_id),
+        movie_id=log.movie_id,
         tmdb_id=log.tmdb_id,
         date_watched=log.date_watched.date(),
         watched_where=log.watched_where,
@@ -390,7 +390,7 @@ async def test_invalidation_failure_does_not_raise():
     inner_repository.create_log.return_value = log
     repository = LogCacheRepository(inner_repository)
     request = LogCreateRequest(
-        movie_id=str(log.movie_id),
+        movie_id=log.movie_id,
         tmdb_id=log.tmdb_id,
         date_watched=log.date_watched.date(),
         watched_where=log.watched_where,

--- a/tests/units/repository/test_postgres_log_repository.py
+++ b/tests/units/repository/test_postgres_log_repository.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from contextlib import asynccontextmanager
 from datetime import UTC, date, datetime
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 import pytest_asyncio
@@ -92,7 +92,7 @@ async def _seed_fk_entities(seed_session: AsyncSession) -> tuple[PostgresUser, P
 
 
 def _create_request(
-    movie_id: str,
+    movie_id: UUID,
     *,
     tmdb_id: int,
     date_watched: date = date(2024, 1, 2),
@@ -116,7 +116,7 @@ async def test_create_log_persists_row(repository: PostgresLogRepository, seed_s
 
     log = await repository.create_log(
         user.id,
-        _create_request(str(movie.id), tmdb_id=movie.tmdb_id),
+        _create_request(movie.id, tmdb_id=movie.tmdb_id),
     )
 
     assert log.id is not None


### PR DESCRIPTION
## Summary

Closes #152.

#152 (and #61) asked to normalize internal ID typing, originally targeting Mongo's `PydanticObjectId`. The PostgreSQL migration (#130) already normalized everything to `UUID` end-to-end — `auth_dependency` returns `UUID`, controllers/services/repositories use `UUID` throughout, and `to_object_id`/`PydanticObjectId` are gone entirely.

This PR fixes the one remaining gap, the exact field both issues flagged: `LogCreateRequest.movie_id` was still typed `str | None`, causing a wasteful `UUID -> str -> UUID` round-trip:

- `LogService.create_log` stringified the movie UUID into the request
- `PostgresLogRepository.create_log` parsed it back with `UUID(...)`

## Changes

- `app/schemas/log_schemas.py` — `LogCreateRequest.movie_id: str | None` → `UUID | None`
- `app/services/log_service.py` — assign `movie.id` directly, no `str()`
- `app/repository/postgres_log_repository.py` — use `create_log_request.movie_id` directly, drop the `UUID(...)` re-parse (the `None` guard stays)
- Tests updated to pass UUIDs without `str()` wrappers

## Boundary rule (per #152)

- External API payloads still accept/emit string UUIDs — Pydantic coerces JSON strings to `UUID` on input, and response schemas keep `str` IDs. No public API change.
- Token/cookie values (`set_auth_cookies`) intentionally remain strings.

## Verification

- `uv run pytest tests/units/repository/test_log_cache_repository.py tests/units/services/test_log_service.py tests/units/schemas/test_log_schemas.py tests/units/controllers/test_log_controller.py` — 65 passed
- `make lint` / `make typecheck` — clean
- Postgres-backed repository tests rely on CI (no local `postgres` binary)