### PR TITLE
refactor(profile): rename friends_only visibility to followers_only

### DIFF
--- a/alembic/versions/005_rename_profile_visibility.py
+++ b/alembic/versions/005_rename_profile_visibility.py
@@ -1,0 +1,33 @@
+"""rename friends-only profile visibility to followers-only
+
+Revision ID: 005_rename_profile_visibility
+Revises: 004_create_logs_table
+Create Date: 2026-07-16 00:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "005_rename_profile_visibility"
+down_revision: str | Sequence[str] | None = "004_create_logs_table"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+CONSTRAINT_NAME = "ck_users_profile_visibility"
+OLD_CONSTRAINT = "profile_visibility IN ('public', 'friends_only', 'private')"
+NEW_CONSTRAINT = "profile_visibility IN ('public', 'followers_only', 'private')"
+
+
+def upgrade() -> None:
+    """Replace the legacy friends-only value with followers-only."""
+    op.drop_constraint(CONSTRAINT_NAME, "users", type_="check")
+    op.execute("UPDATE users SET profile_visibility = 'followers_only' WHERE profile_visibility = 'friends_only'")
+    op.create_check_constraint(CONSTRAINT_NAME, "users", NEW_CONSTRAINT)
+
+
+def downgrade() -> None:
+    """Restore the legacy friends-only value and constraint."""
+    op.drop_constraint(CONSTRAINT_NAME, "users", type_="check")
+    op.execute("UPDATE users SET profile_visibility = 'friends_only' WHERE profile_visibility = 'followers_only'")
+    op.create_check_constraint(CONSTRAINT_NAME, "users", OLD_CONSTRAINT)

--- a/app/schemas/auth_schemas.py
+++ b/app/schemas/auth_schemas.py
@@ -18,7 +18,7 @@ class RegisterRequest(BaseSchema):
     date_of_birth: date = Field(..., description="Date of birth in YYYY-MM-DD format")
     profile_visibility: ProfileVisibilityStr = Field(
         default="private",
-        description="Profile visibility setting (public, friends_only, private)",
+        description="Profile visibility setting (public, followers_only, private)",
     )
     verification_code: str | None = Field(
         None,
@@ -47,7 +47,10 @@ class RegisterResponse(BaseSchema):
     email: EmailStr = Field(..., description="User's email address")
     handle: str = Field(..., description="User's unique handle")
     bio: str | None = Field(None, description="User biography")
-    profile_visibility: ProfileVisibilityStr = Field(..., description="Profile visibility setting")
+    profile_visibility: ProfileVisibilityStr = Field(
+        ...,
+        description="Profile visibility setting (public, followers_only, private)",
+    )
 
 
 class LoginRequest(BaseSchema):

--- a/app/schemas/user_schemas.py
+++ b/app/schemas/user_schemas.py
@@ -21,7 +21,7 @@ class UserCreateRequest(BaseSchema):
     password_hash: str | None = Field(None, description="Hashed password for local auth")
     profile_visibility: ProfileVisibilityStr = Field(
         default="private",
-        description="Profile visibility setting (public, friends_only, private)",
+        description="Profile visibility setting (public, followers_only, private)",
     )
 
 
@@ -33,7 +33,10 @@ class UserCreateResponse(BaseSchema):
     handle: str
     bio: str | None = None
     date_of_birth: date
-    profile_visibility: ProfileVisibilityStr = Field(..., description="Profile visibility setting")
+    profile_visibility: ProfileVisibilityStr = Field(
+        ...,
+        description="Profile visibility setting (public, followers_only, private)",
+    )
 
 
 class UserResponse(BaseSchema):
@@ -44,7 +47,10 @@ class UserResponse(BaseSchema):
     handle: str
     bio: str | None = None
     date_of_birth: date | None = None
-    profile_visibility: ProfileVisibilityStr = Field(..., description="Profile visibility setting")
+    profile_visibility: ProfileVisibilityStr = Field(
+        ...,
+        description="Profile visibility setting (public, followers_only, private)",
+    )
 
 
 class UpdateProfileRequest(BaseSchema):
@@ -53,7 +59,7 @@ class UpdateProfileRequest(BaseSchema):
     bio: BioStr = Field(None, description="User biography")
     date_of_birth: date | None = Field(None, description="Date of birth in YYYY-MM-DD format")
     profile_visibility: ProfileVisibilityStr | None = Field(
-        None, description="Profile visibility setting (public, friends_only, private)"
+        None, description="Profile visibility setting (public, followers_only, private)"
     )
 
 
@@ -62,7 +68,10 @@ class UserProfileResponse(BaseSchema):
     last_name: str = Field(..., description="User's last name")
     handle: str = Field(..., description="User's unique handle")
     bio: str | None = Field(None, description="User biography")
-    profile_visibility: ProfileVisibilityStr = Field(..., description="Profile visibility setting")
+    profile_visibility: ProfileVisibilityStr = Field(
+        ...,
+        description="Profile visibility setting (public, followers_only, private)",
+    )
     date_of_birth: date | None = Field(
         None,
         description="Date of birth (visible on public profiles or to the profile owner)",

--- a/app/types/user_validation.py
+++ b/app/types/user_validation.py
@@ -9,7 +9,7 @@ Types:
     NameStr              — required name field (1–50 chars, validated characters)
     HandleStr            — required handle field (3–20 chars, alphanumeric + underscore)
     BioStr               — optional bio field (None or up to 500 chars, HTML stripped)
-    ProfileVisibilityStr — required profile visibility ("public", "friends_only", "private")
+    ProfileVisibilityStr — required profile visibility ("public", "followers_only", "private")
 """
 
 from typing import Annotated
@@ -18,7 +18,7 @@ from pydantic import AfterValidator, StringConstraints
 
 from app.utils.sanitize_utils import HANDLE_PATTERN, NAME_PATTERN, strip_html_tags
 
-PROFILE_VISIBILITY_CHOICES = ("public", "friends_only", "private")
+PROFILE_VISIBILITY_CHOICES = ("public", "followers_only", "private")
 
 
 def validate_name(v: str) -> str:

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,7 @@ Developer-facing documentation covering infrastructure, implementation details, 
 | [Deployment Options](technical/deployment-options.md) | VPS and optional Vercel deployment guidance |
 | [E2E Testing](technical/e2e-testing.md) | Setup and run end-to-end tests |
 | [Postgres Migration](technical/postgres-migration.md) | PostgreSQL setup and the completed MongoDB → PostgreSQL migration |
-| [Profile Visibility](technical/profile-visibility.md) | Visibility field, service logic, migration, and friends-only stub |
+| [Profile Visibility](technical/profile-visibility.md) | Visibility field, service logic, migration, and followers-only authorization stub |
 | [Pydantic Types and Validators](technical/pydantic_types_and_validators.md) | Reusable Annotated validation types by domain |
 | [Rate Limiting](technical/rate-limiting.md) | slowapi setup, Redis backend, endpoint decoration, test strategy |
 | [Redis Caching](technical/redis-caching.md) | Cache layer configuration, design, and usage |

--- a/docs/functional/profile-visibility.md
+++ b/docs/functional/profile-visibility.md
@@ -7,7 +7,7 @@ Users can control who sees their profile and movie logs through a visibility set
 | Level | Profile Info | Movie Logs |
 |---|---|---|
 | `public` | Full (name, handle, bio, date of birth) | Accessible to all authenticated users |
-| `friends_only` | Basic (name, handle, bio) — date of birth hidden | Hidden (same as private until friends system is built) |
+| `followers_only` | Basic (name, handle, bio) — date of birth hidden | Hidden (same as private until follower authorization is built) |
 | `private` | Basic (name, handle, bio) — date of birth hidden | Hidden |
 
 **Note:** Email and password are never exposed to other users.
@@ -29,7 +29,7 @@ POST /v1/auth/register
   "password": "securepassword123",
   "handle": "johndoe",
   "dateOfBirth": "1990-01-01",
-  "profileVisibility": "public"
+  "profileVisibility": "followers_only"
 }
 ```
 
@@ -40,9 +40,17 @@ Update visibility via the profile settings endpoint:
 ```json
 PUT /v1/users/settings/profile
 {
-  "profileVisibility": "private"
+  "profileVisibility": "followers_only"
 }
 ```
+
+## Coordinated Release
+
+`followers_only` is a breaking replacement for `friends_only`; clients must not send the old value after this backend revision is deployed. Backend issue #195 and [cinelog_web#70](https://github.com/benincasantonio/cinelog_web/issues/70) therefore ship as one coordinated release.
+
+Deploy the backend first so its automatic database migration completes, then deploy the matching frontend immediately afterward. If registration or profile settings must remain available without any temporary client/server mismatch, place those writes in a short maintenance or read-only window during the deployment.
+
+Rollback also requires a maintenance window and coordinated old backend/frontend deployment. Operators must downgrade the database with the new backend image before restoring the old images; see the technical guide for the exact commands.
 
 ## Viewing Other Users' Profiles
 
@@ -60,7 +68,7 @@ Returns a `UserProfileResponse` based on the target user's visibility setting. A
 GET /v1/logs/{handle}
 ```
 
-Returns the user's movie logs if their profile is public or the requester is the profile owner. Returns **403** (`PROFILE_NOT_PUBLIC`) for private/friends-only profiles.
+Returns the user's movie logs if their profile is public or the requester is the profile owner. Returns **403** (`PROFILE_NOT_PUBLIC`) for private/followers-only profiles.
 
 ### Error Responses
 

--- a/docs/technical/postgres-migration.md
+++ b/docs/technical/postgres-migration.md
@@ -80,6 +80,18 @@ make db-schema-rollback
 
 Alembic is the only migration system. The Mongo→Postgres data migration targets (`db-data-migrate`, `migrate-all`, `postgres-migrate-all`, and their dry-run variants) were removed with the migration tooling once the production data migration completed.
 
+### Alembic migration test harness
+
+Migration tests use the shared `alembic_test_harness` pytest fixture from `tests/units/db/conftest.py`. The fixture provisions a unique PostgreSQL database with `pytest-postgresql`, points Alembic at that database, and removes it after the test.
+
+The `AlembicTestHarness` interface provides:
+
+- `upgrade(revision="head")` to run real Alembic upgrades
+- `downgrade(revision)` to test rollback behavior
+- `connect()` to seed legacy rows and inspect data or constraints with direct SQL
+
+A migration test should upgrade to the preceding revision, seed the old database shape, upgrade to the revision under test, and verify both data and schema behavior. Reversible migrations should also be downgraded and verified. Tests using this fixture remain part of `make test-unit` because they live under `tests/units/`.
+
 ## Production Compose Migration
 
 `docker-compose.prod.yml` includes a one-shot `db-migrate` service that runs before the API starts:

--- a/docs/technical/profile-visibility.md
+++ b/docs/technical/profile-visibility.md
@@ -4,15 +4,20 @@ Implementation details for the user profile visibility feature.
 
 ## Data Model
 
-The `User` model includes a `profile_visibility` field (alias: `profileVisibility`):
+The `User` model includes a `profile_visibility` column. API schemas expose it as `profileVisibility`:
 
 ```python
-profile_visibility: str = Field(default="private", alias="profileVisibility")
+profile_visibility: Mapped[str] = mapped_column(
+    Text,
+    nullable=False,
+    server_default=text("'private'"),
+    default="private",
+)
 ```
 
-Valid values: `"public"`, `"friends_only"`, `"private"`.
+Valid values: `"public"`, `"followers_only"`, `"private"`.
 
-Default is `"private"` for existing users (set via migration 002).
+The default is `"private"`.
 
 ## Validation
 
@@ -21,7 +26,7 @@ Default is `"private"` for existing users (set via migration 002).
 `RegisterRequest`, `UpdateProfileRequest`, and `UserCreateRequest` all use this type, so application-level writes are limited to:
 
 - `"public"`
-- `"friends_only"`
+- `"followers_only"`
 - `"private"`
 
 The PostgreSQL `users` table also enforces the same set with `CHECK (profile_visibility IN (...))`, so invalid values are rejected even if data bypasses Pydantic.
@@ -45,20 +50,79 @@ The old `GET /v1/users/{user_id}/logs` endpoint has been replaced by `GET /v1/lo
 
 `UserService` (in `app/services/user_service.py`) has one visibility-aware method:
 
-- `get_visible_profile(handle, requester_id)` — returns `UserProfileResponse`. Owner and public profiles get full data; private/friends-only profiles get `date_of_birth=None`.
+- `get_visible_profile(handle, requester_id)` — returns `UserProfileResponse`. Owner and public profiles get full data; private/followers-only profiles get `date_of_birth=None`.
 
 Both services compare `str(user.id) == str(requester_id)` for ownership detection.
 
 ## Migration
 
-`migrations/002_add_profile_visibility.py` sets `profileVisibility: "private"` on all existing users missing the field. The `down()` function unsets it.
+Alembic revision `002_create_users_table` creates the column with a `private` server default and the original visibility constraint.
 
-## Friends-Only Stub
+Revision `005_rename_profile_visibility` drops `ck_users_profile_visibility`, converts stored `friends_only` rows to `followers_only`, and recreates the constraint with the current values. Its downgrade reverses the conversion and restores the original constraint.
 
-`friends_only` is stored as a valid value but behaves identically to `private`. When a friends/follow system is implemented, the service layer checks can be updated without a schema or migration change.
+## Coordinated Deployment and Rollback
+
+The backend change and [cinelog_web#70](https://github.com/benincasantonio/cinelog_web/issues/70) are intentionally incompatible with their previous wire values. Use the following release order:
+
+1. Rehearse the migration against PostgreSQL before production:
+
+   ```bash
+   uv run pytest tests/units/db/test_profile_visibility_migration.py -v
+   make db-schema-migrate-dry-run
+   ```
+
+2. If a temporary client/server mismatch is unacceptable, enable maintenance or read-only mode for registration and profile settings.
+3. Deploy the new backend first. The production `db-migrate` service automatically runs `alembic upgrade head` before the API starts.
+4. Confirm the deployed image and database revision:
+
+   ```bash
+   docker compose -f docker-compose.prod.yml run --rm --no-deps db-migrate alembic current
+   ```
+
+   The revision must be `005_rename_profile_visibility`.
+
+5. Run the database smoke checks through the managed PostgreSQL console or a direct, `psql`-compatible production DSN:
+
+   ```bash
+   psql "$POSTGRES_DSN" <<'SQL'
+   SELECT profile_visibility, count(*)
+   FROM users
+   GROUP BY profile_visibility
+   ORDER BY profile_visibility;
+
+   SELECT pg_get_constraintdef(oid)
+   FROM pg_constraint
+   WHERE conrelid = 'users'::regclass
+     AND conname = 'ck_users_profile_visibility';
+   SQL
+   ```
+
+   The data query must contain no `friends_only` rows, and the constraint must allow only `public`, `followers_only`, and `private`. `POSTGRES_DSN` refers to the same database as `DATABASE_URL` but uses a driver-neutral PostgreSQL URI accepted by `psql`.
+
+6. With a smoke-test account, submit `profileVisibility: "followers_only"` through registration or `PUT /v1/users/settings/profile`; confirm the response returns `followers_only` and that `friends_only` receives `422`.
+7. Deploy the matching frontend immediately, then disable maintenance/read-only mode.
+
+Prefer roll-forward after revision `005` has reached production. If rollback is unavoidable:
+
+1. Enable maintenance mode for registration and profile settings.
+2. While the new backend image containing revision `005_rename_profile_visibility` is still deployed, downgrade explicitly:
+
+   ```bash
+   docker compose -f docker-compose.prod.yml run --rm --no-deps db-migrate alembic downgrade 004_create_logs_table
+   docker compose -f docker-compose.prod.yml run --rm --no-deps db-migrate alembic current
+   ```
+
+3. Confirm revision `004_create_logs_table`, verify rows were converted back to `friends_only`, and verify the restored check constraint.
+4. Deploy the old backend and old frontend together, then disable maintenance mode.
+
+Never deploy the old backend image before the downgrade: that image does not contain revision `005`, so its automatic migration job may be unable to resolve the database's current revision.
+
+## Followers-Only Authorization Stub
+
+`followers_only` currently behaves identically to `private`. A later epic ticket will grant accepted followers access by updating service-layer authorization; no further visibility-value rename will be required.
 
 ## See Also
 
 - [Functional: Profile Visibility](../functional/profile-visibility.md)
 - [Pydantic Types and Validators](pydantic_types_and_validators.md)
-- [Migrations](migrations.md)
+- [PostgreSQL Migration](postgres-migration.md)

--- a/docs/technical/pydantic_types_and_validators.md
+++ b/docs/technical/pydantic_types_and_validators.md
@@ -33,7 +33,7 @@ User-related validators used by `auth_schemas` and `user_schemas`.
 | `NameStr` | Required name (1–50 chars, letters/accents/hyphens only) |
 | `HandleStr` | Required handle (3–20 chars, alphanumeric + underscore, no leading digit; casing preserved) |
 | `BioStr` | Optional bio (`None` or up to 500 chars, HTML tags stripped) |
-| `ProfileVisibilityStr` | Required profile visibility (`public`, `friends_only`, or `private`) |
+| `ProfileVisibilityStr` | Required profile visibility (`public`, `followers_only`, or `private`) |
 
 ### log_validation.py
 

--- a/tests/alembic_test_harness.py
+++ b/tests/alembic_test_harness.py
@@ -1,0 +1,30 @@
+"""Reusable helpers for testing Alembic revisions against PostgreSQL."""
+
+from dataclasses import dataclass
+
+import psycopg
+from alembic.config import Config
+
+from alembic import command
+
+PostgresConnectionParams = dict[str, str | int]
+
+
+@dataclass(frozen=True)
+class AlembicTestHarness:
+    """Run Alembic commands and direct SQL against an isolated test database."""
+
+    config: Config
+    connection_params: PostgresConnectionParams
+
+    def upgrade(self, revision: str = "head") -> None:
+        """Upgrade the isolated database to a revision."""
+        command.upgrade(self.config, revision)
+
+    def downgrade(self, revision: str) -> None:
+        """Downgrade the isolated database to a revision."""
+        command.downgrade(self.config, revision)
+
+    def connect(self) -> psycopg.Connection:
+        """Open a synchronous connection for seeding and assertions."""
+        return psycopg.connect(**self.connection_params)

--- a/tests/e2e/test_log_e2e.py
+++ b/tests/e2e/test_log_e2e.py
@@ -608,34 +608,35 @@ class TestLogE2E:
         response = await async_client.delete("/v1/logs/00000000-0000-4000-8000-000000000000")
         assert response.status_code in [401, 403]
 
-    async def test_friends_only_profile_other_user_logs(self, async_client):
-        """Test that a friends-only profile's logs are not accessible by a non-friend."""
-        # Create User A with friends_only profile (no login needed)
+    async def test_followers_only_profile_other_user_logs(self, async_client):
+        """Test that a followers-only profile's logs are not accessible by another user."""
+        # Create User A with followers_only profile (no login needed)
         user_a = {
-            "email": "usera_friends_only@example.com",
+            "email": "usera_followers_only@example.com",
             "password": "securepassword123",
             "firstName": "UserA",
             "lastName": "Test",
-            "handle": "userafriendsonly",
+            "handle": "userafollowersonly",
             "dateOfBirth": "1990-01-01",
-            "profile_visibility": "friends_only",
+            "profileVisibility": "followers_only",
         }
         user_not_logged = await register(async_client, user_a)
         handle_user_not_logged = user_not_logged["handle"]
-        assert handle_user_not_logged == "userafriendsonly"
+        assert handle_user_not_logged == "userafollowersonly"
+        assert user_not_logged["profileVisibility"] == "followers_only"
 
         # Create User B and login
         user_b = {
-            "email": "userb_friends_only@example.com",
+            "email": "userb_followers_only@example.com",
             "password": "securepassword123",
             "firstName": "UserB",
             "lastName": "Test",
-            "handle": "userbfriendsonly",
+            "handle": "userbfollowersonly",
             "dateOfBirth": "1990-01-01",
-            "profile_visibility": "friends_only",
+            "profileVisibility": "followers_only",
         }
         login_b = await register_and_login(async_client, user_b)
-        assert login_b["handle"] == "userbfriendsonly"
+        assert login_b["handle"] == "userbfollowersonly"
 
         response = await async_client.get(f"/v1/logs/{handle_user_not_logged}")
 

--- a/tests/units/controllers/test_auth_controller.py
+++ b/tests/units/controllers/test_auth_controller.py
@@ -59,7 +59,7 @@ class TestAuthController:
             handle="johndoe",
             bio=None,
             user_id="user123",
-            profile_visibility="private",
+            profile_visibility="followers_only",
         )
 
         response = client.post(
@@ -71,7 +71,7 @@ class TestAuthController:
                 "lastName": "Doe",
                 "handle": "johndoe",
                 "dateOfBirth": "1990-01-01",
-                "profileVisibility": "private",
+                "profileVisibility": " FOLLOWERS_ONLY ",
                 "verificationCode": "ABC123",
             },
         )
@@ -81,7 +81,9 @@ class TestAuthController:
         assert data["email"] == "test@example.com"
         assert data["firstName"] == "John"
         assert data["handle"] == "johndoe"
-        mock_register.assert_called_once()
+        assert data["profileVisibility"] == "followers_only"
+        request = mock_register.await_args.kwargs["request"]
+        assert request.profile_visibility == "followers_only"
 
     @patch.object(get_auth_service(), "register", new_callable=AsyncMock)
     def test_register_with_exception(self, mock_register, client):

--- a/tests/units/controllers/test_user_controller.py
+++ b/tests/units/controllers/test_user_controller.py
@@ -79,8 +79,8 @@ class TestGetVisibleProfile:
             last_name="Doe",
             handle="johndoe",
             bio="A bio",
-            profile_visibility="public",
-            date_of_birth=date(1990, 1, 1),
+            profile_visibility="followers_only",
+            date_of_birth=None,
         )
 
         response = client.get(
@@ -94,7 +94,7 @@ class TestGetVisibleProfile:
         data = response.json()
         assert data["firstName"] == "John"
         assert data["handle"] == "johndoe"
-        assert data["profileVisibility"] == "public"
+        assert data["profileVisibility"] == "followers_only"
         mock_get_visible_profile.assert_awaited_once_with(handle="johndoe", requester_id="user123")
 
     def test_get_visible_profile_unauthorized(self, client):
@@ -163,12 +163,12 @@ class TestUpdateProfileController:
             handle="johndoe",
             bio=None,
             date_of_birth=date(1990, 1, 1),
-            profile_visibility="public",
+            profile_visibility="followers_only",
         )
 
         response = client.put(
             "/v1/users/settings/profile",
-            json={"profileVisibility": "public"},
+            json={"profileVisibility": " FOLLOWERS_ONLY "},
             cookies={
                 "__Host-access_token": "token",
                 "__Host-csrf_token": "test-token",
@@ -180,7 +180,9 @@ class TestUpdateProfileController:
 
         assert response.status_code == 200
         data = response.json()
-        assert data["profileVisibility"] == "public"
+        assert data["profileVisibility"] == "followers_only"
+        request = mock_update_profile.await_args.args[1]
+        assert request.profile_visibility == "followers_only"
 
     def test_update_profile_unauthorized(self, client):
         app.dependency_overrides = {}
@@ -228,6 +230,7 @@ class TestUpdateProfileController:
         app.dependency_overrides = {}
 
         assert response.status_code == 422
+        mock_update_profile.assert_not_awaited()
 
     @patch.object(get_user_service(), "update_profile", new_callable=AsyncMock)
     def test_update_profile_invalid_visibility(self, mock_update_profile, client, override_auth):
@@ -235,7 +238,7 @@ class TestUpdateProfileController:
 
         response = client.put(
             "/v1/users/settings/profile",
-            json={"profileVisibility": "hidden"},
+            json={"profileVisibility": "friends_only"},
             cookies={
                 "__Host-access_token": "token",
                 "__Host-csrf_token": "test-token",
@@ -246,6 +249,7 @@ class TestUpdateProfileController:
         app.dependency_overrides = {}
 
         assert response.status_code == 422
+        mock_update_profile.assert_not_awaited()
 
 
 class TestChangePasswordController:

--- a/tests/units/db/conftest.py
+++ b/tests/units/db/conftest.py
@@ -1,0 +1,49 @@
+"""Shared fixtures for PostgreSQL and Alembic database tests."""
+
+from collections.abc import Iterator
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from alembic.config import Config
+from pytest_postgresql.janitor import DatabaseJanitor
+from sqlalchemy import URL
+
+from tests.alembic_test_harness import AlembicTestHarness, PostgresConnectionParams
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+
+
+@pytest.fixture
+def alembic_test_harness(postgresql_proc, monkeypatch) -> Iterator[AlembicTestHarness]:
+    """Provide Alembic and SQL access to a fresh PostgreSQL database."""
+    database_name = f"cinelog_migration_test_{uuid4().hex[:8]}"
+    connection_params: PostgresConnectionParams = {
+        "host": postgresql_proc.host,
+        "port": postgresql_proc.port,
+        "user": postgresql_proc.user,
+        "password": postgresql_proc.password,
+        "dbname": database_name,
+    }
+
+    with DatabaseJanitor(
+        user=postgresql_proc.user,
+        host=postgresql_proc.host,
+        port=postgresql_proc.port,
+        dbname=database_name,
+        version=postgresql_proc.version,
+        password=postgresql_proc.password,
+    ):
+        database_url = URL.create(
+            "postgresql+asyncpg",
+            username=postgresql_proc.user,
+            password=postgresql_proc.password,
+            host=postgresql_proc.host,
+            port=postgresql_proc.port,
+            database=database_name,
+        )
+        monkeypatch.setenv("DATABASE_URL", database_url.render_as_string(hide_password=False))
+
+        config = Config(PROJECT_ROOT / "alembic.ini")
+        config.set_main_option("script_location", str(PROJECT_ROOT / "alembic"))
+        yield AlembicTestHarness(config=config, connection_params=connection_params)

--- a/tests/units/db/test_profile_visibility_migration.py
+++ b/tests/units/db/test_profile_visibility_migration.py
@@ -1,0 +1,87 @@
+"""Integration coverage for the profile-visibility Alembic migration."""
+
+import pytest
+from psycopg.errors import CheckViolation
+
+from tests.alembic_test_harness import AlembicTestHarness
+
+PREVIOUS_REVISION = "004_create_logs_table"
+
+
+def _insert_user(harness: AlembicTestHarness, *, email: str, handle: str, visibility: str) -> None:
+    with harness.connect() as connection:
+        connection.execute(
+            """
+            INSERT INTO users (email, handle, first_name, last_name, profile_visibility)
+            VALUES (%s, %s, 'Migration', 'Test', %s)
+            """,
+            (email, handle, visibility),
+        )
+
+
+def _profile_visibilities(harness: AlembicTestHarness) -> list[str]:
+    with harness.connect() as connection:
+        rows = connection.execute("SELECT profile_visibility FROM users ORDER BY email").fetchall()
+    return [row[0] for row in rows]
+
+
+def _constraint_definition(harness: AlembicTestHarness) -> str:
+    with harness.connect() as connection:
+        row = connection.execute(
+            """
+            SELECT pg_get_constraintdef(oid)
+            FROM pg_constraint
+            WHERE conrelid = 'users'::regclass
+              AND conname = 'ck_users_profile_visibility'
+            """
+        ).fetchone()
+    assert row is not None
+    return row[0]
+
+
+def test_profile_visibility_migration_converts_data_and_replaces_constraint(
+    alembic_test_harness: AlembicTestHarness,
+):
+    alembic_test_harness.upgrade(PREVIOUS_REVISION)
+    _insert_user(
+        alembic_test_harness,
+        email="legacy@example.com",
+        handle="legacyuser",
+        visibility="friends_only",
+    )
+
+    alembic_test_harness.upgrade()
+
+    assert _profile_visibilities(alembic_test_harness) == ["followers_only"]
+    upgraded_constraint = _constraint_definition(alembic_test_harness)
+    assert "followers_only" in upgraded_constraint
+    assert "friends_only" not in upgraded_constraint
+
+    _insert_user(
+        alembic_test_harness,
+        email="follower@example.com",
+        handle="followeruser",
+        visibility="followers_only",
+    )
+    with pytest.raises(CheckViolation):
+        _insert_user(
+            alembic_test_harness,
+            email="rejected@example.com",
+            handle="rejecteduser",
+            visibility="friends_only",
+        )
+
+    alembic_test_harness.downgrade(PREVIOUS_REVISION)
+
+    assert _profile_visibilities(alembic_test_harness) == ["friends_only", "friends_only"]
+    downgraded_constraint = _constraint_definition(alembic_test_harness)
+    assert "friends_only" in downgraded_constraint
+    assert "followers_only" not in downgraded_constraint
+
+    with pytest.raises(CheckViolation):
+        _insert_user(
+            alembic_test_harness,
+            email="downgrade-rejected@example.com",
+            handle="downgraderejected",
+            visibility="followers_only",
+        )

--- a/tests/units/repository/test_user_repository.py
+++ b/tests/units/repository/test_user_repository.py
@@ -286,7 +286,7 @@ async def test_update_user_profile_only_changes_whitelisted_fields(
             "first_name": "Jane",
             "last_name": "Smith",
             "bio": "New bio",
-            "profile_visibility": "public",
+            "profile_visibility": "followers_only",
             "date_of_birth": date(1991, 2, 3),
             "email": "ignored@example.com",
         },
@@ -296,7 +296,7 @@ async def test_update_user_profile_only_changes_whitelisted_fields(
     assert updated.first_name == "Jane"
     assert updated.last_name == "Smith"
     assert updated.bio == "New bio"
-    assert updated.profile_visibility == "public"
+    assert updated.profile_visibility == "followers_only"
     assert updated.date_of_birth == date(1991, 2, 3)
 
     persisted = await seed_session.get(User, user.id)
@@ -305,14 +305,17 @@ async def test_update_user_profile_only_changes_whitelisted_fields(
 
 
 @pytest.mark.asyncio
-async def test_profile_visibility_check_constraint_rejects_invalid_value(seed_session: AsyncSession):
+@pytest.mark.parametrize("profile_visibility", ["friends_only", "hidden"])
+async def test_profile_visibility_check_constraint_rejects_invalid_value(
+    seed_session: AsyncSession, profile_visibility: str
+):
     invalid_user = User(
         email="invalid-visibility@example.com",
         handle="invalidvisibility",
         first_name="Invalid",
         last_name="Visibility",
         date_of_birth=date(1990, 1, 1),
-        profile_visibility="hidden",
+        profile_visibility=profile_visibility,
     )
 
     seed_session.add(invalid_user)

--- a/tests/units/schemas/test_user_schemas.py
+++ b/tests/units/schemas/test_user_schemas.py
@@ -18,14 +18,26 @@ def test_user_create_request_rejects_invalid_profile_visibility():
         )
 
 
-def test_user_create_request_normalizes_profile_visibility():
+def test_user_create_request_normalizes_followers_only_profile_visibility():
     request = UserCreateRequest(
         first_name="John",
         last_name="Doe",
         email="john@example.com",
         handle="johndoe",
         date_of_birth=date(1990, 1, 1),
-        profile_visibility=" PUBLIC ",
+        profile_visibility=" FOLLOWERS_ONLY ",
     )
 
-    assert request.profile_visibility == "public"
+    assert request.profile_visibility == "followers_only"
+
+
+def test_user_create_request_rejects_friends_only_profile_visibility():
+    with pytest.raises(ValidationError):
+        UserCreateRequest(
+            first_name="John",
+            last_name="Doe",
+            email="john@example.com",
+            handle="johndoe",
+            date_of_birth=date(1990, 1, 1),
+            profile_visibility="friends_only",
+        )

--- a/tests/units/services/test_log_service.py
+++ b/tests/units/services/test_log_service.py
@@ -444,8 +444,8 @@ class TestGetUserLogsByHandle:
         assert exc_info.value.error.error_code == ErrorCodes.PROFILE_NOT_PUBLIC.error_code
 
     @pytest.mark.asyncio
-    async def test_friends_only_profile_blocks_access(self, log_service, mock_user_repository):
-        mock_user = self._create_mock_user(user_id="user456", handle="johndoe", profile_visibility="friends_only")
+    async def test_followers_only_profile_blocks_access(self, log_service, mock_user_repository):
+        mock_user = self._create_mock_user(user_id="user456", handle="johndoe", profile_visibility="followers_only")
         mock_user_repository.find_user_by_handle.return_value = mock_user
 
         request = LogListRequest()

--- a/tests/units/services/test_user_service.py
+++ b/tests/units/services/test_user_service.py
@@ -95,8 +95,8 @@ class TestGetVisibleProfile:
         assert result.handle == "johndoe"
 
     @pytest.mark.asyncio
-    async def test_friends_only_profile_hides_date_of_birth(self, user_service, mock_user_repository):
-        mock_user = create_mock_user(handle="johndoe", profile_visibility="friends_only")
+    async def test_followers_only_profile_hides_date_of_birth(self, user_service, mock_user_repository):
+        mock_user = create_mock_user(handle="johndoe", profile_visibility="followers_only")
         mock_user_repository.find_user_by_handle.return_value = mock_user
 
         result = await user_service.get_visible_profile(handle="johndoe", requester_id="other_user")

--- a/tests/units/types/test_user_validation.py
+++ b/tests/units/types/test_user_validation.py
@@ -17,9 +17,17 @@ class TestProfileVisibilityValidation:
         model = ProfileVisibilityModel(visibility="private")
         assert model.visibility == "private"
 
-    def test_valid_friends_only(self):
-        model = ProfileVisibilityModel(visibility="friends_only")
-        assert model.visibility == "friends_only"
+    def test_valid_followers_only(self):
+        model = ProfileVisibilityModel(visibility="followers_only")
+        assert model.visibility == "followers_only"
+
+    def test_followers_only_is_normalized(self):
+        model = ProfileVisibilityModel(visibility=" FOLLOWERS_ONLY ")
+        assert model.visibility == "followers_only"
+
+    def test_friends_only_is_rejected(self):
+        with pytest.raises(ValidationError):
+            ProfileVisibilityModel(visibility="friends_only")
 
     def test_valid_uppercase_normalized(self):
         model = ProfileVisibilityModel(visibility="PUBLIC")


### PR DESCRIPTION
## Summary

- rename the supported profile visibility value from `friends_only` to `followers_only` across validation, schemas, API responses, tests, and documentation
- add Alembic revision `005` to convert existing PostgreSQL rows and replace the check constraint, with a symmetric downgrade
- add a reusable PostgreSQL/Alembic test harness and migration coverage for upgrade, conversion, constraint enforcement, and downgrade
- preserve the current private-like authorization behavior until follower authorization is implemented
- document the coordinated backend/frontend release, production smoke checks, and downgrade-before-old-image rollback procedure

## Impact

`followers_only` is now the only accepted follower-restricted wire value. Legacy `friends_only` rows are migrated automatically, and new `friends_only` API inputs are rejected.

This backend change ships together with [cinelog_web#70](https://github.com/benincasantonio/cinelog_web/issues/70). Deploy the backend first, allow revision `005` to complete, then deploy the frontend immediately. A rollback must downgrade to `004_create_logs_table` while the new backend image is still available before restoring the old images.

Closes #195

## Validation

- `make lint`
- `make format-check`
- `make typecheck`
- `make test-unit` — 445 passed
- `make test-e2e` — 79 passed
- `make db-schema-migrate-dry-run`
- migration harness verifies `004 → 005 → 004` against PostgreSQL