### PR TITLE
feat: add portable GitHub epic creation skill

### DIFF
--- a/.agents/skills/create-github-epic/SKILL.md
+++ b/.agents/skills/create-github-epic/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: create-github-epic
+description: Draft and create GitHub epics with reviewed child issues, native sub-issue links, and blocked-by relationships through GitHub CLI. Use when the user asks to plan, decompose, create, resume, or verify a GitHub epic or a set of linked issues. Always preview the complete manifest and require explicit approval before any GitHub write.
+---
+
+# Create GitHub Epic
+
+Create a coherent parent epic and independently deliverable child issues. Treat GitHub's native
+sub-issue and dependency relationships as the source of truth.
+
+## Safety boundary
+
+- Perform only read-only repository and GitHub inspection until the preview is approved.
+- Never treat skill invocation, a general request to create an epic, or approval of an earlier
+  draft as approval of the current manifest.
+- Show the exact repository, titles, bodies, labels, milestone, sub-issue links, and dependency
+  graph immediately before requesting approval.
+- If any material field changes after approval, show the revised manifest and request approval
+  again.
+- Never create missing labels, milestones, projects, or issue types unless the user separately
+  authorizes that mutation.
+- Never delete or close partially created issues automatically.
+- Follow the repository's `AGENTS.md` and issue workflow in addition to this skill.
+
+## Workflow
+
+### 1. Ground the proposal
+
+Inspect before asking questions:
+
+- Read the applicable `AGENTS.md`, `Makefile`, architecture docs, and relevant source/docs.
+- Inspect `.github/ISSUE_TEMPLATE/` and issue forms when present.
+- Resolve the repository with `gh repo view`.
+- List existing labels, open milestones, and recent or similarly titled epics.
+- Search open and closed issues for exact or near-duplicate parent and child titles.
+- Inspect one or two representative epics to learn title, body, label, and delivery conventions.
+
+Ask only for product intent or tradeoffs that cannot be derived from these sources.
+Repository patterns may establish architecture, naming style, and required quality checks, but they
+do not establish new feature behavior. Do not infer visibility, ownership, uniqueness, deletion,
+idempotency, pagination, compatibility, endpoint, status-code, or data-retention requirements
+from a similar issue or from implementation conventions.
+
+Before drafting, identify every unresolved decision that would materially change the issue graph,
+public contract, stored data, authorization boundary, or acceptance criteria. Present concrete
+options and a recommended default, then wait for the user's answer. Do not hide assumptions in an
+out-of-scope list.
+
+### 2. Decompose the work
+
+- Make every child issue independently reviewable, testable, and valuable.
+- Split by delivered behavior or contract rather than by architectural layer alone.
+- Put shared decisions and cross-child invariants in the epic.
+- Put child-specific scope, acceptance criteria, verification, documentation, and exclusions in
+  each child.
+- Use only requirements supplied by the user, explicitly documented for the target feature, or
+  confirmed during clarification. Label lower-impact implementation details as proposals.
+- Express each dependency as: `dependent issue is blocked by blocker issue`.
+- Reject self-dependencies and cycles. Do not create issues until the dependency graph is a DAG.
+- Use full issue URLs for cross-repository parents or dependencies.
+
+Read [references/issue-format.md](references/issue-format.md) before drafting the manifest.
+
+### 3. Preview the complete manifest
+
+Present, in this order:
+
+1. Target repository and inferred conventions.
+2. Epic title, full body, labels, and milestone.
+3. A child-issue table with stable draft keys (`T1`, `T2`, ...), title, labels, and blockers.
+4. A Mermaid dependency graph where `T1 --> T2` means **T2 is blocked by T1**.
+5. Every full child body.
+6. The expected relationship strategy: native `gh issue` flags or `gh api` fallback.
+7. A concise duplicate-search result.
+
+End with a direct approval request that states the number of issues and target repository. Do not
+run any write command until the user approves that exact preview.
+
+### 4. Preflight after approval
+
+- Re-run `gh auth status`, repository resolution, label/milestone validation, and duplicate search.
+- Stop if authentication, permissions, repository identity, or requested metadata changed.
+- Detect relationship flags from the installed binary's `--help`; never infer support from a
+  version number or the online manual.
+- Read [references/github-cli.md](references/github-cli.md) before creating or linking issues.
+- Keep a creation ledger containing each draft key, created number, URL, and completed
+  relationships.
+
+### 5. Create and link
+
+- Create the parent epic first and capture its number and URL.
+- Create children in draft-key order. Link the parent during creation when native `--parent` is
+  available; otherwise add the native relationship through `gh api`.
+- Add dependency relationships only after all same-manifest children exist.
+- Before every relationship write, read the current relationships and skip an existing link.
+- After all children are known, update the epic's delivery section with ordinary linked bullets.
+  Do not duplicate native sub-issues as task-list checkboxes.
+- Stream issue bodies through `--body-file` so shell interpolation cannot corrupt Markdown.
+
+### 6. Verify and report
+
+- Re-read the parent, its sub-issues, and every child's `blocked_by` relationships.
+- Compare the live graph with the approved manifest by issue database ID or full URL, not just by
+  issue number.
+- Report the epic URL, a child URL table, verified dependency edges, and the CLI path used.
+- If creation stops partway, preserve all created issues. Report the creation ledger, the failed
+  command or API response, missing relationships, and exact safe resume point.
+- On a resumed run, rediscover existing issues and relationships before proposing any writes.
+
+## Completion requirements
+
+Do not claim success unless:
+
+- Every approved issue exists exactly once.
+- Every child is a native sub-issue of the approved parent.
+- Every approved blocked-by edge exists and no unapproved edge was added.
+- The final epic body contains actual issue links and no duplicate sub-issue task list.
+- The user receives all created URLs and any remaining manual action.

--- a/.agents/skills/create-github-epic/agents/openai.yaml
+++ b/.agents/skills/create-github-epic/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Create GitHub Epic"
+  short_description: "Draft and create linked GitHub epics"
+  default_prompt: "Use $create-github-epic to draft and create a GitHub epic with native sub-issue and dependency relationships."

--- a/.agents/skills/create-github-epic/references/github-cli.md
+++ b/.agents/skills/create-github-epic/references/github-cli.md
@@ -1,0 +1,179 @@
+# GitHub CLI Relationship Reference
+
+Use this reference only after the user approves the exact issue manifest.
+
+## Contents
+
+- [Read-only preflight](#read-only-preflight)
+- [Capability detection](#capability-detection)
+- [Create issues](#create-issues)
+- [Native relationship path](#native-relationship-path)
+- [REST fallback path](#rest-fallback-path)
+- [Idempotency and verification](#idempotency-and-verification)
+- [Failure handling](#failure-handling)
+
+## Read-only preflight
+
+Resolve and verify the repository rather than parsing `git remote`:
+
+```bash
+repo_slug=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+gh auth status
+gh label list --repo "$repo_slug" --limit 200
+gh api --paginate "repos/$repo_slug/milestones?state=open&per_page=100"
+```
+
+Search both open and closed issues before creating anything:
+
+```bash
+gh issue list --repo "$repo_slug" --state all \
+  --search '"EXACT TITLE" in:title' \
+  --json number,title,state,url
+```
+
+Compare returned titles exactly in addition to reviewing near matches.
+
+## Capability detection
+
+Check the installed binary. Online documentation may describe flags that the local binary does
+not yet provide.
+
+```bash
+if gh issue create --help 2>&1 | grep -q -- '--parent'; then
+  native_parent_create=true
+else
+  native_parent_create=false
+fi
+
+if gh issue edit --help 2>&1 | grep -q -- '--add-blocked-by'; then
+  native_dependency_edit=true
+else
+  native_dependency_edit=false
+fi
+```
+
+Detect parent and dependency support separately. Use the REST fallback for only the unsupported
+operation.
+
+## Create issues
+
+Use a body file or standard input. Capture the URL printed by `gh issue create` and derive the
+number only after validating that output.
+
+```bash
+parent_url=$(gh issue create --repo "$repo_slug" \
+  --title "[Epic] EPIC TITLE" \
+  --body-file "$parent_body_file" \
+  --label enhancement --label feature)
+parent_number=${parent_url##*/}
+```
+
+Add only labels and milestones that the read-only preflight proved exist. Omit `--milestone`
+when no milestone was approved.
+
+## Native relationship path
+
+When supported, link a new child during creation:
+
+```bash
+child_url=$(gh issue create --repo "$repo_slug" \
+  --title "feat(scope): child title" \
+  --body-file "$child_body_file" \
+  --parent "$parent_number")
+```
+
+For an existing child:
+
+```bash
+gh issue edit "$child_number" --repo "$repo_slug" --parent "$parent_number"
+```
+
+Add a dependency to the **dependent** issue. This means the dependent cannot finish until the
+blocker finishes:
+
+```bash
+gh issue edit "$dependent_number" --repo "$repo_slug" \
+  --add-blocked-by "$blocker_number"
+```
+
+Comma-separate multiple blockers only after every blocker reference is resolved. Prefer full URLs
+for cross-repository relationships.
+
+## REST fallback path
+
+All fallback writes still use GitHub CLI through `gh api`.
+
+### Resolve database IDs
+
+The relationship endpoints require the REST integer `id`. Do not pass the GraphQL `node_id` or
+the string returned by `gh issue view --json id`.
+
+```bash
+child_database_id=$(gh api "repos/$repo_slug/issues/$child_number" --jq .id)
+blocker_database_id=$(gh api "repos/$repo_slug/issues/$blocker_number" --jq .id)
+```
+
+For a cross-repository issue, resolve the ID from that issue's own `OWNER/REPO`.
+
+### Add a sub-issue
+
+Write to the parent issue and pass the child's database ID:
+
+```bash
+gh api --method POST \
+  -H "Accept: application/vnd.github+json" \
+  "repos/$repo_slug/issues/$parent_number/sub_issues" \
+  -F "sub_issue_id=$child_database_id"
+```
+
+### Add a blocked-by dependency
+
+Write to the dependent issue and pass the blocker's database ID:
+
+```bash
+gh api --method POST \
+  -H "Accept: application/vnd.github+json" \
+  "repos/$repo_slug/issues/$dependent_number/dependencies/blocked_by" \
+  -F "issue_id=$blocker_database_id"
+```
+
+Do not replace a failed native relationship with body text. Stop and report when the repository,
+GitHub host, or token does not support the relationship endpoint.
+
+## Idempotency and verification
+
+Read before every relationship write:
+
+```bash
+gh api --paginate \
+  "repos/$repo_slug/issues/$parent_number/sub_issues?per_page=100"
+
+gh api --paginate \
+  "repos/$repo_slug/issues/$dependent_number/dependencies/blocked_by?per_page=100"
+```
+
+Compare the returned integer `id` or `html_url` with the intended issue. Issue numbers alone are
+not unique across repositories.
+
+After all writes, query the same endpoints again and compare the live relationship sets with the
+approved manifest. When native JSON fields are available, `gh issue view --json
+parent,subIssues,blockedBy,blocking` is an additional check, not a replacement for the
+cross-version REST verification.
+
+## Failure handling
+
+- Record each created URL immediately.
+- On `401` or `403`, stop and report the missing authentication or permission.
+- On `404`, verify host support, repository identity, issue visibility, and endpoint spelling.
+- On `409` or `422`, re-read the relationship first; treat it as success only if the intended
+  relationship already exists.
+- Never delete, close, relabel, or unlink successful partial results as rollback.
+- Resume by discovering the parent, children, and live edges, then perform only missing writes
+  after a refreshed preview and approval.
+
+## Official references
+
+- [GitHub CLI: create issue](https://cli.github.com/manual/gh_issue_create)
+- [GitHub CLI: edit issue](https://cli.github.com/manual/gh_issue_edit)
+- [REST API: sub-issues](https://docs.github.com/en/rest/issues/sub-issues)
+- [REST API: issue dependencies](https://docs.github.com/en/rest/issues/issue-dependencies)

--- a/.agents/skills/create-github-epic/references/issue-format.md
+++ b/.agents/skills/create-github-epic/references/issue-format.md
@@ -1,0 +1,166 @@
+# Epic and Sub-Issue Format
+
+Use repository-specific templates when they exist. Otherwise apply these structures and adapt
+their headings to the repository's established conventions.
+
+## Contents
+
+- [Draft manifest](#draft-manifest)
+- [Epic title and body](#epic-title-and-body)
+- [Child title and body](#child-title-and-body)
+- [Dependency graph](#dependency-graph)
+- [Quality rules](#quality-rules)
+
+## Draft manifest
+
+Show the target and write state first:
+
+```markdown
+**Repository:** OWNER/REPO
+**Write status:** Awaiting explicit approval
+**Relationship path:** Native gh flags | gh api fallback
+```
+
+Summarize children with stable draft keys:
+
+```markdown
+| Key | Title | Labels | Blocked by |
+|-----|-------|--------|------------|
+| T1 | feat(domain): first capability | feature | — |
+| T2 | feat(domain): dependent capability | feature | T1 |
+```
+
+Include full parent and child bodies after the table. Do not abbreviate bodies that will be sent
+to GitHub.
+
+## Epic title and body
+
+Follow an established repository prefix when one exists. Cinelog uses:
+
+```text
+[Epic] Outcome-oriented title
+```
+
+Draft the parent with this shape:
+
+```markdown
+## Summary
+
+Describe the user or developer outcome and why the grouped work belongs in one epic.
+
+## Agreed behavior and contracts
+
+- State decisions shared by multiple children.
+- State compatibility, security, privacy, and API boundaries when relevant.
+
+## Scope
+
+### In scope
+
+- List the capabilities delivered by the epic.
+
+### Out of scope
+
+- List deliberate exclusions that could otherwise be mistaken for omissions.
+
+## Sub-issues and delivery order
+
+- T1 — First independently deliverable outcome.
+- T2 — Second outcome; blocked by T1.
+
+Explain which children may proceed in parallel and why dependencies exist.
+
+## Epic acceptance criteria
+
+- [ ] State measurable end-to-end outcomes.
+- [ ] Require all native sub-issues to be complete.
+- [ ] Include repository quality and documentation requirements.
+
+## Delivery policy
+
+State the repository's issue-branch, review, commit, and pull-request rules.
+```
+
+After child creation, replace draft keys in the delivery section with ordinary linked bullets:
+
+```markdown
+- #123 — T1: First independently deliverable outcome.
+- #124 — T2: Second outcome; blocked by #123.
+```
+
+Do not use `- [ ] #123` for the child list. GitHub's native sub-issue relationship owns child
+completion state.
+
+## Child title and body
+
+Follow the repository's issue-title convention. Cinelog normally uses Conventional Commit-style
+titles such as:
+
+```text
+feat(notifications): expose notification preferences
+refactor(profile): rename a visibility value
+docs(agents): document an agent workflow
+```
+
+Draft each child with this shape:
+
+```markdown
+## Summary
+
+Describe the independently valuable outcome.
+
+**Parent epic:** #PARENT
+
+## Scope
+
+### In scope
+
+- List concrete behavior, contracts, and affected surfaces.
+
+### Out of scope
+
+- List exclusions and work owned by sibling issues.
+
+## Acceptance criteria
+
+- [ ] Use observable, testable statements.
+- [ ] Include failure and compatibility behavior.
+- [ ] Include documentation requirements when behavior changes.
+
+## Verification
+
+- Name required unit, integration, end-to-end, migration, or manual checks.
+
+## Implementation constraints
+
+- Preserve repository architecture and explicitly shared epic decisions.
+```
+
+The parent reference may appear in the body for human navigation. Keep dependency relationships
+native; explain dependency rationale in the epic rather than maintaining a second body-only graph.
+
+## Dependency graph
+
+Use the same edge direction everywhere:
+
+```mermaid
+flowchart LR
+  T1["T1: Foundation"] --> T2["T2: Dependent capability"]
+```
+
+`T1 --> T2` means **T2 is blocked by T1**. Reject a graph containing a path from any node back to
+itself. Existing external blockers must use full issue URLs in the manifest.
+
+## Quality rules
+
+- Prefer 3–8 coherent children; use more only when the epic genuinely requires them.
+- Avoid children that only add a model, repository, tests, or docs with no independent outcome.
+- Give every child unambiguous in-scope and out-of-scope boundaries.
+- Put a shared decision in the epic once, then reference it from children.
+- Never invent product rules from repository architecture or a related issue. Ask before fixing
+  authorization, visibility, uniqueness, deletion, idempotency, pagination, API, or compatibility
+  behavior that the user did not specify.
+- Mark lower-impact implementation choices as proposals until the manifest is approved.
+- Reuse existing labels and milestones; do not invent taxonomy during epic creation.
+- Keep each acceptance criterion verifiable without interpreting implementation details.
+- Preserve exact approved wording during creation except for replacing draft keys with issue links.

--- a/.claude/skills/create-github-epic
+++ b/.claude/skills/create-github-epic
@@ -1,0 +1,1 @@
+../../.agents/skills/create-github-epic

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ Developer-facing documentation covering infrastructure, implementation details, 
 | [CORS Configuration](technical/cors-configuration.md) | CORS environment variables and behavior |
 | [Deployment Options](technical/deployment-options.md) | VPS and optional Vercel deployment guidance |
 | [E2E Testing](technical/e2e-testing.md) | Setup and run end-to-end tests |
+| [GitHub Epic Creation Skill](technical/github-epic-skill.md) | Cross-client epic drafting, approval, relationship creation, and recovery |
 | [Notification Architecture](technical/notifications.md) | Typed persistence, service response mapping, deduplication, and extension contract |
 | [Postgres Migration](technical/postgres-migration.md) | PostgreSQL setup and the completed MongoDB → PostgreSQL migration |
 | [Profile Visibility](technical/profile-visibility.md) | Visibility field, service logic, migration, and followers-only authorization stub |

--- a/docs/technical/github-epic-skill.md
+++ b/docs/technical/github-epic-skill.md
@@ -1,0 +1,101 @@
+# GitHub Epic Creation Skill
+
+**Last Updated:** 2026-07-25
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Availability and Invocation](#availability-and-invocation)
+- [Workflow](#workflow)
+- [GitHub Relationships](#github-relationships)
+- [Safety and Recovery](#safety-and-recovery)
+- [Troubleshooting](#troubleshooting)
+- [See Also](#see-also)
+
+## Overview
+
+The `create-github-epic` skill turns a feature brief or prepared ticket list into a GitHub parent
+epic, native sub-issues, and blocked-by relationships. It is repository-local and shares one
+canonical instruction set across Codex, OpenCode, and Claude Code.
+
+The skill follows the repository's issue-first development flow and existing `[Epic]` convention.
+It does not change application behavior, APIs, schemas, or database state.
+
+## Availability and Invocation
+
+| Client | Discovery | Invocation |
+|--------|-----------|------------|
+| Codex | `.agents/skills/create-github-epic/` | `$create-github-epic` |
+| OpenCode | `.agents/skills/create-github-epic/` | Automatic selection or the `skill` tool |
+| Claude Code | `.claude/skills/create-github-epic` symlink | `/create-github-epic` |
+
+The canonical `SKILL.md` uses only the common `name` and `description` frontmatter fields.
+Codex-specific display metadata lives in `agents/openai.yaml` and is ignored by other clients.
+
+## Workflow
+
+1. Inspect repository instructions, source and documentation context, issue templates, labels,
+   milestones, and existing epics.
+2. Decompose the requested outcome into independently deliverable children and an acyclic
+   dependency graph.
+3. Show the complete parent and child bodies, metadata, and Mermaid graph.
+4. Wait for explicit approval of that exact manifest.
+5. Create the issues, add native relationships, update the parent with actual issue links, and
+   verify the live graph.
+
+The parent body lists linked children with ordinary bullets. GitHub's native sub-issue section,
+not a duplicated Markdown checklist, tracks child completion.
+
+## GitHub Relationships
+
+Recent GitHub CLI versions support parent and dependency flags directly:
+
+```bash
+gh issue create --parent PARENT
+gh issue edit DEPENDENT --add-blocked-by BLOCKER
+```
+
+The skill checks the installed binary's help before using those flags. This is necessary because
+an installed CLI can lag behind the current online manual even when GitHub itself already supports
+the relationships.
+
+When native flags are unavailable, the skill uses `gh api` with GitHub's REST endpoints:
+
+- `POST /repos/{owner}/{repo}/issues/{parent}/sub_issues`
+- `POST /repos/{owner}/{repo}/issues/{dependent}/dependencies/blocked_by`
+
+These endpoints require the related issue's integer REST `id`, not its issue number or GraphQL
+node ID. The skill resolves the ID from the issue's REST resource and verifies relationships with
+the corresponding GET endpoints.
+
+## Safety and Recovery
+
+No GitHub write occurs before the user reviews and approves the exact manifest. A material edit
+invalidates approval and requires a new preview.
+
+The skill records each created URL and reads relationships before adding them. If a later step
+fails, it preserves successful issues, reports the safe resume point, and never deletes or closes
+issues as an automatic rollback.
+
+Missing labels, milestones, projects, or issue types are reported rather than created implicitly.
+Cross-repository relationships require full issue URLs.
+
+## Troubleshooting
+
+| Problem | Cause | Resolution |
+|---------|-------|------------|
+| Relationship flags are unknown | Installed `gh` predates the flags | Allow the skill to use its documented `gh api` fallback |
+| REST endpoint returns `403` | Token lacks issue write permission | Re-authenticate `gh` with access to the target repository |
+| REST endpoint returns `404` | Wrong repository/issue, hidden issue, or unsupported GitHub host | Verify `gh repo view`, issue URLs, host version, and visibility |
+| REST endpoint returns `422` | Invalid, cyclic, duplicate, or otherwise rejected relationship | Re-read the live graph; retry only if the intended edge is missing |
+| Skill is not visible | Client has not discovered its project skill directory | Restart the client and verify the canonical path or Claude symlink |
+| A run stopped after creating some issues | A later issue or relationship write failed | Invoke the skill again; it will rediscover live issues and propose only missing writes |
+
+## See Also
+
+- [Codex skill documentation](https://developers.openai.com/codex/skills/)
+- [OpenCode skill documentation](https://opencode.ai/docs/skills/)
+- [Claude Code skill documentation](https://code.claude.com/docs/en/skills)
+- [GitHub CLI issue manual](https://cli.github.com/manual/gh_issue)
+- [GitHub sub-issue REST API](https://docs.github.com/en/rest/issues/sub-issues)
+- [GitHub issue dependency REST API](https://docs.github.com/en/rest/issues/issue-dependencies)


### PR DESCRIPTION
## Description

Add a repository-local `create-github-epic` skill shared by Codex, OpenCode, and Claude Code from one canonical instruction set. The skill turns a feature brief or prepared ticket list into a reviewed GitHub epic with native sub-issue and blocked-by relationships while keeping all GitHub writes behind explicit approval of the exact manifest.

The workflow feature-detects native `gh issue` relationship flags and falls back to the supported REST endpoints through `gh api` when those flags are unavailable. It also records creation progress, skips existing relationships, preserves partial results, and reports a safe resume point instead of rolling back successfully created issues.

## Related Issue(s)

Closes #209

## Changes Made

- Add the canonical `.agents/skills/create-github-epic/` skill for Codex and OpenCode discovery.
- Add Codex UI metadata in `.agents/skills/create-github-epic/agents/openai.yaml`.
- Add focused references for repository-aware epic and child issue formatting, dependency DAGs, GitHub CLI capability detection, native relationship flags, and REST fallbacks.
- Require a complete manifest preview and fresh explicit approval before any GitHub mutation, including renewed approval after material changes or partial-run recovery.
- Add idempotent sub-issue and blocked-by relationship handling with creation-ledger verification and non-destructive recovery behavior.
- Expose the same canonical skill to Claude Code through `.claude/skills/create-github-epic` without duplicating instructions.
- Document cross-client invocation, compatibility, safety, recovery, and troubleshooting in `docs/technical/github-epic-skill.md`, linked from `docs/README.md`.
- No new application dependencies, API behavior, schemas, migrations, or environment variables are introduced.

## How to Test

1. Validate the canonical skill:
   ```bash
   python3 /Users/antoniobenincasa/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/create-github-epic
   ```
2. Confirm OpenCode discovers `create-github-epic`:
   ```bash
   opencode debug skill
   ```
3. Confirm the Claude Code symlink resolves to the canonical skill:
   ```bash
   test -L .claude/skills/create-github-epic
   test -f .claude/skills/create-github-epic/SKILL.md
   ```
4. Review the four draft-only forward-test scenarios:
   - A vague collaborative-watchlists brief stays read-only and announces repository and issue research before drafting.
   - A prepared movie-collections DAG selects the installed `gh api` fallback, renders parallel and chained edges correctly, and detects overlapping issues `#131` and `#132` before writes.
   - A cyclic `T1 <- T3 <- T2 <- T1` graph is rejected before manifest creation.
   - A partial-run ledger preserves the parent, `T1`, and `T2`, proposes only missing `T3`, parent links, and blocked-by edges, requests refreshed approval, and performs no rollback.
5. Confirm the tightened retry asks for underspecified product rules instead of inventing them.
6. Check the final diff for whitespace errors:
   ```bash
   git diff --check main...HEAD
   ```

No credentials, environment variables, or database migrations are required. The pre-commit Ruff, formatting, and mypy checks also pass.

## Checklist

- [x] Code compiles/builds without errors
- [x] Tests pass locally
- [x] New tests added for new functionality (if applicable)
- [x] No new warnings introduced
- [x] Documentation updated (if applicable)
- [x] Database migrations included (not applicable; no database changes)
- [x] Environment variables documented (not applicable; no new environment variables)