### PR TITLE
ci: add linear commit history check

### DIFF
--- a/.github/workflows/linear-commit-history.yml
+++ b/.github/workflows/linear-commit-history.yml
@@ -1,0 +1,25 @@
+name: Linear Commit History Check
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  linear-commit-history:
+    name: Linear Commit History Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require a single commit
+        env:
+          COMMIT_COUNT: ${{ github.event.pull_request.commits }}
+        run: |
+          if [ "$COMMIT_COUNT" -ne 1 ]; then
+            echo "::error title=Linear commit history required::Pull requests must contain exactly one commit; found $COMMIT_COUNT. Squash the branch commits and push the rewritten branch."
+            exit 1
+          fi
+
+          echo "Pull request contains exactly one commit."


### PR DESCRIPTION
## Summary

- add a dedicated `Linear Commit History Check` for pull requests targeting `main`
- pass only when the pull request contains exactly one commit
- fail with a clear instruction to squash and force-push when multiple commits are present
- keep the implementation entirely within GitHub Actions without checkout, dependencies, or application code

## Impact

After this workflow is merged, the repository ruleset can require the stable `Linear Commit History Check` status before merging.

The ruleset requirement must be enabled after this PR reaches `main`; requiring it beforehand would leave the introducing PR without an available required check.

## Validation

- one-commit shell condition passes
- multiple-commit shell condition fails
- `make lint` passes
- `make format-check` passes
- `make typecheck` passes
- branch remains exactly one commit ahead of `main`

Closes #189