### PR TITLE
feat(notifications): emit follow.started when a user follows another

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -215,9 +215,9 @@ The `__Host-` prefix enforces: `Secure=true`, no `Domain`, `path=/` — prevents
 | `LogService` | Viewing log CRUD with movie fetching and poster auto-population |
 | `MovieRatingService` | Movie rating create/update/read |
 | `UserService` | User info and profile retrieval with follower/following summaries |
-| `FollowService` | Public-target eligibility and idempotent follow/unfollow mutations |
+| `FollowService` | Public-target eligibility, idempotent follow/unfollow mutations, and `follow.started` emission |
 | `StatsService` | Viewing statistics with `asyncio.gather()` for parallel DB queries |
-| `NotificationService` | Inbox pagination, batch response assembly, and explicit read state |
+| `NotificationService` | Inbox pagination, batch response assembly, explicit read state, and cooldown-aware creation |
 
 ## Middleware
 

--- a/app/config/notification_config.py
+++ b/app/config/notification_config.py
@@ -3,12 +3,17 @@
 Owns the notification cursor scope so the reusable pagination configuration in
 ``app/config/cursor_pagination_config.py`` stays free of per-domain constants.
 
+Also owns producer cooldown TTLs such as ``FOLLOW_STARTED_NOTIFICATION_COOLDOWN_SECONDS``.
+
 The raw prefix is deliberately private: a scope is only ever obtained through
 ``notification_list_cursor_scope()``, so an inbox cursor cannot accidentally be
 signed without its recipient binding.
 """
 
 from uuid import UUID
+
+# Rolling window used by the follow.started producer to suppress unfollow/refollow spam.
+FOLLOW_STARTED_NOTIFICATION_COOLDOWN_SECONDS = 604800
 
 _NOTIFICATION_LIST_CURSOR_PREFIX = "notifications.list"
 

--- a/app/dependencies/service_dependency.py
+++ b/app/dependencies/service_dependency.py
@@ -56,6 +56,7 @@ def get_follow_service() -> FollowService:
     return FollowService(
         user_repository=get_user_repository(),
         follow_repository=get_follow_repository(),
+        notification_service=get_notification_service(),
     )
 
 

--- a/app/services/follow_service.py
+++ b/app/services/follow_service.py
@@ -1,11 +1,20 @@
 """Business rules for basic public-profile following."""
 
+import logging
+from datetime import UTC, datetime
 from uuid import UUID
 
+from app.config.notification_config import FOLLOW_STARTED_NOTIFICATION_COOLDOWN_SECONDS
+from app.models.user_model import User
 from app.repository.follow_repository_protocol import FollowRepositoryProtocol
 from app.repository.user_repository_protocol import UserRepositoryProtocol
+from app.schemas.notification_schemas import NotificationCreateData
+from app.services.notification_service import NotificationService
+from app.types import NotificationType
 from app.utils.error_codes_utils import ErrorCodes
 from app.utils.exceptions_utils import AppException
+
+logger = logging.getLogger(__name__)
 
 
 class FollowService:
@@ -15,9 +24,11 @@ class FollowService:
         self,
         user_repository: UserRepositoryProtocol,
         follow_repository: FollowRepositoryProtocol,
+        notification_service: NotificationService | None = None,
     ):
         self.user_repository = user_repository
         self.follow_repository = follow_repository
+        self.notification_service = notification_service or NotificationService()
 
     async def follow_user(self, follower_id: UUID, handle: str) -> None:
         """Follow an active public target, or keep an existing edge unchanged."""
@@ -40,6 +51,7 @@ class FollowService:
             raise AppException(ErrorCodes.PROFILE_NOT_PUBLIC)
 
         await self.follow_repository.create_follow(follower.id, target.id)
+        await self._notify_follow_started(actor=follower, recipient=target)
 
     async def unfollow_user(self, follower_id: UUID, handle: str) -> None:
         """Unfollow an active target regardless of its current visibility."""
@@ -53,3 +65,35 @@ class FollowService:
             raise AppException(ErrorCodes.USER_NOT_FOUND)
 
         await self.follow_repository.delete_follow(follower.id, target.id)
+
+    async def _notify_follow_started(self, *, actor: User, recipient: User) -> None:
+        """Emit a follow.started inbox row without failing the follow mutation."""
+
+        try:
+            await self.notification_service.create_notification(
+                NotificationCreateData(
+                    recipient_id=recipient.id,
+                    actor_id=actor.id,
+                    type=NotificationType.FOLLOW_STARTED,
+                    title="New follower",
+                    body=f"{actor.first_name} {actor.last_name} started following you.",
+                    deduplication_key=self._follow_started_deduplication_key(actor.id),
+                ),
+                cooldown_key=self._follow_started_cooldown_key(recipient.id, actor.id),
+                cooldown_seconds=FOLLOW_STARTED_NOTIFICATION_COOLDOWN_SECONDS,
+            )
+        except Exception:
+            logger.exception(
+                "Failed to emit follow.started notification for recipient_id=%s actor_id=%s",
+                recipient.id,
+                actor.id,
+            )
+
+    @staticmethod
+    def _follow_started_cooldown_key(recipient_id: UUID, actor_id: UUID) -> str:
+        return f"cinelog:notif:follow-started:{recipient_id}:{actor_id}"
+
+    @staticmethod
+    def _follow_started_deduplication_key(actor_id: UUID) -> str:
+        iso_week = datetime.now(UTC).strftime("%G-W%V")
+        return f"follow.started:{actor_id}:{iso_week}"

--- a/app/services/notification_service.py
+++ b/app/services/notification_service.py
@@ -18,6 +18,7 @@ from app.schemas.notification_schemas import (
     NotificationListRequest,
     NotificationListResponse,
 )
+from app.services.cache_service import CacheService
 from app.types import NotificationType, TimestampUUIDCursor
 from app.utils.cursor_pagination_utils import (
     decode_timestamp_uuid_cursor,
@@ -35,6 +36,10 @@ class NotificationService:
         repository: NotificationRepositoryProtocol | None = None,
     ) -> None:
         self.repository = repository or get_notification_repository()
+
+    @property
+    def _cache(self) -> CacheService:
+        return CacheService.get_instance()
 
     @staticmethod
     def _to_response(notification: Notification) -> NotificationBaseResponse:
@@ -60,10 +65,25 @@ class NotificationService:
             created_at=notification.created_at,
         )
 
-    async def create_notification(self, data: NotificationCreateData) -> NotificationCreateResult:
-        """Create a typed notification for use by future domain producers."""
+    async def create_notification(
+        self,
+        data: NotificationCreateData,
+        *,
+        cooldown_key: str | None = None,
+        cooldown_seconds: int | None = None,
+    ) -> NotificationCreateResult | None:
+        """Create a typed notification, optionally suppressing repeats for a cooldown window."""
 
-        return await self.repository.create_notification(data)
+        if cooldown_key is not None:
+            if cooldown_seconds is None:
+                raise ValueError("cooldown_seconds is required when cooldown_key is set")
+            if await self._cache.get(cooldown_key) is not None:
+                return None
+
+        result = await self.repository.create_notification(data)
+        if cooldown_key is not None:
+            await self._cache.set(cooldown_key, {"emitted": True}, ttl=cooldown_seconds)
+        return result
 
     async def list_notifications(
         self,

--- a/docs/functional/following.md
+++ b/docs/functional/following.md
@@ -26,6 +26,10 @@ The endpoint requires authentication and a matching CSRF header/cookie pair. It 
 The operation is idempotent: following the same user again also returns `204` and does not create a duplicate
 relationship. A preserved relationship can be retried after the target becomes non-public.
 
+A newly created follow writes a `follow.started` in-app notification to the target's inbox. Repeating the follow,
+including unfollow then refollow within 7 days, does not create another notification. The follow still returns `204`
+if that inbox write fails. See [In-App Notifications](notifications.md).
+
 ## Unfollow a user
 
 ```http
@@ -68,4 +72,5 @@ behind those counts.
 ## See Also
 
 - [Technical: Following](../technical/following.md)
+- [In-App Notifications](notifications.md)
 - [Profile Visibility](profile-visibility.md)

--- a/docs/functional/notifications.md
+++ b/docs/functional/notifications.md
@@ -1,6 +1,14 @@
 # In-App Notifications
 
-Cinelog provides an authenticated, persisted notification inbox for activity history. Notification text is rendered in English by the server and returned exactly as stored.
+Cinelog provides an authenticated, persisted notification inbox for activity history. Stored `title` and `body` are English presentation text. Clients should render the displayed string from `type` and `actor`, which stay current if the actor renames or the recipient changes language.
+
+## Producers
+
+`follow.started` is emitted when an authenticated user creates a new follow edge to a public profile. The recipient is the followed user and the actor is the follower.
+
+Duplicate `PUT /v1/users/{handle}/follow` calls, already-following retries, and unfollow-then-refollow within a rolling 7-day window do not create another inbox row. A follow still succeeds with `204` if notification persistence fails.
+
+See [Following](following.md) for eligibility and mutation semantics.
 
 ## Notification Shape
 
@@ -11,7 +19,7 @@ Every notification contains common presentation and read-state fields:
   "id": "d51b78c5-1847-49dc-826f-461c87974c60",
   "type": "follow.started",
   "title": "New follower",
-  "body": "A user started following you.",
+  "body": "Movie Fan started following you.",
   "actor": {
     "handle": "moviefan",
     "firstName": "Movie",
@@ -91,3 +99,4 @@ Read state is presentation state only. Reading a notification never accepts a fo
 ## See Also
 
 - [Technical: Notification Architecture](../technical/notifications.md)
+- [Following](following.md)

--- a/docs/technical/following.md
+++ b/docs/technical/following.md
@@ -1,7 +1,8 @@
 # Following — Technical
 
 The first following implementation stores accepted directional edges for public targets. It intentionally does not
-pre-build pending requests, status transitions, soft deletion, notifications, or follower-only authorization.
+pre-build pending requests, status transitions, soft deletion, or follower-only authorization. A successful new
+follow emits a `follow.started` in-app notification; see [Notification Architecture](notifications.md).
 
 ## Persistence
 
@@ -25,11 +26,17 @@ Users are soft-deleted elsewhere in the application, so follow reads join the re
 
 - `FollowRepository` performs conflict-safe inserts, idempotent deletes, active-edge checks, and profile aggregation.
 - `FollowService` validates the authenticated follower, resolves target handles case-insensitively through
-  `UserRepository`, rejects self-follows, and applies the public-target policy.
+  `UserRepository`, rejects self-follows, applies the public-target policy, and asks `NotificationService` to emit
+  `follow.started` after a new edge is inserted.
 - `UserService.get_visible_profile` combines its existing visibility-aware profile mapping with a `FollowSummary`.
 - `UserProfileResponse` serializes `follower_count`, `following_count`, and `is_following` as camelCase.
 - `PUT` and `DELETE /v1/users/{handle}/follow` are authenticated, CSRF-protected, rate-limited endpoints returning
   `204 No Content`.
+
+Notification emission is a second PostgreSQL transaction after `create_follow` commits. `FollowService` swallows and
+logs emission failures so a lost inbox row cannot turn a successful follow into a `500`. Duplicate PUTs return before
+`create_follow` and therefore do not notify. Unfollow then refollow is gated by a Redis rolling 7-day cooldown plus
+the notification `deduplication_key`; see [Notification Architecture](notifications.md).
 
 The profile aggregate is read in one database round trip using scalar count subqueries plus an existence check.
 
@@ -63,10 +70,12 @@ Coverage includes:
 - real-PostgreSQL repository idempotency, concurrency, directionality, active-user filtering, and aggregates;
 - service policy and controller authentication/CSRF/error contracts;
 - camelCase schema serialization;
-- E2E follow, unfollow, mutual counts, non-public rejection, and visibility-transition behavior.
+- E2E follow, unfollow, mutual counts, non-public rejection, visibility-transition behavior, and follow.started
+  inbox emission with same-week refollow suppression.
 
 ## See Also
 
 - [Functional: Following](../functional/following.md)
+- [Technical: Notification Architecture](notifications.md)
 - [Technical: Profile Visibility](profile-visibility.md)
 - [Postgres Migration](postgres-migration.md)

--- a/docs/technical/notifications.md
+++ b/docs/technical/notifications.md
@@ -12,7 +12,7 @@ Alembic revision `006_create_notifications_table` creates `notifications` with:
 | `recipient_id` | Required user FK; hard deletion cascades the inbox rows |
 | `actor_id` | Optional user FK; hard deletion sets it to `NULL` |
 | `type` | Text constrained to registered `NotificationType` values |
-| `title`, `body` | Rendered English presentation text |
+| `title`, `body` | Stored English presentation text; clients render displayed copy from `type` and `actor` |
 | `deduplication_key` | Optional producer event key |
 | `read_at` | Nullable server-owned read timestamp |
 | shared fields | Soft deletion plus created/updated timestamps |
@@ -31,6 +31,31 @@ Active chronology uses `(recipient_id, created_at DESC, id DESC)`. A matching pa
 Schemas import these enums from `app.types`; services do not repeat raw action strings. `NotificationBaseResponse`, `NotificationListResponse`, and `MarkAllNotificationsReadResponse` reject extra fields and inherit the application's camelCase aliases.
 
 The generic response always includes `availableActions: []`. The registered action enum exists now so later follow-domain adapters can return authorized enum members without changing the common wire type.
+
+## Follow Started Producer
+
+`FollowService` is the first domain producer. After a new public follow edge commits, it calls `NotificationService.create_notification` with:
+
+| Field | Value |
+|---|---|
+| `type` | `follow.started` |
+| `recipient_id` | followed user |
+| `actor_id` | follower |
+| `title` | `New follower` |
+| `body` | `{first_name} {last_name} started following you.` |
+| `deduplication_key` | `follow.started:{follower_id}:{ISO week}` using `%G-W%V` |
+
+Emission is skipped on the already-following path. Failures are swallowed and logged in `FollowService` so the follow `204` is independent of the inbox write. The follow insert and notification insert remain separate transactions.
+
+`create_notification` accepts optional `cooldown_key` and `cooldown_seconds`. When a cooldown key is present it:
+
+1. Returns `None` without inserting if Redis already has the key.
+2. Inserts through the repository.
+3. `SET`s the key after the insert returns, including when the row already existed (`created=False`).
+
+The follow producer uses `cinelog:notif:follow-started:{recipient_id}:{follower_id}` with `FOLLOW_STARTED_NOTIFICATION_COOLDOWN_SECONDS` (7 days). Redis is the rolling primary gate; the ISO-week `deduplication_key` is the durable backstop if Redis loses state. A rolling 7-day expiry always lands in a later ISO week, so the database key cannot suppress an emission Redis approved.
+
+`CacheService` is resolved lazily through `CacheService.get_instance()` so the `@lru_cache`d `NotificationService` does not capture the singleton before startup initialization.
 
 ## Repository and Read Semantics
 
@@ -76,5 +101,6 @@ The project currently follows its established service-level ORM-to-response mapp
 ## See Also
 
 - [Functional: In-App Notifications](../functional/notifications.md)
+- [Technical: Following](following.md)
 - [Pydantic Types and Validators](pydantic_types_and_validators.md)
 - [PostgreSQL Migration](postgres-migration.md)

--- a/docs/technical/redis-caching.md
+++ b/docs/technical/redis-caching.md
@@ -59,6 +59,7 @@ Examples:
 - `cinelog:logs:user:{user_id}:where:{watched_where}:from:{from}:to:{to}:sort:{sort_by}:{sort_order}` — filtered user logs
 - `cinelog:logs:movie:{movie_id}:user:{user_id_or_all}` — logs for a movie, optionally scoped to a user
 - `cinelog:stats:{user_id}:all` — stats for a specific user
+- `cinelog:notif:follow-started:{recipient_id}:{follower_id}` — rolling cooldown for `follow.started` emission
 
 Key construction is the caller's responsibility — `CacheService` is key-agnostic.
 

--- a/docs/technical/service-dependencies.md
+++ b/docs/technical/service-dependencies.md
@@ -20,9 +20,11 @@ Controllers receive services through FastAPI `Depends(...)`.
 | `get_auth_service()` | `AuthService` |
 | `get_auth_rate_limit_service()` | `AuthRateLimitService` |
 | `get_user_service()` | `UserService` |
+| `get_follow_service()` | `FollowService` (composes `NotificationService` for `follow.started`) |
 | `get_movie_service()` | `MovieService` |
 | `get_movie_rating_service()` | `MovieRatingService` |
 | `get_log_service()` | `LogService` (wraps the log repository with `LogCacheRepository`) |
+| `get_notification_service()` | `NotificationService` |
 | `get_stats_service()` | `StatsService` with `StatsRepository`; response caching is composed through `StatsCacheService` |
 
 ## Endpoint Usage

--- a/tests/e2e/test_follow_e2e.py
+++ b/tests/e2e/test_follow_e2e.py
@@ -142,3 +142,52 @@ class TestFollowE2E:
         assert bob_profile.json()["followerCount"] == 1
         assert bob_profile.json()["followingCount"] == 1
         assert bob_profile.json()["isFollowing"] is False
+
+    async def test_follow_emits_inbox_notification_and_same_week_refollow_is_silent(self, async_client):
+        target = _user_data("notifollowtarget", "public")
+        follower = _user_data("notifollower", "public")
+        await register(async_client, target)
+        follower_login = await register_and_login(async_client, follower)
+
+        follow_response = await async_client.put(
+            f"/v1/users/{target['handle']}/follow",
+            headers={"X-CSRF-Token": follower_login["csrfToken"]},
+        )
+        assert follow_response.status_code == 204
+
+        await _login(async_client, target)
+        inbox = await async_client.get("/v1/notifications")
+        assert inbox.status_code == 200
+        payload = inbox.json()
+        assert payload["unreadCount"] == 1
+        assert len(payload["items"]) == 1
+        notification = payload["items"][0]
+        assert notification["type"] == "follow.started"
+        assert notification["title"] == "New follower"
+        assert notification["body"] == "Notifollower Follow started following you."
+        assert notification["actor"] == {
+            "handle": follower["handle"],
+            "firstName": follower["firstName"],
+            "lastName": follower["lastName"],
+        }
+        assert notification["availableActions"] == []
+        assert notification["readAt"] is None
+
+        follower_login = await _login(async_client, follower)
+        unfollow_response = await async_client.delete(
+            f"/v1/users/{target['handle']}/follow",
+            headers={"X-CSRF-Token": follower_login["csrfToken"]},
+        )
+        refollow_response = await async_client.put(
+            f"/v1/users/{target['handle']}/follow",
+            headers={"X-CSRF-Token": follower_login["csrfToken"]},
+        )
+        assert unfollow_response.status_code == 204
+        assert refollow_response.status_code == 204
+
+        await _login(async_client, target)
+        inbox_after_refollow = await async_client.get("/v1/notifications")
+        assert inbox_after_refollow.status_code == 200
+        assert inbox_after_refollow.json()["unreadCount"] == 1
+        assert len(inbox_after_refollow.json()["items"]) == 1
+        assert inbox_after_refollow.json()["items"][0]["id"] == notification["id"]

--- a/tests/units/dependencies/test_service_dependency.py
+++ b/tests/units/dependencies/test_service_dependency.py
@@ -7,6 +7,7 @@ from app.dependencies.repository_dependency import (
 from app.dependencies.service_dependency import (
     _get_runtime_log_repository,
     get_follow_service,
+    get_notification_service,
     get_stats_service,
     get_user_service,
 )
@@ -22,6 +23,7 @@ def clear_caches() -> None:
     get_stats_repository.cache_clear()
     get_user_repository.cache_clear()
     get_follow_service.cache_clear()
+    get_notification_service.cache_clear()
     get_stats_service.cache_clear()
     get_user_service.cache_clear()
 
@@ -55,5 +57,6 @@ def test_follow_and_user_services_share_follow_repository():
 
     assert isinstance(follow_service.follow_repository, FollowRepository)
     assert user_service.follow_repository is follow_service.follow_repository
+    assert follow_service.notification_service is get_notification_service()
 
     clear_caches()

--- a/tests/units/services/test_follow_service.py
+++ b/tests/units/services/test_follow_service.py
@@ -1,12 +1,15 @@
 """Unit tests for public-profile follow business rules."""
 
+from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
 
+from app.config.notification_config import FOLLOW_STARTED_NOTIFICATION_COOLDOWN_SECONDS
 from app.services.follow_service import FollowService
+from app.types import NotificationType
 from app.utils.error_codes_utils import ErrorCodes
 from app.utils.exceptions_utils import AppException
 
@@ -24,19 +27,49 @@ def follow_repository():
 
 
 @pytest.fixture
-def service(user_repository, follow_repository):
+def notification_service():
+    return AsyncMock()
+
+
+@pytest.fixture
+def service(user_repository, follow_repository, notification_service):
     return FollowService(
         user_repository=user_repository,
         follow_repository=follow_repository,
+        notification_service=notification_service,
     )
 
 
-def _user(*, visibility: str = "public"):
-    return SimpleNamespace(id=uuid4(), profile_visibility=visibility)
+def _user(*, visibility: str = "public", first_name: str = "Ada", last_name: str = "Lovelace"):
+    return SimpleNamespace(
+        id=uuid4(),
+        profile_visibility=visibility,
+        first_name=first_name,
+        last_name=last_name,
+    )
+
+
+def _assert_follow_started_emitted(notification_service, *, actor, recipient) -> None:
+    notification_service.create_notification.assert_awaited_once()
+    call = notification_service.create_notification.await_args
+    data = call.args[0]
+    assert data.recipient_id == recipient.id
+    assert data.actor_id == actor.id
+    assert data.type is NotificationType.FOLLOW_STARTED
+    assert data.title == "New follower"
+    assert data.body == f"{actor.first_name} {actor.last_name} started following you."
+    assert data.deduplication_key == f"follow.started:{actor.id}:{datetime.now(UTC).strftime('%G-W%V')}"
+    assert call.kwargs["cooldown_key"] == f"cinelog:notif:follow-started:{recipient.id}:{actor.id}"
+    assert call.kwargs["cooldown_seconds"] == FOLLOW_STARTED_NOTIFICATION_COOLDOWN_SECONDS
 
 
 @pytest.mark.asyncio
-async def test_follow_public_target_creates_directional_edge(service, user_repository, follow_repository):
+async def test_follow_public_target_creates_directional_edge(
+    service,
+    user_repository,
+    follow_repository,
+    notification_service,
+):
     follower = _user(visibility="private")
     target = _user()
     user_repository.find_user_by_id.return_value = follower
@@ -46,6 +79,7 @@ async def test_follow_public_target_creates_directional_edge(service, user_repos
 
     user_repository.find_user_by_handle.assert_awaited_once_with("TargetUser")
     follow_repository.create_follow.assert_awaited_once_with(follower.id, target.id)
+    _assert_follow_started_emitted(notification_service, actor=follower, recipient=target)
 
 
 @pytest.mark.asyncio
@@ -53,6 +87,7 @@ async def test_existing_edge_is_idempotent_after_target_becomes_private(
     service,
     user_repository,
     follow_repository,
+    notification_service,
 ):
     follower = _user()
     target = _user(visibility="private")
@@ -63,6 +98,7 @@ async def test_existing_edge_is_idempotent_after_target_becomes_private(
     await service.follow_user(follower.id, "target")
 
     follow_repository.create_follow.assert_not_awaited()
+    notification_service.create_notification.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -71,6 +107,7 @@ async def test_new_follow_rejects_non_public_target(
     service,
     user_repository,
     follow_repository,
+    notification_service,
     visibility,
 ):
     follower = _user()
@@ -83,10 +120,11 @@ async def test_new_follow_rejects_non_public_target(
 
     assert exc_info.value.error is ErrorCodes.PROFILE_NOT_PUBLIC
     follow_repository.create_follow.assert_not_awaited()
+    notification_service.create_notification.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_follow_rejects_self_follow(service, user_repository, follow_repository):
+async def test_follow_rejects_self_follow(service, user_repository, follow_repository, notification_service):
     follower = _user()
     user_repository.find_user_by_id.return_value = follower
     user_repository.find_user_by_handle.return_value = follower
@@ -97,10 +135,11 @@ async def test_follow_rejects_self_follow(service, user_repository, follow_repos
     assert exc_info.value.error is ErrorCodes.SELF_FOLLOW_NOT_ALLOWED
     follow_repository.is_following.assert_not_awaited()
     follow_repository.create_follow.assert_not_awaited()
+    notification_service.create_notification.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_follow_rejects_inactive_follower(service, user_repository, follow_repository):
+async def test_follow_rejects_inactive_follower(service, user_repository, follow_repository, notification_service):
     user_repository.find_user_by_id.return_value = None
 
     with pytest.raises(AppException) as exc_info:
@@ -109,10 +148,11 @@ async def test_follow_rejects_inactive_follower(service, user_repository, follow
     assert exc_info.value.error is ErrorCodes.USER_NOT_FOUND
     user_repository.find_user_by_handle.assert_not_awaited()
     follow_repository.create_follow.assert_not_awaited()
+    notification_service.create_notification.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_follow_rejects_missing_target(service, user_repository, follow_repository):
+async def test_follow_rejects_missing_target(service, user_repository, follow_repository, notification_service):
     follower = _user()
     user_repository.find_user_by_id.return_value = follower
     user_repository.find_user_by_handle.return_value = None
@@ -122,6 +162,25 @@ async def test_follow_rejects_missing_target(service, user_repository, follow_re
 
     assert exc_info.value.error is ErrorCodes.USER_NOT_FOUND
     follow_repository.create_follow.assert_not_awaited()
+    notification_service.create_notification.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_follow_swallows_notification_emission_failure(
+    service,
+    user_repository,
+    follow_repository,
+    notification_service,
+):
+    follower = _user()
+    target = _user()
+    user_repository.find_user_by_id.return_value = follower
+    user_repository.find_user_by_handle.return_value = target
+    notification_service.create_notification.side_effect = RuntimeError("redis down")
+
+    await service.follow_user(follower.id, "target")
+
+    follow_repository.create_follow.assert_awaited_once_with(follower.id, target.id)
 
 
 @pytest.mark.asyncio

--- a/tests/units/services/test_notification_service.py
+++ b/tests/units/services/test_notification_service.py
@@ -2,7 +2,7 @@
 
 from datetime import UTC, datetime
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
 import pytest
@@ -27,6 +27,39 @@ from app.utils.error_codes_utils import ErrorCodes
 from app.utils.exceptions_utils import AppException
 
 
+class FakeNotificationCache:
+    def __init__(self):
+        self.values: dict[str, dict[str, bool]] = {}
+        self.ttls: dict[str, int | None] = {}
+
+    async def get(self, key: str) -> dict[str, bool] | None:
+        return self.values.get(key)
+
+    async def set(self, key: str, value: dict[str, bool], ttl: int | None = None) -> bool:
+        self.values[key] = value
+        self.ttls[key] = ttl
+        return True
+
+
+@pytest.fixture
+def repository():
+    return AsyncMock()
+
+
+@pytest.fixture
+def fake_cache():
+    return FakeNotificationCache()
+
+
+@pytest.fixture
+def service(repository, fake_cache):
+    with patch(
+        "app.services.notification_service.CacheService.get_instance",
+        return_value=fake_cache,
+    ):
+        yield NotificationService(repository=repository)
+
+
 def _notification(*, actor=None, read_at=None):
     return SimpleNamespace(
         id=uuid4(),
@@ -37,16 +70,6 @@ def _notification(*, actor=None, read_at=None):
         read_at=read_at,
         created_at=datetime(2026, 7, 18, 10, 0, tzinfo=UTC),
     )
-
-
-@pytest.fixture
-def repository():
-    return AsyncMock()
-
-
-@pytest.fixture
-def service(repository):
-    return NotificationService(repository=repository)
 
 
 @pytest.mark.asyncio
@@ -172,6 +195,75 @@ async def test_create_notification_delegates_typed_internal_input(
 
     assert await service.create_notification(data) is expected
     repository.create_notification.assert_awaited_once_with(data)
+
+
+@pytest.mark.asyncio
+async def test_create_notification_emits_and_arms_cooldown_when_absent(
+    service: NotificationService,
+    repository: AsyncMock,
+    fake_cache: FakeNotificationCache,
+):
+    data = NotificationCreateData(
+        recipient_id=uuid4(),
+        type=NotificationType.FOLLOW_STARTED,
+        title="Title",
+        body="Body",
+    )
+    expected = NotificationCreateResult(notification=_notification(), created=True)
+    repository.create_notification.return_value = expected
+
+    result = await service.create_notification(
+        data,
+        cooldown_key="cinelog:notif:follow-started:recipient:actor",
+        cooldown_seconds=604800,
+    )
+
+    assert result is expected
+    repository.create_notification.assert_awaited_once_with(data)
+    assert fake_cache.values["cinelog:notif:follow-started:recipient:actor"] == {"emitted": True}
+    assert fake_cache.ttls["cinelog:notif:follow-started:recipient:actor"] == 604800
+
+
+@pytest.mark.asyncio
+async def test_create_notification_returns_none_when_cooldown_is_present(
+    service: NotificationService,
+    repository: AsyncMock,
+    fake_cache: FakeNotificationCache,
+):
+    fake_cache.values["cinelog:notif:follow-started:recipient:actor"] = {"emitted": True}
+    data = NotificationCreateData(
+        recipient_id=uuid4(),
+        type=NotificationType.FOLLOW_STARTED,
+        title="Title",
+        body="Body",
+    )
+
+    result = await service.create_notification(
+        data,
+        cooldown_key="cinelog:notif:follow-started:recipient:actor",
+        cooldown_seconds=604800,
+    )
+
+    assert result is None
+    repository.create_notification.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_create_notification_requires_cooldown_seconds_when_key_is_set(
+    service: NotificationService,
+    repository: AsyncMock,
+):
+    data = NotificationCreateData(
+        recipient_id=uuid4(),
+        type=NotificationType.FOLLOW_STARTED,
+        title="Title",
+        body="Body",
+    )
+
+    with pytest.raises(ValueError, match="cooldown_seconds is required"):
+        await service.create_notification(data, cooldown_key="cinelog:notif:follow-started:recipient:actor")
+
+    repository.create_notification.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

The in-app notification inbox already stored `follow.started` rows, but nothing produced them. A successful new public follow now writes that inbox item for the followed user.

Follow success stays independent of the inbox write: emission failures are logged and the endpoint still returns `204`. Duplicate `PUT`s and unfollow-then-refollow within 7 days do not create another row.

## Related Issue(s)

Closes #219

## Changes Made

- `FollowService` emits `follow.started` after `create_follow` commits, with English stored copy (`New follower` / `{first} {last} started following you.`)
- `NotificationService.create_notification` accepts optional `cooldown_key` / `cooldown_seconds` and returns `None` when Redis already has the key
- Redis rolling gate: `cinelog:notif:follow-started:{recipient_id}:{follower_id}` with a 7-day TTL (`GET` before insert, `SET` after success)
- PostgreSQL backstop: `deduplication_key = follow.started:{follower_id}:{ISO week}` using the existing partial unique index
- `get_follow_service()` now composes `NotificationService`; no Alembic migration (the type is already registered)
- Clients should render displayed text from `type` + `actor`; stored English copy is presentation fallback

## How to Test

1. `make lint && make typecheck`
2. `make test-unit`
3. `make test-e2e`
4. Follow a public profile, then `GET /v1/notifications` as the target — expect one unread `follow.started` row
5. Unfollow and refollow in the same week — the inbox should still contain a single row

Edge cases covered in tests: already-following retries, non-public targets, self-follow, and a raising notification service that must not fail the follow.

## Checklist

- [x] Code compiles/builds without errors
- [x] Tests pass locally (`make test-unit` 590 passed, `make test-e2e` 90 passed)
- [x] New tests added for new functionality (if applicable)
- [x] No new warnings introduced
- [x] Documentation updated (if applicable)
- [x] Database migrations included (if applicable) — N/A, type already registered
- [x] Environment variables documented (if applicable) — N/A

Made with [Cursor](https://cursor.com)