### PR TITLE
fix(security): strip request input from validation error responses

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,6 +1,7 @@
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from slowapi.errors import RateLimitExceeded
@@ -22,6 +23,7 @@ from app.services.cache_service import CacheService
 from app.services.tmdb_service import TMDBService
 from app.utils.exceptions_utils import AppException
 from app.utils.rate_limit_utils import rate_limit_exceeded_handler
+from app.utils.validation_error_utils import sanitize_validation_errors
 
 
 @asynccontextmanager
@@ -65,6 +67,15 @@ async def app_exception_handler(request: Request, exc: AppException):
             "error_message": exc.error.error_message,
             "error_description": exc.error.error_description,
         },
+    )
+
+
+@app.exception_handler(RequestValidationError)
+async def validation_exception_handler(request: Request, exc: RequestValidationError):
+    """Return 422 details without echoing the submitted request values."""
+    return JSONResponse(
+        status_code=422,
+        content={"detail": sanitize_validation_errors(exc.errors())},
     )
 
 

--- a/app/utils/validation_error_utils.py
+++ b/app/utils/validation_error_utils.py
@@ -1,0 +1,34 @@
+"""Sanitization of request validation errors before they are returned to clients."""
+
+from collections.abc import Sequence
+from typing import Any, cast
+
+from fastapi.encoders import jsonable_encoder
+
+# Echoing the submitted value back would leak credentials (passwords, reset
+# codes) into browser devtools, proxy/WAF logs, and monitoring tools, so the
+# whole field is dropped instead of redacting a denylist of keys.
+_STRIPPED_KEYS = {"input", "url"}
+
+
+def sanitize_validation_errors(errors: Sequence[Any]) -> list[Any]:
+    """Return validation error entries without the submitted request values.
+
+    Keeps ``type``, ``loc``, ``msg``, and ``ctx`` so clients retain full
+    field-level feedback.
+    """
+
+    sanitized = [
+        {key: _encode_value(value) for key, value in error.items() if key not in _STRIPPED_KEYS} for error in errors
+    ]
+    return cast(list[Any], jsonable_encoder(sanitized))
+
+
+def _encode_value(value: Any) -> Any:
+    # Custom validators surface as ``ctx: {"error": ValueError(...)}``, which
+    # jsonable_encoder would flatten to an empty dict instead of the message.
+    if isinstance(value, dict):
+        return {key: _encode_value(inner) for key, inner in value.items()}
+    if isinstance(value, Exception):
+        return str(value)
+    return value

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,7 @@ Developer-facing documentation covering infrastructure, implementation details, 
 | [Service Dependencies](technical/service-dependencies.md) | Service providers, FastAPI `Depends` wiring, test overrides |
 | [Stats Caching](technical/stats-caching.md) | Stats caching strategy, TTL, and invalidation triggers |
 | [TMDB Service](technical/tmdb-service.md) | Singleton lifecycle, HTTP client, cache keys, MovieService integration |
+| [Validation Error Sanitization](technical/validation-error-sanitization.md) | Why 422 responses never echo submitted request values |
 
 ## Quick Links
 

--- a/docs/technical/validation-error-sanitization.md
+++ b/docs/technical/validation-error-sanitization.md
@@ -1,0 +1,40 @@
+# Validation Error Sanitization
+
+## Problem
+
+FastAPI's default `RequestValidationError` handler echoes the submitted request payload back in each 422 error entry's `input` field. For auth endpoints this leaked cleartext passwords and reset codes into browser devtools, proxy/WAF/CDN logs, and monitoring tools (security audit finding, issue #24).
+
+## Behavior
+
+A custom `RequestValidationError` handler in `app/__init__.py` returns the standard `{"detail": [...]}` shape but strips the `input` echo (and pydantic's docs `url`) from every entry via `sanitize_validation_errors()` in `app/utils/validation_error_utils.py`. Dropping the field entirely — instead of redacting a denylist of sensitive keys — means newly added fields can never leak by omission.
+
+Clients keep full field-level feedback through `type`, `loc`, `msg`, and `ctx`:
+
+```json
+{
+  "detail": [
+    {
+      "type": "value_error",
+      "loc": ["body", "email"],
+      "msg": "value is not a valid email address: An email address must have an @-sign.",
+      "ctx": { "reason": "An email address must have an @-sign." }
+    },
+    { "type": "missing", "loc": ["body", "dateOfBirth"], "msg": "Field required" }
+  ]
+}
+```
+
+## Implementation notes
+
+- `ctx` values that are exceptions (custom `@field_validator`s raising `ValueError`) are stringified before JSON encoding — `jsonable_encoder` alone would flatten them to `{}`.
+- The handler applies app-wide: every endpoint's 422 response is sanitized, not just auth routes.
+
+## Tests
+
+- `tests/units/utils/test_validation_error_utils.py` — sanitizer unit tests
+- `tests/units/controllers/test_auth_controller.py` — register/login/reset-password 422 responses contain no submitted secrets
+- `tests/e2e/test_auth_e2e.py::test_validation_error_does_not_echo_password` — full-stack regression
+
+## See Also
+
+- [Authentication (technical)](authentication.md)

--- a/tests/e2e/test_auth_e2e.py
+++ b/tests/e2e/test_auth_e2e.py
@@ -119,6 +119,23 @@ class TestAuthE2E:
 
         assert response.status_code == 422  # Validation error
 
+    async def test_validation_error_does_not_echo_password(self, async_client):
+        """422 responses must not leak submitted credentials (issue #24)."""
+        response = await async_client.post(
+            "/v1/auth/register",
+            json={
+                "email": "not-an-email",
+                "password": "SuperSecret1!",
+                "firstName": "Test",
+                "lastName": "User",
+                "handle": "testuser",
+            },
+        )
+
+        assert response.status_code == 422
+        assert "SuperSecret1!" not in response.text
+        assert all("input" not in error for error in response.json()["detail"])
+
     async def test_login_success(self, async_client):
         """Test successful user login."""
         await async_client.post(

--- a/tests/units/controllers/test_auth_controller.py
+++ b/tests/units/controllers/test_auth_controller.py
@@ -89,6 +89,52 @@ class TestAuthController:
 
         assert response.status_code == 422  # Validation error
 
+    def test_register_validation_error_does_not_echo_password(self, client):
+        """Validation errors must not leak the submitted password (issue #24)."""
+        response = client.post(
+            "/v1/auth/register",
+            json={
+                "email": "not-an-email",
+                "password": "SuperSecret1!",
+                "handle": "validhandle",
+                "firstName": "Tony",
+                "lastName": "B",
+            },
+        )
+
+        assert response.status_code == 422
+        assert "SuperSecret1!" not in response.text
+        details = response.json()["detail"]
+        assert all("input" not in error for error in details)
+        assert all("loc" in error and "msg" in error for error in details)
+
+    def test_login_validation_error_does_not_echo_password(self, client):
+        """Missing-field errors must not echo the payload containing the password."""
+        response = client.post(
+            "/v1/auth/login",
+            json={"password": "SuperSecret1!"},  # email missing
+        )
+
+        assert response.status_code == 422
+        assert "SuperSecret1!" not in response.text
+        assert all("input" not in error for error in response.json()["detail"])
+
+    def test_reset_password_validation_error_does_not_echo_secrets(self, client):
+        """Field-level errors must not echo the new password or reset code."""
+        response = client.post(
+            "/v1/auth/reset-password",
+            json={
+                "email": "test@example.com",
+                "code": "reset-code-123",
+                "newPassword": "Pw1!",  # violates min_length=8
+            },
+        )
+
+        assert response.status_code == 422
+        assert "Pw1!" not in response.text
+        assert "reset-code-123" not in response.text
+        assert all("input" not in error for error in response.json()["detail"])
+
     @patch.object(get_auth_service(), "forgot_password", new_callable=AsyncMock)
     def test_forgot_password_success(self, mock_forgot_password, client):
         """Test successful forgot-password request."""

--- a/tests/units/utils/test_validation_error_utils.py
+++ b/tests/units/utils/test_validation_error_utils.py
@@ -1,0 +1,78 @@
+"""Unit tests for validation error sanitization."""
+
+from app.utils.validation_error_utils import sanitize_validation_errors
+
+
+def test_strips_dict_input_from_body_level_error():
+    errors = [
+        {
+            "type": "missing",
+            "loc": ("body", "dateOfBirth"),
+            "msg": "Field required",
+            "input": {"email": "not-an-email", "password": "SuperSecret1!"},
+        }
+    ]
+
+    sanitized = sanitize_validation_errors(errors)
+
+    assert sanitized == [{"type": "missing", "loc": ["body", "dateOfBirth"], "msg": "Field required"}]
+
+
+def test_strips_scalar_input_from_field_level_error():
+    errors = [
+        {
+            "type": "string_too_short",
+            "loc": ("body", "password"),
+            "msg": "String should have at least 8 characters",
+            "input": "short",
+            "ctx": {"min_length": 8},
+        }
+    ]
+
+    sanitized = sanitize_validation_errors(errors)
+
+    assert sanitized[0] == {
+        "type": "string_too_short",
+        "loc": ["body", "password"],
+        "msg": "String should have at least 8 characters",
+        "ctx": {"min_length": 8},
+    }
+
+
+def test_strips_pydantic_docs_url():
+    errors = [
+        {
+            "type": "missing",
+            "loc": ("body",),
+            "msg": "Field required",
+            "input": None,
+            "url": "https://errors.pydantic.dev/2/v/missing",
+        }
+    ]
+
+    sanitized = sanitize_validation_errors(errors)
+
+    assert sanitized == [{"type": "missing", "loc": ["body"], "msg": "Field required"}]
+
+
+def test_entry_without_input_is_unchanged():
+    errors = [{"type": "json_invalid", "loc": ("body",), "msg": "JSON decode error"}]
+
+    assert sanitize_validation_errors(errors) == [{"type": "json_invalid", "loc": ["body"], "msg": "JSON decode error"}]
+
+
+def test_non_serializable_ctx_is_json_encoded():
+    errors = [
+        {
+            "type": "value_error",
+            "loc": ("body", "handle"),
+            "msg": "Value error, invalid handle",
+            "input": "bad handle",
+            "ctx": {"error": ValueError("invalid handle")},
+        }
+    ]
+
+    sanitized = sanitize_validation_errors(errors)
+
+    assert sanitized[0]["ctx"] == {"error": "invalid handle"}
+    assert "input" not in sanitized[0]


### PR DESCRIPTION
## Summary

Closes #24.

Security audit finding (HIGH): FastAPI's default `RequestValidationError` handler echoes the submitted payload back in each 422 error entry's `input` field — including cleartext passwords on register/login and reset codes on password reset. These responses land in browser devtools, proxy/WAF/CDN logs, and monitoring tools.

## Approach

Drop the `input` echo entirely (along with pydantic's docs `url`) rather than redacting a denylist of sensitive keys: secure by default, nothing to maintain, and future sensitive fields can never leak by omission. The response keeps FastAPI's standard `{"detail": [...]}` shape with `type`, `loc`, `msg`, and `ctx`, so clients retain full field-level feedback.

**Before:**
```json
{"type": "missing", "loc": ["body", "dateOfBirth"], "msg": "Field required",
 "input": {"email": "not-an-email", "password": "SuperSecret1!", ...}}
```

**After:**
```json
{"type": "missing", "loc": ["body", "dateOfBirth"], "msg": "Field required"}
```

## Changes

- `app/utils/validation_error_utils.py` (new) — `sanitize_validation_errors()`; exception values in `ctx` (custom `@field_validator`s raising `ValueError`) are stringified, since `jsonable_encoder` alone flattens them to `{}`
- `app/__init__.py` — custom `RequestValidationError` handler registered next to the existing `AppException` handler
- Docs: `docs/technical/validation-error-sanitization.md` + index row in `docs/README.md`

## Tests

- 5 sanitizer unit tests (`tests/units/utils/test_validation_error_utils.py`)
- 3 controller tests asserting register/login/reset-password 422 responses contain no submitted secrets
- 1 e2e regression test (`test_auth_e2e.py::test_validation_error_does_not_echo_password`)

## Verification

- Reproduced the leak live against a locally running instance, then confirmed the same request returns no `input` after the fix
- `make lint` / `make typecheck` — clean
- `uv run pytest tests/units` — 373 mock-based tests pass locally (Postgres-backed repository tests run in CI)
- `make test-e2e` — 74 passed